### PR TITLE
feat: implement time-locked withdrawals for FiatBridge

### DIFF
--- a/stellar-contracts/src/lib.rs
+++ b/stellar-contracts/src/lib.rs
@@ -12,6 +12,17 @@ pub enum Error {
     ZeroAmount = 4,
     ExceedsLimit = 5,
     InsufficientFunds = 6,
+    WithdrawalLocked = 7,
+    RequestNotFound = 8,
+}
+
+// ── Models ────────────────────────────────────────────────────────────────
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WithdrawRequest {
+    pub to: Address,
+    pub amount: i128,
+    pub unlock_ledger: u32,
 }
 
 // ── Storage keys ──────────────────────────────────────────────────────────
@@ -21,6 +32,9 @@ pub enum DataKey {
     Token,
     BridgeLimit,
     TotalDeposited,
+    LockPeriod,
+    WithdrawQueue(u64),
+    NextRequestID,
 }
 
 // ── Contract ──────────────────────────────────────────────────────────────
@@ -82,11 +96,8 @@ impl FiatBridge {
         Ok(())
     }
 
-    /// Release tokens to `to`. Only the admin may call this.
-    pub fn withdraw(env: Env, to: Address, amount: i128) -> Result<(), Error> {
-        if amount <= 0 {
-            return Err(Error::ZeroAmount);
-        }
+    /// Register a withdrawal request that matures after the lock period. Admin only.
+    pub fn request_withdrawal(env: Env, to: Address, amount: i128) -> Result<u64, Error> {
         let admin: Address = env
             .storage()
             .instance()
@@ -94,17 +105,100 @@ impl FiatBridge {
             .ok_or(Error::NotInitialized)?;
         admin.require_auth();
 
+        if amount <= 0 {
+            return Err(Error::ZeroAmount);
+        }
+
+        let lock_period: u32 = env.storage().instance().get(&DataKey::LockPeriod).unwrap_or(0);
+        let unlock_ledger = env.ledger().sequence() + lock_period;
+
+        let request_id: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::NextRequestID)
+            .unwrap_or(0);
+
+        let request = WithdrawRequest {
+            to,
+            amount,
+            unlock_ledger,
+        };
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::WithdrawQueue(request_id), &request);
+        env.storage()
+            .instance()
+            .set(&DataKey::NextRequestID, &(request_id + 1));
+
+        Ok(request_id)
+    }
+
+    /// Execute a matured withdrawal request.
+    pub fn execute_withdrawal(env: Env, request_id: u64) -> Result<(), Error> {
+        let request: WithdrawRequest = env
+            .storage()
+            .persistent()
+            .get(&DataKey::WithdrawQueue(request_id))
+            .ok_or(Error::RequestNotFound)?;
+
+        if env.ledger().sequence() < request.unlock_ledger {
+            return Err(Error::WithdrawalLocked);
+        }
+
         let token_id: Address = env
             .storage()
             .instance()
             .get(&DataKey::Token)
             .ok_or(Error::NotInitialized)?;
         let token_client = token::Client::new(&env, &token_id);
+
         let balance = token_client.balance(&env.current_contract_address());
-        if amount > balance {
+        if request.amount > balance {
             return Err(Error::InsufficientFunds);
         }
-        token_client.transfer(&env.current_contract_address(), &to, &amount);
+
+        token_client.transfer(&env.current_contract_address(), &request.to, &request.amount);
+
+        env.storage()
+            .persistent()
+            .remove(&DataKey::WithdrawQueue(request_id));
+
+        Ok(())
+    }
+
+    /// Cancel a pending withdrawal request. Admin only.
+    pub fn cancel_withdrawal(env: Env, request_id: u64) -> Result<(), Error> {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::NotInitialized)?;
+        admin.require_auth();
+
+        if !env
+            .storage()
+            .persistent()
+            .has(&DataKey::WithdrawQueue(request_id))
+        {
+            return Err(Error::RequestNotFound);
+        }
+
+        env.storage()
+            .persistent()
+            .remove(&DataKey::WithdrawQueue(request_id));
+        Ok(())
+    }
+
+    /// Set the mandatory delay period for withdrawals (in ledgers). Admin only.
+    pub fn set_lock_period(env: Env, ledgers: u32) -> Result<(), Error> {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::NotInitialized)?;
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::LockPeriod, &ledgers);
         Ok(())
     }
 
@@ -171,6 +265,16 @@ impl FiatBridge {
             .instance()
             .get(&DataKey::TotalDeposited)
             .ok_or(Error::NotInitialized)
+    }
+    /// Get details of a withdrawal request.
+    pub fn get_withdrawal_request(env: Env, request_id: u64) -> Option<WithdrawRequest> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::WithdrawQueue(request_id))
+    }
+    /// Get the current lock period in ledgers.
+    pub fn get_lock_period(env: Env) -> u32 {
+        env.storage().instance().get(&DataKey::LockPeriod).unwrap_or(0)
     }
 }
 

--- a/stellar-contracts/src/test.rs
+++ b/stellar-contracts/src/test.rs
@@ -60,9 +60,69 @@ fn test_deposit_and_withdraw() {
     assert_eq!(token.balance(&user), 800);
     assert_eq!(token.balance(&contract_id), 200);
 
-    bridge.withdraw(&user, &100);
+    // Default lock period is 0
+    let req_id = bridge.request_withdrawal(&user, &100);
+    bridge.execute_withdrawal(&req_id);
+
     assert_eq!(token.balance(&user), 900);
     assert_eq!(token.balance(&contract_id), 100);
+}
+
+#[test]
+fn test_time_locked_withdrawal() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, bridge, _, _, token, token_sac) = setup_bridge(&env, 500);
+    let user = Address::generate(&env);
+    token_sac.mint(&user, &1_000);
+    bridge.deposit(&user, &200);
+
+    bridge.set_lock_period(&100);
+    assert_eq!(bridge.get_lock_period(), 100);
+
+    let start_ledger = env.ledger().sequence();
+    let req_id = bridge.request_withdrawal(&user, &100);
+
+    // Check request details
+    let req = bridge.get_withdrawal_request(&req_id).unwrap();
+    assert_eq!(req.to, user);
+    assert_eq!(req.amount, 100);
+    assert_eq!(req.unlock_ledger, start_ledger + 100);
+
+    // Try to execute too early
+    let result = bridge.try_execute_withdrawal(&req_id);
+    assert_eq!(result, Err(Ok(Error::WithdrawalLocked)));
+
+    // Advance ledger
+    env.ledger().with_mut(|li| {
+        li.sequence = start_ledger + 100;
+    });
+
+    bridge.execute_withdrawal(&req_id);
+    assert_eq!(token.balance(&user), 900);
+    assert_eq!(token.balance(&contract_id), 100);
+    assert_eq!(bridge.get_withdrawal_request(&req_id), None);
+}
+
+#[test]
+fn test_cancel_withdrawal() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_, bridge, _, _, _, token_sac) = setup_bridge(&env, 500);
+    let user = Address::generate(&env);
+    token_sac.mint(&user, &1_000);
+    bridge.deposit(&user, &200);
+
+    let req_id = bridge.request_withdrawal(&user, &100);
+    assert!(bridge.get_withdrawal_request(&req_id).is_some());
+
+    bridge.cancel_withdrawal(&req_id);
+    assert!(bridge.get_withdrawal_request(&req_id).is_none());
+
+    let result = bridge.try_execute_withdrawal(&req_id);
+    assert_eq!(result, Err(Ok(Error::RequestNotFound)));
 }
 
 #[test]
@@ -148,7 +208,8 @@ fn test_insufficient_funds_withdraw() {
     token_sac.mint(&user, &1_000);
     bridge.deposit(&user, &100);
 
-    let result = bridge.try_withdraw(&user, &200);
+    let req_id = bridge.request_withdrawal(&user, &200);
+    let result = bridge.try_execute_withdrawal(&req_id);
     assert_eq!(result, Err(Ok(Error::InsufficientFunds)));
 }
 


### PR DESCRIPTION
This PR implements time-locked withdrawals as requested in issue #99. It adds a withdrawal queue, request and execution logic, and comprehensive tests. Closes #99.