### PR TITLE
feat(settings): fiat currency preference and defaults

### DIFF
--- a/dex_with_fiat_frontend/src/components/Providers.tsx
+++ b/dex_with_fiat_frontend/src/components/Providers.tsx
@@ -3,6 +3,7 @@
 import { ReactNode } from 'react';
 import { ThemeProvider } from '@/contexts/ThemeContext';
 import { StellarWalletProvider } from '@/contexts/StellarWalletContext';
+import { UserPreferencesProvider } from '@/contexts/UserPreferencesContext';
 
 interface ProvidersProps {
   children: ReactNode;
@@ -11,7 +12,9 @@ interface ProvidersProps {
 export function Providers({ children }: ProvidersProps) {
   return (
     <ThemeProvider>
-      <StellarWalletProvider>{children}</StellarWalletProvider>
+      <UserPreferencesProvider>
+        <StellarWalletProvider>{children}</StellarWalletProvider>
+      </UserPreferencesProvider>
     </ThemeProvider>
   );
 }

--- a/dex_with_fiat_frontend/src/components/StellarChatInterface.tsx
+++ b/dex_with_fiat_frontend/src/components/StellarChatInterface.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useCallback, useEffect, useRef } from 'react';
-import { Wallet, LogOut, Moon, Sun, Menu, X, Plus, Star } from 'lucide-react';
+import { Wallet, LogOut, Moon, Sun, Menu, X, Plus, Star, Settings } from 'lucide-react';
 import { useStellarWallet } from '@/contexts/StellarWalletContext';
 import { useTheme } from '@/contexts/ThemeContext';
 import useChat from '@/hooks/useChat';
@@ -10,15 +10,19 @@ import ChatInput from './ChatInput';
 import ChatHistorySidebar from './ChatHistorySidebar';
 import StellarFiatModal from './StellarFiatModal';
 import BankDetailsModal from './BankDetailsModal';
+import UserSettings from './UserSettings';
 import { TransactionData } from '@/types';
 import SkeletonChat from '@/components/ui/skeleton/SkeletonChat';
 import SkeletonSidebar from '@/components/ui/skeleton/SkeletonSidebar';
+import { useUserPreferences } from '@/contexts/UserPreferencesContext';
 
 export default function StellarChatInterface() {
   const { connection, connect, disconnect } = useStellarWallet();
   const { isDarkMode, toggleDarkMode } = useTheme();
+  const { fiatCurrency } = useUserPreferences();
 
   const [showSidebar, setShowSidebar] = useState(false);
+  const [showSettings, setShowSettings] = useState(false);
   const [showModal, setShowModal] = useState(false);
   const [defaultAmount, setDefaultAmount] = useState('');
   const [showBankDetails, setShowBankDetails] = useState(false);
@@ -262,6 +266,15 @@ export default function StellarChatInterface() {
             </button>
 
             <button
+              onClick={() => setShowSettings(true)}
+              title="Settings"
+              aria-label="Open settings"
+              className={`p-2 rounded-lg transition-colors ${isDarkMode ? 'hover:bg-gray-800 text-gray-400' : 'hover:bg-gray-100 text-gray-600'}`}
+            >
+              <Settings className="w-5 h-5" />
+            </button>
+
+            <button
               onClick={toggleDarkMode}
               className={`p-2 rounded-lg transition-colors ${isDarkMode ? 'hover:bg-gray-800 text-gray-400' : 'hover:bg-gray-100 text-gray-600'}`}
             >
@@ -396,6 +409,7 @@ export default function StellarChatInterface() {
           setDefaultAmount('');
         }}
         defaultAmount={defaultAmount}
+        fiatCurrency={fiatCurrency}
         onDepositSuccess={handleDepositSuccess}
       />
 
@@ -404,6 +418,12 @@ export default function StellarChatInterface() {
         isOpen={showBankDetails}
         onClose={() => setShowBankDetails(false)}
         xlmAmount={bankDetailsXlmAmount}
+      />
+
+      {/* Settings panel */}
+      <UserSettings
+        isOpen={showSettings}
+        onClose={() => setShowSettings(false)}
       />
     </div>
   );

--- a/dex_with_fiat_frontend/src/components/StellarFiatModal.tsx
+++ b/dex_with_fiat_frontend/src/components/StellarFiatModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import {
   X,
   Loader2,
@@ -16,12 +16,17 @@ import {
   withdrawFromContract,
   stroopsToDisplay,
 } from '@/lib/stellarContract';
+import {
+  getTokenPrice,
+  formatFiatAmount,
+} from '@/lib/cryptoPriceService';
 import SkeletonPayout from '@/components/ui/skeleton/SkeletonPayout';
 
 interface StellarFiatModalProps {
   isOpen: boolean;
   onClose: () => void;
   defaultAmount?: string;
+  fiatCurrency?: string;
   isAdminMode?: boolean;
   recipientAddress?: string;
   onDepositSuccess?: (xlmAmount: number) => void;
@@ -56,6 +61,7 @@ export default function StellarFiatModal({
   isOpen,
   onClose,
   defaultAmount = '',
+  fiatCurrency = 'usd',
   isAdminMode = false,
   recipientAddress = '',
   onDepositSuccess,
@@ -65,6 +71,7 @@ export default function StellarFiatModal({
   const [amount, setAmount] = useState(defaultAmount);
   const [activePreset, setActivePreset] = useState<number | null>(null);
   const [recipient, setRecipient] = useState(recipientAddress);
+  const [fiatEstimate, setFiatEstimate] = useState<string | null>(null);
 
   const AMOUNT_PRESETS = [5, 10, 25, 50, 100];
 
@@ -134,6 +141,25 @@ export default function StellarFiatModal({
       cancelled = true;
     };
   }, [defaultAmount, isAdminMode, isOpen, recipientAddress]);
+
+  // Live fiat estimate: recalculate whenever amount or fiatCurrency changes
+  const updateFiatEstimate = useCallback(async () => {
+    const xlm = parseFloat(amount);
+    if (!xlm || xlm <= 0) {
+      setFiatEstimate(null);
+      return;
+    }
+    try {
+      const price = await getTokenPrice('XLM', fiatCurrency);
+      setFiatEstimate(formatFiatAmount(xlm * price, fiatCurrency));
+    } catch {
+      setFiatEstimate(null);
+    }
+  }, [amount, fiatCurrency]);
+
+  useEffect(() => {
+    updateFiatEstimate();
+  }, [updateFiatEstimate]);
 
   if (!isOpen) return null;
 
@@ -330,6 +356,14 @@ export default function StellarFiatModal({
                 className={`w-full bg-gray-800 border rounded-lg px-4 py-3 text-white placeholder-gray-500 focus:outline-none ${isOverLimit ? 'border-red-500 focus:border-red-400' : 'border-gray-600 focus:border-blue-500'}`}
               />
             </div>
+
+            {/* Fiat estimate */}
+            {fiatEstimate && (
+              <p className="text-xs text-gray-400 -mt-2 mb-4">
+                ≈ <span className="text-white font-medium">{fiatEstimate}</span>{' '}
+                at current market rate
+              </p>
+            )}
 
             {isDepositFlow && (
               <div className="mb-4 rounded-xl border border-gray-700 bg-gray-800/60 px-4 py-3">

--- a/dex_with_fiat_frontend/src/components/UserSettings.tsx
+++ b/dex_with_fiat_frontend/src/components/UserSettings.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { X, Check } from 'lucide-react';
+import { useTheme } from '@/contexts/ThemeContext';
+import {
+  SUPPORTED_FIAT_CURRENCIES,
+  FiatCurrencyCode,
+  useUserPreferences,
+} from '@/contexts/UserPreferencesContext';
+
+interface UserSettingsProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export default function UserSettings({ isOpen, onClose }: UserSettingsProps) {
+  const { isDarkMode } = useTheme();
+  const { fiatCurrency, setFiatCurrency } = useUserPreferences();
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  // Close on Escape
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [isOpen, onClose]);
+
+  // Focus trap: move focus into panel on open
+  useEffect(() => {
+    if (isOpen) panelRef.current?.focus();
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  const handleSelect = (code: FiatCurrencyCode) => {
+    setFiatCurrency(code);
+    onClose();
+  };
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 z-40 bg-black/50 backdrop-blur-sm"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      {/* Panel */}
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label="User settings"
+        tabIndex={-1}
+        className={`fixed inset-y-0 right-0 z-50 w-80 flex flex-col shadow-2xl focus:outline-none transition-colors duration-300 ${
+          isDarkMode ? 'bg-gray-900 border-l border-gray-700' : 'bg-white border-l border-gray-200'
+        }`}
+      >
+        {/* Header */}
+        <div
+          className={`flex items-center justify-between px-5 py-4 border-b ${
+            isDarkMode ? 'border-gray-700' : 'border-gray-200'
+          }`}
+        >
+          <h2
+            className={`text-base font-semibold ${
+              isDarkMode ? 'text-gray-100' : 'text-gray-900'
+            }`}
+          >
+            Settings
+          </h2>
+          <button
+            onClick={onClose}
+            aria-label="Close settings"
+            className={`p-1.5 rounded-lg transition-colors ${
+              isDarkMode
+                ? 'text-gray-400 hover:text-gray-200 hover:bg-gray-800'
+                : 'text-gray-500 hover:text-gray-700 hover:bg-gray-100'
+            }`}
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto px-5 py-6 space-y-6">
+          {/* Currency section */}
+          <section>
+            <h3
+              className={`text-xs font-semibold uppercase tracking-wider mb-3 ${
+                isDarkMode ? 'text-gray-400' : 'text-gray-500'
+              }`}
+            >
+              Default fiat currency
+            </h3>
+            <p
+              className={`text-xs mb-4 ${
+                isDarkMode ? 'text-gray-500' : 'text-gray-400'
+              }`}
+            >
+              All quotes and conversion estimates will be displayed in this
+              currency.
+            </p>
+
+            <ul role="listbox" aria-label="Select default fiat currency" className="space-y-1">
+              {SUPPORTED_FIAT_CURRENCIES.map(({ code, label, symbol }) => {
+                const isSelected = fiatCurrency === code;
+                return (
+                  <li key={code}>
+                    <button
+                      role="option"
+                      aria-selected={isSelected}
+                      onClick={() => handleSelect(code)}
+                      className={`w-full flex items-center justify-between px-4 py-3 rounded-lg text-sm transition-all duration-150 ${
+                        isSelected
+                          ? isDarkMode
+                            ? 'bg-blue-900/40 border border-blue-500/60 text-blue-300'
+                            : 'bg-blue-50 border border-blue-300 text-blue-700'
+                          : isDarkMode
+                            ? 'border border-transparent hover:bg-gray-800 text-gray-300'
+                            : 'border border-transparent hover:bg-gray-50 text-gray-700'
+                      }`}
+                    >
+                      <span className="flex items-center gap-3">
+                        <span
+                          className={`w-7 text-center font-mono font-semibold text-xs ${
+                            isSelected
+                              ? isDarkMode
+                                ? 'text-blue-300'
+                                : 'text-blue-600'
+                              : isDarkMode
+                                ? 'text-gray-400'
+                                : 'text-gray-500'
+                          }`}
+                        >
+                          {symbol}
+                        </span>
+                        <span>{label}</span>
+                      </span>
+
+                      {isSelected && (
+                        <Check
+                          className={`w-4 h-4 shrink-0 ${
+                            isDarkMode ? 'text-blue-400' : 'text-blue-600'
+                          }`}
+                        />
+                      )}
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          </section>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/dex_with_fiat_frontend/src/contexts/UserPreferencesContext.tsx
+++ b/dex_with_fiat_frontend/src/contexts/UserPreferencesContext.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+const STORAGE_KEY = 'fiat-currency';
+const DEFAULT_CURRENCY = 'usd';
+
+export const SUPPORTED_FIAT_CURRENCIES = [
+  { code: 'usd', label: 'USD — US Dollar',        symbol: '$'   },
+  { code: 'eur', label: 'EUR — Euro',              symbol: '€'   },
+  { code: 'gbp', label: 'GBP — British Pound',     symbol: '£'   },
+  { code: 'ngn', label: 'NGN — Nigerian Naira',    symbol: '₦'   },
+  { code: 'cad', label: 'CAD — Canadian Dollar',   symbol: 'CA$' },
+  { code: 'aud', label: 'AUD — Australian Dollar', symbol: 'A$'  },
+  { code: 'jpy', label: 'JPY — Japanese Yen',      symbol: '¥'   },
+] as const;
+
+export type FiatCurrencyCode = (typeof SUPPORTED_FIAT_CURRENCIES)[number]['code'];
+
+interface UserPreferencesContextType {
+  fiatCurrency: FiatCurrencyCode;
+  setFiatCurrency: (currency: FiatCurrencyCode) => void;
+  currencySymbol: string;
+}
+
+const UserPreferencesContext = createContext<UserPreferencesContextType | undefined>(
+  undefined,
+);
+
+export function UserPreferencesProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [fiatCurrency, setFiatCurrencyState] =
+    useState<FiatCurrencyCode>(DEFAULT_CURRENCY);
+
+  // Restore saved preference on mount
+  useEffect(() => {
+    const saved = localStorage.getItem(STORAGE_KEY) as FiatCurrencyCode | null;
+    if (saved && SUPPORTED_FIAT_CURRENCIES.some((c) => c.code === saved)) {
+      setFiatCurrencyState(saved);
+    }
+  }, []);
+
+  const setFiatCurrency = (currency: FiatCurrencyCode) => {
+    setFiatCurrencyState(currency);
+    localStorage.setItem(STORAGE_KEY, currency);
+  };
+
+  const currencySymbol =
+    SUPPORTED_FIAT_CURRENCIES.find((c) => c.code === fiatCurrency)?.symbol ?? '$';
+
+  return (
+    <UserPreferencesContext.Provider
+      value={{ fiatCurrency, setFiatCurrency, currencySymbol }}
+    >
+      {children}
+    </UserPreferencesContext.Provider>
+  );
+}
+
+export const useUserPreferences = () => {
+  const context = useContext(UserPreferencesContext);
+  if (!context) {
+    throw new Error(
+      'useUserPreferences must be used within a UserPreferencesProvider',
+    );
+  }
+  return context;
+};

--- a/dex_with_fiat_frontend/src/lib/cryptoPriceService.ts
+++ b/dex_with_fiat_frontend/src/lib/cryptoPriceService.ts
@@ -17,14 +17,14 @@ export interface TokenPriceData {
 
 // Token ID mapping for CoinGecko API
 const TOKEN_IDS: Record<string, string> = {
+  XLM: 'stellar',
   ETH: 'ethereum',
   USDC: 'usd-coin',
   USDT: 'tether',
-  XLM: 'stellar',
 };
 
-// Supported fiat currencies
-const SUPPORTED_CURRENCIES = ['usd', 'eur', 'gbp', 'ngn', 'cad', 'aud', 'jpy'];
+// Supported fiat currencies — exported so UI can reference the same list
+export const SUPPORTED_CURRENCIES = ['usd', 'eur', 'gbp', 'ngn', 'cad', 'aud', 'jpy'];
 
 // Cache for prices to avoid excessive API calls
 const priceCache: Map<string, TokenPriceData> = new Map();
@@ -99,11 +99,11 @@ function getFallbackPrices(
   vsCurrencies: string[],
 ): CryptoPrice {
   const fallbackPrices: CryptoPrice = {
-    ETH: { usd: 4000, eur: 3700, gbp: 3200, ngn: 6500000 },
-    STRK: { usd: 0.8, eur: 0.74, gbp: 0.64, ngn: 1300 },
-    USDC: { usd: 1, eur: 0.92, gbp: 0.8, ngn: 1650 },
-    USDT: { usd: 1, eur: 0.92, gbp: 0.8, ngn: 1650 },
-    XLM: { usd: 0.12, eur: 0.11, gbp: 0.095, ngn: 200 },
+    XLM:  { usd: 0.11, eur: 0.10, gbp: 0.087, ngn: 180,    cad: 0.15, aud: 0.17, jpy: 16.5  },
+    ETH:  { usd: 4000, eur: 3700, gbp: 3200,  ngn: 6500000, cad: 5400, aud: 6200, jpy: 600000 },
+    STRK: { usd: 0.8,  eur: 0.74, gbp: 0.64,  ngn: 1300,    cad: 1.08, aud: 1.24, jpy: 120   },
+    USDC: { usd: 1,    eur: 0.92, gbp: 0.8,   ngn: 1650,    cad: 1.35, aud: 1.55, jpy: 150   },
+    USDT: { usd: 1,    eur: 0.92, gbp: 0.8,   ngn: 1650,    cad: 1.35, aud: 1.55, jpy: 150   },
   };
 
   const result: CryptoPrice = {};
@@ -218,4 +218,21 @@ export async function getMultipleTokenPrices(
  */
 export function clearPriceCache(): void {
   priceCache.clear();
+}
+
+/**
+ * Format a fiat amount with the correct locale and currency symbol.
+ * Falls back to a plain number string if Intl is unavailable.
+ */
+export function formatFiatAmount(amount: number, currency: string): string {
+  try {
+    return new Intl.NumberFormat(undefined, {
+      style: 'currency',
+      currency: currency.toUpperCase(),
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(amount);
+  } catch {
+    return `${currency.toUpperCase()} ${amount.toFixed(2)}`;
+  }
 }


### PR DESCRIPTION
Adds a user-configurable default fiat currency that is persisted to localStorage and applied across the entire conversion flow.

Context & persistence
- New UserPreferencesContext stores the selected FiatCurrencyCode and writes it to localStorage under the key "fiat-currency" on every change, then restores it on mount — identical pattern to ThemeContext
- UserPreferencesProvider is composed inside Providers.tsx so every page tree receives the preference automatically

Settings UI (UserSettings.tsx)
- Slide-in panel anchored to the right edge of the viewport, opened via a Settings gear icon added to the header
- Renders the full list of supported currencies (USD, EUR, GBP, NGN, CAD, AUD, JPY) as a listbox with ARIA roles; active item shows a checkmark and blue highlight that respects dark/light mode
- Closes on backdrop click, Escape key, or currency selection; focus is moved to the panel on open for keyboard accessibility

Conversion display (StellarFiatModal.tsx)
- Accepts a new optional fiatCurrency prop forwarded from StellarChatInterface
- Fetches a live XLM price via getTokenPrice() whenever the entered XLM amount or the preferred currency changes; displays the result as "≈ <formatted amount> at current market rate" directly beneath the amount input using the new formatFiatAmount() helper

cryptoPriceService.ts
- Added XLM / stellar to TOKEN_IDS so the CoinGecko API is called with the correct coin identifier
- Expanded fallback price table to cover XLM across all seven supported currencies plus CAD/AUD/JPY for existing tokens
- SUPPORTED_CURRENCIES is now exported so the context and UI share the same authoritative list
- New formatFiatAmount(amount, currency) uses Intl.NumberFormat for locale-aware currency formatting with a plain-text fallback

Closes #74