### PR TITLE
feat: contextual help cards for first time users

### DIFF
--- a/dex_with_fiat_frontend/src/components/ChatMessages.tsx
+++ b/dex_with_fiat_frontend/src/components/ChatMessages.tsx
@@ -1,8 +1,16 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
-import { ChatMessage } from '@/types';
+import { useEffect, useRef, useState } from 'react';
+import { ChatMessage, SuggestedAction } from '@/types';
 import { useTheme } from '@/contexts/ThemeContext';
+import {
+  Wallet,
+  ArrowDownCircle,
+  CreditCard,
+  X,
+  Sparkles,
+  ChevronRight,
+} from 'lucide-react';
 import Message from './Message';
 
 interface ChatMessagesProps {
@@ -15,6 +23,88 @@ interface ChatMessagesProps {
   isLoading?: boolean;
 }
 
+interface HelpCardProps {
+  id: string;
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+  actionLabel: string;
+  onAction: () => void;
+  onDismiss: (id: string) => void;
+  isDarkMode: boolean;
+}
+
+function HelpCard({
+  id,
+  icon,
+  title,
+  description,
+  actionLabel,
+  onAction,
+  onDismiss,
+  isDarkMode,
+}: HelpCardProps) {
+  return (
+    <div
+      className={`relative group p-5 rounded-2xl border transition-all duration-300 transform hover:-translate-y-1 hover:shadow-xl ${
+        isDarkMode
+          ? 'bg-gray-800/50 border-gray-700 hover:border-blue-500/50'
+          : 'bg-white border-gray-100 hover:border-blue-200'
+      }`}
+    >
+      <button
+        onClick={() => onDismiss(id)}
+        className={`absolute top-3 right-3 p-1 rounded-full opacity-0 group-hover:opacity-100 transition-opacity ${
+          isDarkMode
+            ? 'hover:bg-gray-700 text-gray-500 hover:text-gray-300'
+            : 'hover:bg-gray-100 text-gray-400 hover:text-gray-600'
+        }`}
+        aria-label="Dismiss"
+      >
+        <X className="w-4 h-4" />
+      </button>
+
+      <div className="flex flex-col h-full">
+        <div
+          className={`w-12 h-12 rounded-xl flex items-center justify-center mb-4 ${
+            isDarkMode ? 'bg-blue-500/10 text-blue-400' : 'bg-blue-50 text-blue-600'
+          }`}
+        >
+          {icon}
+        </div>
+
+        <h3
+          className={`text-base font-semibold mb-2 ${
+            isDarkMode ? 'text-gray-100' : 'text-gray-900'
+          }`}
+        >
+          {title}
+        </h3>
+
+        <p
+          className={`text-sm leading-relaxed mb-6 flex-grow ${
+            isDarkMode ? 'text-gray-400' : 'text-gray-500'
+          }`}
+        >
+          {description}
+        </p>
+
+        <button
+          onClick={onAction}
+          className={`flex items-center justify-center gap-2 w-full py-2.5 px-4 rounded-xl text-sm font-medium transition-all ${
+            isDarkMode
+              ? 'bg-blue-600 hover:bg-blue-500 text-white shadow-lg shadow-blue-900/20'
+              : 'bg-blue-600 hover:bg-blue-700 text-white shadow-lg shadow-blue-200'
+          }`}
+        >
+          {actionLabel}
+          <ChevronRight className="w-4 h-4" />
+        </button>
+      </div>
+    </div>
+  );
+}
+
 export default function ChatMessages({
   messages,
   onActionClick,
@@ -23,6 +113,28 @@ export default function ChatMessages({
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const { isDarkMode } = useTheme();
+
+  const [dismissedCards, setDismissedCards] = useState<string[]>([]);
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  // Load dismissed cards from localStorage
+  useEffect(() => {
+    const saved = localStorage.getItem('dexfiat_dismissed_help_cards');
+    if (saved) {
+      try {
+        setDismissedCards(JSON.parse(saved));
+      } catch (e) {
+        console.error('Failed to parse dismissed cards', e);
+      }
+    }
+    setIsLoaded(true);
+  }, []);
+
+  const dismissCard = (id: string) => {
+    const updated = [...dismissedCards, id];
+    setDismissedCards(updated);
+    localStorage.setItem('dexfiat_dismissed_help_cards', JSON.stringify(updated));
+  };
 
   const scrollToBottom = () => {
     if (containerRef.current) {
@@ -34,21 +146,56 @@ export default function ChatMessages({
   };
 
   useEffect(() => {
-    // Always scroll to bottom when AI is generating or when new messages are added
     if (isLoading || messages.length > 0) {
       const timer = setTimeout(() => {
         scrollToBottom();
-      }, 100); // Slightly longer delay to ensure content is rendered
-
+      }, 100);
       return () => clearTimeout(timer);
     }
   }, [messages, isLoading]);
 
+  const helpCards = [
+    {
+      id: 'wallet',
+      icon: <Wallet className="w-6 h-6" />,
+      title: 'Connect Wallet',
+      description:
+        'Connect your Freighter wallet to securely sign transactions on the Stellar network.',
+      actionLabel: 'Connect Now',
+      onAction: () => onActionClick('connect', 'connect_wallet'),
+    },
+    {
+      id: 'deposit',
+      icon: <ArrowDownCircle className="w-6 h-6" />,
+      title: 'Deposit XLM',
+      description:
+        'Lock your XLM assets into our secure bridge contract to initiate a conversion to fiat.',
+      actionLabel: 'Start Deposit',
+      onAction: () => onActionClick('deposit', 'confirm_fiat'),
+    },
+    {
+      id: 'payout',
+      icon: <CreditCard className="w-6 h-6" />,
+      title: 'Setup Payout',
+      description:
+        'Configure your local bank details to receive Naira or USD once your deposit is confirmed.',
+      actionLabel: 'Setup Bank',
+      onAction: () =>
+        onActionClick('payout_guide', 'query', {
+          query: 'How do I setup my bank details for payout?',
+        }),
+    },
+  ];
+
+  const visibleCards = helpCards.filter(
+    (card) => !dismissedCards.includes(card.id),
+  );
+
   return (
     <div
       ref={containerRef}
-      className={`flex-1 overflow-y-auto p-6 space-y-6 transition-colors duration-300 ${
-        isDarkMode ? 'bg-gray-900' : 'bg-white'
+      className={`flex-1 overflow-y-auto p-6 transition-colors duration-300 ${
+        isDarkMode ? 'bg-gray-900' : 'bg-gray-50'
       }`}
       style={{
         height: '100%',
@@ -57,27 +204,57 @@ export default function ChatMessages({
       }}
     >
       {messages.length === 0 ? (
-        <div className="flex items-center justify-center h-full">
-          <div
-            className={`text-center max-w-md transition-colors duration-300 ${
-              isDarkMode ? 'text-gray-400' : 'text-gray-500'
-            }`}
-          >
+        <div className="max-w-4xl mx-auto h-full flex flex-col items-center justify-center py-12">
+          {/* Welcome Header */}
+          <div className="text-center mb-12">
             <div
-              className={`text-xl font-medium mb-3 transition-colors duration-300 ${
-                isDarkMode ? 'text-gray-200' : 'text-gray-900'
+              className={`inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-medium mb-4 ${
+                isDarkMode ? 'bg-blue-500/10 text-blue-400' : 'bg-blue-50 text-blue-600'
               }`}
             >
-              Welcome to DexFiat
+              <Sparkles className="w-3 h-3" />
+              AI-Powered Bridge
             </div>
-            <div className="text-sm leading-relaxed">
-              Start a conversation to convert your cryptocurrency to fiat
-              currency through our secure platform.
-            </div>
+            <h1
+              className={`text-4xl font-bold mb-4 tracking-tight ${
+                isDarkMode ? 'text-white' : 'text-gray-900'
+              }`}
+            >
+              Welcome to <span className="text-blue-600">DexFiat</span>
+            </h1>
+            <p
+              className={`text-lg max-w-xl mx-auto leading-relaxed ${
+                isDarkMode ? 'text-gray-400' : 'text-gray-500'
+              }`}
+            >
+              The most intuitive way to convert your Stellar assets to fiat currency. 
+              Follow the steps below to get started.
+            </p>
           </div>
+
+          {/* Help Cards Grid */}
+          {isLoaded && visibleCards.length > 0 && (
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-6 w-full animate-in fade-in slide-in-from-bottom-4 duration-700">
+              {visibleCards.map((card) => (
+                <HelpCard
+                  key={card.id}
+                  {...card}
+                  onDismiss={dismissCard}
+                  isDarkMode={isDarkMode}
+                />
+              ))}
+            </div>
+          )}
+
+          {/* No cards left placeholder or simple message */}
+          {isLoaded && visibleCards.length === 0 && (
+            <div className={`text-center animate-in fade-in duration-500 ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}>
+              <p>Type a message below to start your conversion journey.</p>
+            </div>
+          )}
         </div>
       ) : (
-        <div className="space-y-6 pb-6">
+        <div className="space-y-6 pb-6 max-w-4xl mx-auto">
           {messages.map((message) => (
             <Message
               key={message.id}

--- a/dex_with_fiat_frontend/src/components/StellarChatInterface.tsx
+++ b/dex_with_fiat_frontend/src/components/StellarChatInterface.tsx
@@ -173,13 +173,18 @@ export default function StellarChatInterface() {
   });
 
   const handleActionClick = useCallback(
-    (actionId: string, actionType: string) => {
+    (actionId: string, actionType: string, data?: Record<string, unknown>) => {
       switch (actionType) {
         case 'connect_wallet':
           connect();
           break;
         case 'confirm_fiat':
           setShowModal(true);
+          break;
+        case 'query':
+          if (data?.query) {
+            sendMessage(data.query as string);
+          }
           break;
         case 'check_portfolio':
           sendMessage('Show me my XLM portfolio and balance');

--- a/dex_with_fiat_frontend/src/hooks/useChat.ts
+++ b/dex_with_fiat_frontend/src/hooks/useChat.ts
@@ -93,7 +93,7 @@ What would you like to do today? I'm here to make your XLM-to-fiat journey smoot
     [getInitialSuggestedActions, connection.isConnected],
   );
 
-  const [messages, setMessages] = useState<ChatMessage[]>([initialMessage]);
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [isInitialized, setIsInitialized] = useState(false);
   const aiAssistant = useMemo(() => new AIAssistant(), []);
@@ -103,8 +103,8 @@ What would you like to do today? I'm here to make your XLM-to-fiat journey smoot
       if (currentSession && currentSession.messages.length > 0) {
         setMessages(currentSession.messages);
       } else if (!currentSessionId) {
-        setMessages([initialMessage]);
-        createNewSession([initialMessage]);
+        setMessages([]);
+        createNewSession([]);
       }
       setIsInitialized(true);
     }
@@ -295,15 +295,15 @@ What would you like to do today? I'm here to make your XLM-to-fiat journey smoot
   );
 
   const clearChat = useCallback(() => {
-    setMessages([initialMessage]);
+    setMessages([]);
     setConversationState({
       messageCount: 0,
       hasUserCancelled: false,
       pendingTransactionData: null,
       shouldTriggerTransaction: false,
     });
-    createNewSession([initialMessage]);
-  }, [initialMessage, createNewSession]);
+    createNewSession([]);
+  }, [createNewSession]);
 
   const loadChatSession = useCallback(
     (sessionId: string) => {


### PR DESCRIPTION

I have implemented the contextual help cards for first-time users as requested. These cards appear in the empty chat state and guide users through the essential steps of using DexFiat.

Changes Made
Help Cards Integration
I added a 
HelpCard
 component and a grid of three setup cards to 
ChatMessages.tsx
:

Connect Wallet: Triggers the Freighter wallet connection.
Deposit XLM: Opens the deposit modal.
Setup Payout: Sends a message to the AI to guide the user through setting up bank details.
State & Persistence
Used localStorage to persist which cards have been dismissed by the user.
The cards remain hidden once dismissed, even after page reloads.
Implemented smooth animations (animate-in fade-in slide-in-from-bottom-4) for a premium feel.
Action Handling
Updated handleActionClick in 
StellarChatInterface.tsx
 to support a generic query action, allowing the help cards to trigger pre-defined AI queries.

- Closes #47 
<img width="1537" height="673" alt="image" src="https://github.com/user-attachments/assets/103a68f2-a520-4863-80c9-9cb114d85cf0" />
