### PR TITLE
Add on-chain bridge limit display and deposit guard

### DIFF
--- a/dex_with_fiat_frontend/src/components/StellarFiatModal.tsx
+++ b/dex_with_fiat_frontend/src/components/StellarFiatModal.tsx
@@ -10,7 +10,9 @@ import {
 } from 'lucide-react';
 import { useStellarWallet } from '@/contexts/StellarWalletContext';
 import {
+  BRIDGE_LIMIT_WARNING_PERCENT,
   depositToContract,
+  getBridgeLimit,
   withdrawFromContract,
   stroopsToDisplay,
 } from '@/lib/stellarContract';
@@ -25,6 +27,29 @@ interface StellarFiatModalProps {
 }
 
 type TxStatus = 'idle' | 'loading' | 'success' | 'error';
+
+function parseAmountToStroops(value: string): bigint | null {
+  const normalized = value.trim();
+
+  if (!normalized) {
+    return null;
+  }
+
+  if (!/^\d*(?:\.\d{0,7})?$/.test(normalized)) {
+    return null;
+  }
+
+  const [wholePart = '0', fractionalPart = ''] = normalized.split('.');
+
+  if (!wholePart && !fractionalPart) {
+    return null;
+  }
+
+  const whole = wholePart || '0';
+  const fraction = (fractionalPart || '').padEnd(7, '0');
+
+  return BigInt(whole) * 10_000_000n + BigInt(fraction || '0');
+}
 
 export default function StellarFiatModal({
   isOpen,
@@ -49,6 +74,9 @@ export default function StellarFiatModal({
   const [txHash, setTxHash] = useState('');
   const [errorMsg, setErrorMsg] = useState('');
   const [isLoadingUI, setIsLoadingUI] = useState(true);
+  const [bridgeLimit, setBridgeLimit] = useState<bigint | null>(null);
+  const [bridgeLimitError, setBridgeLimitError] = useState('');
+  const [isLoadingBridgeLimit, setIsLoadingBridgeLimit] = useState(false);
 
   useEffect(() => {
     if (isOpen) {
@@ -58,14 +86,109 @@ export default function StellarFiatModal({
     }
   }, [isOpen]);
 
+  useEffect(() => {
+    if (!isOpen) return;
+
+    setAmount(defaultAmount);
+    setRecipient(recipientAddress);
+    setActivePreset(null);
+    setStatus('idle');
+    setTxHash('');
+    setErrorMsg('');
+
+    if (isAdminMode) {
+      setBridgeLimit(null);
+      setBridgeLimitError('');
+      setIsLoadingBridgeLimit(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    setBridgeLimit(null);
+    setBridgeLimitError('');
+    setIsLoadingBridgeLimit(true);
+
+    getBridgeLimit()
+      .then((limit) => {
+        if (!cancelled) {
+          setBridgeLimit(limit);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setBridgeLimitError(
+            'Unable to load the current on-chain bridge limit. Deposits are temporarily disabled.',
+          );
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setIsLoadingBridgeLimit(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [defaultAmount, isAdminMode, isOpen, recipientAddress]);
+
   if (!isOpen) return null;
 
-  const stroopsAmount = BigInt(Math.floor(parseFloat(amount || '0') * 1e7));
+  const stroopsAmount = parseAmountToStroops(amount);
+  const hasValidAmount = stroopsAmount !== null && stroopsAmount > BigInt(0);
+  const isDepositFlow = !isAdminMode;
+  const isLimitUnavailable =
+    isDepositFlow && !isLoadingBridgeLimit && (bridgeLimit === null || !!bridgeLimitError);
+  const isOverLimit =
+    isDepositFlow &&
+    bridgeLimit !== null &&
+    hasValidAmount &&
+    stroopsAmount > bridgeLimit;
+  const usagePercent =
+    isDepositFlow && bridgeLimit !== null && bridgeLimit > BigInt(0) && stroopsAmount !== null
+      ? Number((stroopsAmount * 10_000n) / bridgeLimit) / 100
+      : 0;
+  const isHighLimitUsage =
+    isDepositFlow && !isOverLimit && hasValidAmount && usagePercent >= BRIDGE_LIMIT_WARNING_PERCENT;
+  const remainingLimit =
+    isDepositFlow && bridgeLimit !== null && stroopsAmount !== null && bridgeLimit > stroopsAmount
+      ? bridgeLimit - stroopsAmount
+      : BigInt(0);
+  const isSubmitDisabled =
+    status === 'loading' ||
+    !connection.isConnected ||
+    (isDepositFlow && (isLoadingBridgeLimit || isLimitUnavailable || isOverLimit));
 
   const handleAction = async () => {
     if (!connection.isConnected) return;
-    if (!amount || stroopsAmount <= BigInt(0)) {
+
+    if (!amount || stroopsAmount === null || stroopsAmount <= BigInt(0)) {
       setErrorMsg('Please enter a valid amount.');
+      setStatus('error');
+      return;
+    }
+
+    if (isDepositFlow && isLoadingBridgeLimit) {
+      setErrorMsg('Still loading the current bridge limit. Please wait a moment.');
+      setStatus('error');
+      return;
+    }
+
+    if (isDepositFlow && (bridgeLimit === null || bridgeLimitError)) {
+      setErrorMsg(
+        bridgeLimitError ||
+          'Unable to validate against the current bridge limit. Please try again.',
+      );
+      setStatus('error');
+      return;
+    }
+
+    if (isDepositFlow && bridgeLimit !== null && stroopsAmount > bridgeLimit) {
+      setErrorMsg(
+        `Requested amount exceeds the current bridge limit of ${stroopsToDisplay(bridgeLimit)} XLM.`,
+      );
+      setStatus('error');
       return;
     }
 
@@ -105,7 +228,11 @@ export default function StellarFiatModal({
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
-      <div className="relative w-full max-w-md mx-4 bg-gray-900 border border-gray-700 rounded-2xl shadow-2xl p-6">
+      <div
+        role="dialog"
+        aria-modal="true"
+        className="relative w-full max-w-md mx-4 bg-gray-900 border border-gray-700 rounded-2xl shadow-2xl p-6"
+      >
         {/* Header */}
         <div className="flex items-center justify-between mb-6">
           <div className="flex items-center gap-2">
@@ -116,6 +243,7 @@ export default function StellarFiatModal({
           </div>
           <button
             onClick={handleClose}
+            aria-label="Close"
             className="text-gray-400 hover:text-white transition-colors"
           >
             <X className="w-5 h-5" />
@@ -123,7 +251,7 @@ export default function StellarFiatModal({
         </div>
 
         {status === 'success' ? (
-          <div className="text-center py-6">
+          <div data-testid="success-message" className="text-center py-6">
             <CheckCircle className="w-14 h-14 text-green-400 mx-auto mb-4" />
             <p className="text-white font-semibold text-lg mb-2">
               Transaction Confirmed!
@@ -131,7 +259,7 @@ export default function StellarFiatModal({
             <p className="text-gray-400 text-sm mb-4">
               {isAdminMode ? 'Withdrawal' : 'Deposit'} of{' '}
               <span className="text-white font-medium">
-                {stroopsToDisplay(stroopsAmount)} XLM
+                {stroopsToDisplay(stroopsAmount ?? BigInt(0))} XLM
               </span>{' '}
               processed successfully.
             </p>
@@ -185,9 +313,74 @@ export default function StellarFiatModal({
                   setActivePreset(null);
                 }}
                 placeholder="0.00"
-                className="w-full bg-gray-800 border border-gray-600 rounded-lg px-4 py-3 text-white placeholder-gray-500 focus:outline-none focus:border-blue-500"
+                aria-invalid={isOverLimit ? true : undefined}
+                className={`w-full bg-gray-800 border rounded-lg px-4 py-3 text-white placeholder-gray-500 focus:outline-none ${isOverLimit ? 'border-red-500 focus:border-red-400' : 'border-gray-600 focus:border-blue-500'}`}
               />
             </div>
+
+            {isDepositFlow && (
+              <div className="mb-4 rounded-xl border border-gray-700 bg-gray-800/60 px-4 py-3">
+                <div className="flex items-center justify-between text-xs text-gray-400 mb-2">
+                  <span>On-chain per-deposit limit</span>
+                  <span>
+                    {isLoadingBridgeLimit
+                      ? 'Loading...'
+                      : bridgeLimit !== null
+                        ? `${stroopsToDisplay(bridgeLimit)} XLM`
+                        : 'Unavailable'}
+                  </span>
+                </div>
+
+                <div className="flex items-center justify-between text-sm text-gray-200 mb-2">
+                  <span>Requested amount</span>
+                  <span>
+                    {hasValidAmount && stroopsAmount !== null
+                      ? `${stroopsToDisplay(stroopsAmount)} XLM`
+                      : 'Enter an amount'}
+                  </span>
+                </div>
+
+                <div className="h-2 w-full rounded-full bg-gray-700 overflow-hidden mb-2">
+                  <div
+                    className={`h-full rounded-full transition-all ${isOverLimit ? 'bg-red-500' : isHighLimitUsage ? 'bg-amber-400' : 'bg-blue-500'}`}
+                    style={{ width: `${Math.min(usagePercent, 100)}%` }}
+                  />
+                </div>
+
+                <div className="flex items-center justify-between text-xs text-gray-400">
+                  <span>
+                    {hasValidAmount && bridgeLimit !== null
+                      ? `${usagePercent.toFixed(2)}% of limit`
+                      : `High-usage warning at ${BRIDGE_LIMIT_WARNING_PERCENT}%`}
+                  </span>
+                  <span>
+                    {hasValidAmount && bridgeLimit !== null
+                      ? `${stroopsToDisplay(remainingLimit)} XLM remaining`
+                      : 'Awaiting input'}
+                  </span>
+                </div>
+
+                {bridgeLimitError && (
+                  <div className="mt-3 rounded-lg border border-red-800 bg-red-900/20 px-3 py-2 text-sm text-red-300">
+                    {bridgeLimitError}
+                  </div>
+                )}
+
+                {isHighLimitUsage && bridgeLimit !== null && (
+                  <div className="mt-3 rounded-lg border border-amber-700 bg-amber-900/20 px-3 py-2 text-sm text-amber-200">
+                    This request uses {usagePercent.toFixed(2)}% of the current on-chain limit of{' '}
+                    {stroopsToDisplay(bridgeLimit)} XLM.
+                  </div>
+                )}
+
+                {isOverLimit && bridgeLimit !== null && stroopsAmount !== null && (
+                  <div className="mt-3 rounded-lg border border-red-800 bg-red-900/20 px-3 py-2 text-sm text-red-300">
+                    Requested {stroopsToDisplay(stroopsAmount)} XLM exceeds the current on-chain limit of{' '}
+                    {stroopsToDisplay(bridgeLimit)} XLM.
+                  </div>
+                )}
+              </div>
+            )}
 
             {/* Recipient */}
             {isAdminMode && (
@@ -206,7 +399,7 @@ export default function StellarFiatModal({
             )}
 
             {/* Info */}
-            <div className="flex justify-between text-xs text-gray-500 mb-6">
+            <div data-testid="wallet-info" className="flex justify-between text-xs text-gray-500 mb-6">
               <span>
                 Connected: {connection.address.slice(0, 8)}…
                 {connection.address.slice(-4)}
@@ -216,7 +409,10 @@ export default function StellarFiatModal({
 
             {/* Error */}
             {status === 'error' && (
-              <div className="flex items-center gap-2 text-red-400 bg-red-900/20 border border-red-800 rounded-lg px-3 py-2 mb-4 text-sm">
+              <div
+                data-testid="error-message"
+                className="flex items-center gap-2 text-red-400 bg-red-900/20 border border-red-800 rounded-lg px-3 py-2 mb-4 text-sm"
+              >
                 <AlertCircle className="w-4 h-4 flex-shrink-0" />
                 <span>{errorMsg}</span>
               </div>
@@ -225,12 +421,12 @@ export default function StellarFiatModal({
             {/* CTA */}
             <button
               onClick={handleAction}
-              disabled={status === 'loading' || !connection.isConnected}
+              disabled={isSubmitDisabled}
               className="w-full flex items-center justify-center gap-2 bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 disabled:opacity-50 disabled:cursor-not-allowed text-white py-3 rounded-lg font-semibold transition-all"
             >
               {status === 'loading' ? (
                 <>
-                  <Loader2 className="w-4 h-4 animate-spin" />
+                  <Loader2 data-testid="loading-spinner" className="w-4 h-4 animate-spin" />
                   Signing & submitting…
                 </>
               ) : isAdminMode ? (

--- a/dex_with_fiat_frontend/src/lib/stellarContract.ts
+++ b/dex_with_fiat_frontend/src/lib/stellarContract.ts
@@ -23,6 +23,8 @@ export const XLM_SAC_ID =
 // Stellar Testnet passphrase — switch to Networks.PUBLIC for mainnet
 const NETWORK_PASSPHRASE = Networks.TESTNET;
 
+export const BRIDGE_LIMIT_WARNING_PERCENT = 80;
+
 const server = new rpc.Server(RPC_URL, { allowHttp: false });
 
 // ── Helpers ───────────────────────────────────────────────────────────────
@@ -81,6 +83,7 @@ export async function depositToContract(
   amount: bigint,
   signTx: (xdr: string) => Promise<string>,
 ): Promise<string> {
+  await validateBridgeAmountLimit(amount);
   const contract = new Contract(CONTRACT_ID);
   const op = contract.call(
     'deposit',
@@ -119,7 +122,7 @@ export async function withdrawFromContract(
 async function viewCall<T>(functionName: string): Promise<T> {
   // Use a dummy account (Stellar Foundation's well-known testnet account) for simulation
   const DUMMY_SOURCE =
-    'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN';
+    'GBEFLW6RTALNHCL7HW2INWB4ASHZ7E6MF6E2IOIIMBVEAU2B2B4XLRQW';
   const contract = new Contract(CONTRACT_ID);
 
   // We don't need a funded account — just a valid one for building the tx
@@ -158,6 +161,18 @@ export async function getContractBalance(): Promise<bigint> {
 /** Returns the per-deposit limit set by the admin. */
 export async function getBridgeLimit(): Promise<bigint> {
   return viewCall<bigint>('get_limit');
+}
+
+export async function validateBridgeAmountLimit(amount: bigint): Promise<bigint> {
+  const limit = await getBridgeLimit();
+
+  if (amount > limit) {
+    throw new Error(
+      `Requested amount exceeds the current bridge limit of ${stroopsToDisplay(limit)} XLM.`,
+    );
+  }
+
+  return limit;
 }
 
 /** Returns the running total of all deposits ever made. */


### PR DESCRIPTION
This PR updates the fiat deposit modal to show the requested amount relative to the current contract limit from the live get_limit view call. It adds:

A limit usage display in the modal
A high-usage warning at 80%
A hard block for over-limit values (button disabled + error messaging)
A contract-side deposit pre-check to prevent submissions over the on-chain limit
Validation

Production build passes successfully
Live on-chain limit query confirmed via helper:
limit_stroops=100000000000
limit_xlm=10000
<img width="1584" height="867" alt="Screenshot_2026-03-24_10-12-45" src="https://github.com/user-attachments/assets/92d053ed-4283-4d74-9f92-83bd91798e0b" />
<img width="1584" height="867" alt="Screenshot_2026-03-24_10-11-40" src="https://github.com/user-attachments/assets/ac323186-8ad9-4b09-aa44-ff461ec3db07" />
<img width="1584" height="867" alt="Screenshot_2026-03-24_10-11-15" src="https://github.com/user-attachments/assets/a8ebc454-8d80-4c15-a47c-891dfaa3a590" />

Closes #70 
