### PR TITLE
feat: add rate limiting to route

### DIFF
--- a/dex_with_fiat_frontend/src/app/api/create-recipient/route.ts
+++ b/dex_with_fiat_frontend/src/app/api/create-recipient/route.ts
@@ -2,10 +2,16 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getPayoutProvider } from '@/lib/payout/providers/registry';
 import axios from 'axios';
 import { telemetry } from '@/lib/telemetry';
+import { applyRateLimit, getClientIp } from '@/lib/rateLimit';
 
 const PAYSTACK_SECRET_KEY = process.env.PAYSTACK_SECRET_KEY;
+const RATE_LIMIT = { maxRequests: 5, windowMs: 60_000 };
 
 export async function POST(request: NextRequest) {
+  const ip = getClientIp(request);
+  const limited = applyRateLimit(ip, '/api/create-recipient', RATE_LIMIT);
+  if (limited) return limited;
+
   const traceContext = telemetry.extractTraceFromHeaders(request.headers);
   const span = telemetry.createSpan(
     'create-recipient',

--- a/dex_with_fiat_frontend/src/app/api/initiate-transfer/route.ts
+++ b/dex_with_fiat_frontend/src/app/api/initiate-transfer/route.ts
@@ -2,10 +2,16 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getPayoutProvider } from '@/lib/payout/providers/registry';
 import axios from 'axios';
 import { telemetry } from '@/lib/telemetry';
+import { applyRateLimit, getClientIp } from '@/lib/rateLimit';
 
 const PAYSTACK_SECRET_KEY = process.env.PAYSTACK_SECRET_KEY;
+const RATE_LIMIT = { maxRequests: 3, windowMs: 60_000 };
 
 export async function POST(request: NextRequest) {
+  const ip = getClientIp(request);
+  const limited = applyRateLimit(ip, '/api/initiate-transfer', RATE_LIMIT);
+  if (limited) return limited;
+
   const traceContext = telemetry.extractTraceFromHeaders(request.headers);
   const span = telemetry.createSpan(
     'initiate-transfer',

--- a/dex_with_fiat_frontend/src/app/api/verify-account/route.ts
+++ b/dex_with_fiat_frontend/src/app/api/verify-account/route.ts
@@ -1,8 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getPayoutProvider } from '@/lib/payout/providers/registry';
 import { telemetry } from '@/lib/telemetry';
+import { applyRateLimit, getClientIp } from '@/lib/rateLimit';
+
+const RATE_LIMIT = { maxRequests: 10, windowMs: 60_000 };
 
 export async function POST(request: NextRequest) {
+  const ip = getClientIp(request);
+  const limited = applyRateLimit(ip, '/api/verify-account', RATE_LIMIT);
+  if (limited) return limited;
+
   const traceContext = telemetry.extractTraceFromHeaders(request.headers);
   const span = telemetry.createSpan(
     'verify-account',

--- a/dex_with_fiat_frontend/src/lib/rateLimit.ts
+++ b/dex_with_fiat_frontend/src/lib/rateLimit.ts
@@ -1,0 +1,87 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export interface RateLimitConfig {
+  /** Maximum requests allowed per window */
+  maxRequests: number;
+  /** Window duration in milliseconds */
+  windowMs: number;
+}
+
+interface Entry {
+  count: number;
+  resetAt: number;
+}
+
+// Module-level store — persists across requests within the same Node.js process.
+const store = new Map<string, Entry>();
+
+/**
+ * Extract the real client IP, respecting reverse-proxy headers.
+ */
+export function getClientIp(request: NextRequest): string {
+  const forwarded = request.headers.get('x-forwarded-for');
+  if (forwarded) return forwarded.split(',')[0].trim();
+  return request.headers.get('x-real-ip') ?? 'unknown';
+}
+
+/**
+ * Check whether the given IP has exceeded the rate limit for a route.
+ * Uses a fixed-window counter keyed by `route:ip`.
+ *
+ * @returns `null` when the request is allowed, or a ready-to-send 429
+ *          NextResponse when the limit is exceeded.
+ */
+export function applyRateLimit(
+  ip: string,
+  route: string,
+  config: RateLimitConfig,
+): NextResponse | null {
+  const key = `${route}:${ip}`;
+  const now = Date.now();
+
+  let entry = store.get(key);
+
+  // Initialise or reset an expired window.
+  if (!entry || now >= entry.resetAt) {
+    entry = { count: 1, resetAt: now + config.windowMs };
+    store.set(key, entry);
+    return null;
+  }
+
+  entry.count++;
+
+  if (entry.count > config.maxRequests) {
+    const retryAfterSecs = Math.ceil((entry.resetAt - now) / 1000);
+
+    console.warn(
+      JSON.stringify({
+        event: 'rate_limit_exceeded',
+        route,
+        ip,
+        count: entry.count,
+        limit: config.maxRequests,
+        retryAfterSecs,
+        timestamp: new Date().toISOString(),
+      }),
+    );
+
+    return NextResponse.json(
+      {
+        success: false,
+        message: 'Too many requests. Please try again later.',
+        retryAfter: retryAfterSecs,
+      },
+      {
+        status: 429,
+        headers: {
+          'Retry-After': String(retryAfterSecs),
+          'X-RateLimit-Limit': String(config.maxRequests),
+          'X-RateLimit-Remaining': '0',
+          'X-RateLimit-Reset': String(Math.ceil(entry.resetAt / 1000)),
+        },
+      },
+    );
+  }
+
+  return null;
+}


### PR DESCRIPTION
Added per-IP rate limiting to the three payout API routes to protect against abuse and excessive upstream Paystack API calls. A shared rateLimit.ts utility implements a fixed-window counter stored in a module-level Map, keyed by route:ip. The client IP is resolved from x-forwarded-for and x-real-ip headers to correctly handle reverse-proxy environments. Each route enforces its own limit, 10 requests per minute for verify-account, 5 for create-recipient, and 3 for initiate-transfer — reflecting the sensitivity of each operation. When a limit is exceeded, the API returns HTTP 429 with a Retry-After header and a structured JSON log line containing the route, IP, request count, and timestamp for observability.

![ratelimit](https://github.com/user-attachments/assets/23e8ef08-e8f3-4b0b-8ff2-2ce4f58d987e)


closes #59 