### PR TITLE
feat: add chat error boundary fallback

### DIFF
--- a/dex_with_fiat_frontend/src/app/chat/page.tsx
+++ b/dex_with_fiat_frontend/src/app/chat/page.tsx
@@ -2,15 +2,27 @@
 
 import { ThemeProvider } from '@/contexts/ThemeContext';
 import { StellarWalletProvider } from '@/contexts/StellarWalletContext';
+import { useTheme } from '@/contexts/ThemeContext';
+import ErrorBoundary from '@/components/ErrorBoundary';
 import StellarChatInterface from '@/components/StellarChatInterface';
+
+function ChatPageContent() {
+    const { isDarkMode } = useTheme();
+
+    return (
+        <main className="h-screen w-screen overflow-hidden">
+            <ErrorBoundary isDarkMode={isDarkMode}>
+                <StellarChatInterface />
+            </ErrorBoundary>
+        </main>
+    );
+}
 
 export default function ChatPage() {
     return (
         <ThemeProvider>
             <StellarWalletProvider>
-                <main className="h-screen w-screen overflow-hidden">
-                    <StellarChatInterface />
-                </main>
+                <ChatPageContent />
             </StellarWalletProvider>
         </ThemeProvider>
     );

--- a/dex_with_fiat_frontend/src/components/ErrorBoundary.tsx
+++ b/dex_with_fiat_frontend/src/components/ErrorBoundary.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import React from 'react';
+
+interface ErrorBoundaryProps {
+    children: React.ReactNode;
+    isDarkMode?: boolean;
+}
+
+interface ErrorBoundaryState {
+    hasError: boolean;
+}
+
+export default class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+    public constructor(props: ErrorBoundaryProps) {
+        super(props);
+        this.state = { hasError: false };
+    }
+
+    public static getDerivedStateFromError(): ErrorBoundaryState {
+        return { hasError: true };
+    }
+
+    public componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+        console.error('Chat UI crashed:', error, errorInfo);
+    }
+
+    public render() {
+        if (this.state.hasError) {
+            const isDarkMode = this.props.isDarkMode ?? true;
+
+            return (
+                <div
+                    className={`flex h-full w-full items-center justify-center px-6 ${
+                        isDarkMode ? 'bg-gray-900 text-white' : 'bg-gray-50 text-gray-900'
+                    }`}
+                >
+                    <div
+                        className={`w-full max-w-md rounded-2xl border p-6 text-center shadow-lg ${
+                            isDarkMode
+                                ? 'border-gray-700 bg-gray-800'
+                                : 'border-gray-200 bg-white'
+                        }`}
+                    >
+                        <h1 className="text-xl font-semibold">Something went wrong.</h1>
+                        <p
+                            className={`mt-2 text-sm ${
+                                isDarkMode ? 'text-gray-300' : 'text-gray-600'
+                            }`}
+                        >
+                            Please refresh the page.
+                        </p>
+                        <button
+                            type="button"
+                            onClick={() => window.location.reload()}
+                            className="mt-5 inline-flex items-center justify-center rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700"
+                        >
+                            Reload
+                        </button>
+                    </div>
+                </div>
+            );
+        }
+
+        return this.props.children;
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable ErrorBoundary class component for the chat UI
- wrap the chat page render tree so runtime render failures no longer blank the whole screen
- pass the active theme mode into the fallback UI so the error state stays visually consistent

## Verification
- npm run lint
- npm run build

## Screenshot
![Error boundary fallback](https://raw.githubusercontent.com/ViVaLaDaniel/Stellar-Dex-Chat/feat/chat-error-boundary/.github/assets/error-boundary-fallback.png)

## Notes
- kept the change bounded to the requested scope in src/app/chat/page.tsx and src/components/ErrorBoundary.tsx
- fallback UI includes the requested message and a reload action

Closes #26