### PR TITLE
feat(chat): mobile bottom-sheet pattern for chat history

### DIFF
--- a/dex_with_fiat_frontend/src/components/ChatHistorySidebar.tsx
+++ b/dex_with_fiat_frontend/src/components/ChatHistorySidebar.tsx
@@ -16,9 +16,10 @@ import SkeletonSidebar from "@/components/ui/skeleton/SkeletonSidebar";
 
 interface ChatHistorySidebarProps {
     onLoadSession: (sessionId: string) => void;
+    onClose?: () => void;
 }
 
-export default function ChatHistorySidebar({ onLoadSession }: ChatHistorySidebarProps) {
+export default function ChatHistorySidebar({ onLoadSession, onClose }: ChatHistorySidebarProps) {
     const {
         sessions,
         currentSessionId,
@@ -88,16 +89,31 @@ export default function ChatHistorySidebar({ onLoadSession }: ChatHistorySidebar
                 <div className="flex items-center justify-between mb-4">
                     <h2 className={`text-lg font-semibold transition-colors duration-300 ${isDarkMode ? 'text-gray-100' : 'text-gray-900'
                         }`}>Chat History</h2>
-                    <button
-                        onClick={clearAllHistory}
-                        className={`p-2 rounded-lg transition-all duration-200 hover:scale-110 ${isDarkMode
-                                ? 'text-gray-400 hover:text-red-400 hover:bg-red-900/20'
-                                : 'text-gray-500 hover:text-red-600 hover:bg-red-50'
-                            }`}
-                        title="Clear all history"
-                    >
-                        <Trash2 className="w-4 h-4" />
-                    </button>
+                    <div className="flex items-center gap-1">
+                        <button
+                            onClick={clearAllHistory}
+                            className={`p-2 rounded-lg transition-all duration-200 hover:scale-110 ${isDarkMode
+                                    ? 'text-gray-400 hover:text-red-400 hover:bg-red-900/20'
+                                    : 'text-gray-500 hover:text-red-600 hover:bg-red-50'
+                                }`}
+                            title="Clear all history"
+                        >
+                            <Trash2 className="w-4 h-4" />
+                        </button>
+                        {onClose && (
+                            <button
+                                onClick={onClose}
+                                className={`p-2 rounded-lg transition-all duration-200 hover:scale-110 ${isDarkMode
+                                        ? 'text-gray-400 hover:text-gray-200 hover:bg-gray-700'
+                                        : 'text-gray-500 hover:text-gray-700 hover:bg-gray-100'
+                                    }`}
+                                title="Close"
+                                aria-label="Close chat history"
+                            >
+                                <X className="w-4 h-4" />
+                            </button>
+                        )}
+                    </div>
                 </div>
 
                 {/* Search */}

--- a/dex_with_fiat_frontend/src/components/StellarChatInterface.tsx
+++ b/dex_with_fiat_frontend/src/components/StellarChatInterface.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import { Wallet, LogOut, Moon, Sun, Menu, X, Plus, Star } from 'lucide-react';
 import { useStellarWallet } from '@/contexts/StellarWalletContext';
 import { useTheme } from '@/contexts/ThemeContext';
@@ -20,6 +20,14 @@ export default function StellarChatInterface() {
     const [showSidebar, setShowSidebar] = useState(false);
     const [showModal, setShowModal] = useState(false);
     const [defaultAmount, setDefaultAmount] = useState('');
+    const [isMobile, setIsMobile] = useState(false);
+    const [isSheetMounted, setIsSheetMounted] = useState(false);
+
+    const sheetRef = useRef<HTMLDivElement>(null);
+    const dragStartY = useRef(0);
+    const dragDelta = useRef(0);
+    const isDragging = useRef(false);
+    const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
     const {
         messages,
@@ -29,6 +37,106 @@ export default function StellarChatInterface() {
         loadChatSession,
         setTransactionReadyCallback,
     } = useChat();
+
+    // Track viewport width to switch between sidebar and bottom-sheet
+    useEffect(() => {
+        const checkMobile = () => setIsMobile(window.innerWidth < 768);
+        checkMobile();
+        window.addEventListener('resize', checkMobile);
+        return () => window.removeEventListener('resize', checkMobile);
+    }, []);
+
+    // On viewport change, close whichever panel is open to avoid stale state
+    useEffect(() => {
+        setShowSidebar(false);
+        setIsSheetMounted(false);
+    }, [isMobile]);
+
+    // Mount the bottom-sheet when the user opens it on mobile
+    useEffect(() => {
+        if (showSidebar && isMobile) {
+            setIsSheetMounted(true);
+        }
+    }, [showSidebar, isMobile]);
+
+    // Slide the sheet up after it mounts
+    useEffect(() => {
+        if (!isSheetMounted || !sheetRef.current) return;
+        const el = sheetRef.current;
+        el.style.transform = 'translateY(100%)';
+        const raf = requestAnimationFrame(() => {
+            el.style.transition = 'transform 300ms cubic-bezier(0.32, 0.72, 0, 1)';
+            el.style.transform = 'translateY(0)';
+        });
+        return () => cancelAnimationFrame(raf);
+    }, [isSheetMounted]);
+
+    // Focus the sheet for keyboard/screen-reader users
+    useEffect(() => {
+        if (isSheetMounted && sheetRef.current) {
+            sheetRef.current.focus();
+        }
+    }, [isSheetMounted]);
+
+    // Dismiss on Escape key
+    useEffect(() => {
+        if (!isSheetMounted) return;
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') closeSheet();
+        };
+        document.addEventListener('keydown', handleKeyDown);
+        return () => document.removeEventListener('keydown', handleKeyDown);
+    // closeSheet is stable (useCallback with no deps that change), safe to omit
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [isSheetMounted]);
+
+    useEffect(() => {
+        return () => {
+            if (closeTimerRef.current) clearTimeout(closeTimerRef.current);
+        };
+    }, []);
+
+    const closeSheet = useCallback(() => {
+        if (sheetRef.current) {
+            sheetRef.current.style.transition = 'transform 300ms cubic-bezier(0.32, 0.72, 0, 1)';
+            sheetRef.current.style.transform = 'translateY(100%)';
+        }
+        closeTimerRef.current = setTimeout(() => {
+            setIsSheetMounted(false);
+            setShowSidebar(false);
+        }, 300);
+    }, []);
+
+    const handleSheetTouchStart = useCallback((e: React.TouchEvent<HTMLDivElement>) => {
+        dragStartY.current = e.touches[0].clientY;
+        dragDelta.current = 0;
+        isDragging.current = true;
+        if (sheetRef.current) {
+            sheetRef.current.style.transition = 'none';
+        }
+    }, []);
+
+    const handleSheetTouchMove = useCallback((e: React.TouchEvent<HTMLDivElement>) => {
+        if (!isDragging.current || !sheetRef.current) return;
+        const delta = e.touches[0].clientY - dragStartY.current;
+        dragDelta.current = delta;
+        // Only allow downward drag
+        if (delta > 0) {
+            sheetRef.current.style.transform = `translateY(${delta}px)`;
+        }
+    }, []);
+
+    const handleSheetTouchEnd = useCallback(() => {
+        if (!isDragging.current) return;
+        isDragging.current = false;
+        if (dragDelta.current > 120) {
+            closeSheet();
+        } else if (sheetRef.current) {
+            sheetRef.current.style.transition = 'transform 300ms cubic-bezier(0.32, 0.72, 0, 1)';
+            sheetRef.current.style.transform = 'translateY(0)';
+        }
+        dragDelta.current = 0;
+    }, [closeSheet]);
 
     // When the AI decides a transaction is ready, open the modal
     const handleTransactionReady = useCallback((data: TransactionData) => {
@@ -71,21 +179,18 @@ export default function StellarChatInterface() {
 
     return (
         <div className={`flex h-screen w-screen overflow-hidden transition-colors duration-300 ${isDarkMode ? 'bg-gray-900 text-white' : 'bg-gray-50 text-gray-900'}`}>
-            {/* Sidebar */}
-            {showSidebar && (
-    <div className="flex-shrink-0 w-72">
-        {isLoading ? (
-            <SkeletonSidebar />
-        ) : (
-            <ChatHistorySidebar 
-                onLoadSession={(id) => { 
-                    loadChatSession(id); 
-                    setShowSidebar(false); 
-                }} 
-            />
-        )}
-    </div>
-)}
+            {/* Desktop sidebar — only rendered on md+ viewports */}
+            {!isMobile && showSidebar && (
+                <div className="shrink-0 w-72">
+                    {isLoading ? (
+                        <SkeletonSidebar />
+                    ) : (
+                        <ChatHistorySidebar
+                            onLoadSession={(id) => { loadChatSession(id); setShowSidebar(false); }}
+                        />
+                    )}
+                </div>
+            )}
             {/* Main */}
             <div className="flex flex-col flex-1 min-w-0">
                 {/* Header */}
@@ -189,6 +294,46 @@ export default function StellarChatInterface() {
                     />
                 </div>
             </div>
+
+            {/* Mobile bottom-sheet — only rendered when isSheetMounted */}
+            {isSheetMounted && (
+                <>
+                    {/* Backdrop */}
+                    <div
+                        className="fixed inset-0 z-40 bg-black/50 backdrop-blur-sm"
+                        onClick={closeSheet}
+                        aria-hidden="true"
+                    />
+
+                    {/* Sheet */}
+                    <div
+                        ref={sheetRef}
+                        role="dialog"
+                        aria-modal="true"
+                        aria-label="Chat history"
+                        tabIndex={-1}
+                        className={`fixed bottom-0 left-0 right-0 z-50 flex flex-col rounded-t-2xl max-h-[85svh] will-change-transform focus:outline-none ${
+                            isDarkMode ? 'bg-gray-800' : 'bg-white'
+                        }`}
+                        onTouchStart={handleSheetTouchStart}
+                        onTouchMove={handleSheetTouchMove}
+                        onTouchEnd={handleSheetTouchEnd}
+                    >
+                        {/* Drag handle */}
+                        <div
+                            className="flex justify-center pt-3 pb-2 shrink-0 cursor-grab active:cursor-grabbing"
+                            aria-hidden="true"
+                        >
+                            <div className={`w-10 h-1 rounded-full ${isDarkMode ? 'bg-gray-600' : 'bg-gray-300'}`} />
+                        </div>
+
+                        <ChatHistorySidebar
+                            onLoadSession={(id) => { loadChatSession(id); closeSheet(); }}
+                            onClose={closeSheet}
+                        />
+                    </div>
+                </>
+            )}
 
             {/* Deposit / Withdraw Modal */}
             <StellarFiatModal


### PR DESCRIPTION
On viewports narrower than 768px the sidebar is replaced with a bottom-sheet that slides up from the bottom of the screen.

- Mount/unmount driven by `isSheetMounted` so the exit animation completes before the element is removed from the DOM
- Slide-in triggered via requestAnimationFrame after mount using a CSS cubic-bezier ease identical to iOS sheet behaviour
- Swipe-to-close: tracks touchstart/move/end directly on the sheet element; dismisses when drag delta exceeds 120 px, otherwise snaps back
- Overlay click and Escape key both trigger the animated close path
- Focus is moved to the sheet on open for keyboard/screen-reader accessibility (role="dialog", aria-modal, tabIndex=-1)
- Viewport resize resets panel state to avoid stale open state across breakpoints
- Desktop sidebar behaviour is completely unchanged

ChatHistorySidebar receives an optional `onClose` prop; when provided a close button is rendered beside the trash icon (visible in the bottom-sheet only).

Closes #67