### PR TITLE
feat: wallet session TTL and secure reconnect

### DIFF
--- a/dex_with_fiat_frontend/src/components/StellarChatInterface.tsx
+++ b/dex_with_fiat_frontend/src/components/StellarChatInterface.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useCallback, useEffect, useRef } from 'react';
-import { Wallet, LogOut, Moon, Sun, Menu, X, Plus, Star, Settings, ChevronDown, User } from 'lucide-react';
+import { Wallet, LogOut, Moon, Sun, Menu, X, Plus, Star, Settings, ChevronDown, User, AlertCircle } from 'lucide-react';
 import { useStellarWallet } from '@/contexts/StellarWalletContext';
 import { useTheme } from '@/contexts/ThemeContext';
 import useChat from '@/hooks/useChat';
@@ -17,7 +17,7 @@ import SkeletonSidebar from '@/components/ui/skeleton/SkeletonSidebar';
 import { useUserPreferences } from '@/contexts/UserPreferencesContext';
 
 export default function StellarChatInterface() {
-  const { connection, connect, disconnect, accounts, selectedAccountIndex, selectAccount } = useStellarWallet();
+  const { connection, connect, disconnect, accounts, selectedAccountIndex, selectAccount, sessionExpired, clearSessionExpired } = useStellarWallet();
   const { isDarkMode, toggleDarkMode } = useTheme();
   const { fiatCurrency } = useUserPreferences();
 
@@ -475,11 +475,43 @@ export default function StellarChatInterface() {
         xlmAmount={bankDetailsXlmAmount}
       />
 
-      {/* Settings panel */}
-      <UserSettings
-        isOpen={showSettings}
-        onClose={() => setShowSettings(false)}
-      />
+  {/* Settings panel */}
+  <UserSettings
+    isOpen={showSettings}
+    onClose={() => setShowSettings(false)}
+  />
+
+  {/* Session expired banner */}
+  {sessionExpired && (
+    <div className="fixed bottom-4 left-1/2 -translate-x-1/2 z-50 max-w-md w-full px-4">
+      <div className={`flex items-center gap-3 p-4 rounded-lg shadow-lg border ${isDarkMode ? 'bg-gray-800 border-yellow-600/50' : 'bg-white border-yellow-500'}`}>
+        <AlertCircle className="w-5 h-5 text-yellow-500 flex-shrink-0" />
+        <div className="flex-1">
+          <p className={`text-sm font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>
+            Wallet Session Expired
+          </p>
+          <p className={`text-xs ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}>
+            Your wallet session has expired after 24 hours. Please reconnect to continue.
+          </p>
+        </div>
+        <button
+          onClick={() => {
+            clearSessionExpired();
+            connect();
+          }}
+          className="flex-shrink-0 px-3 py-1.5 text-xs font-medium rounded-lg bg-yellow-500 hover:bg-yellow-600 text-white transition-colors"
+        >
+          Reconnect
+        </button>
+        <button
+          onClick={clearSessionExpired}
+          className={`flex-shrink-0 p-1 rounded-lg transition-colors ${isDarkMode ? 'hover:bg-gray-700 text-gray-400' : 'hover:bg-gray-100 text-gray-500'}`}
+        >
+          <X className="w-4 h-4" />
+        </button>
+      </div>
     </div>
-  );
+  )}
+</div>
+);
 }

--- a/dex_with_fiat_frontend/src/contexts/StellarWalletContext.tsx
+++ b/dex_with_fiat_frontend/src/contexts/StellarWalletContext.tsx
@@ -17,6 +17,11 @@ import {
   setAllowed,
 } from '@stellar/freighter-api';
 
+const SESSION_TTL_MS = 24 * 60 * 60 * 1000;
+const STORAGE_KEY_ADDRESS = 'stellar_address';
+const STORAGE_KEY_INDEX = 'stellar_selected_account_index';
+const STORAGE_KEY_TIMESTAMP = 'stellar_connection_timestamp';
+
 declare global {
   interface Window {
     freighter?: {
@@ -64,6 +69,8 @@ interface StellarWalletContextType {
   isFreighterInstalled: boolean;
   isLoading: boolean;
   error: string | null;
+  sessionExpired: boolean;
+  clearSessionExpired: () => void;
 }
 
 const defaultConnection: StellarWalletConnection = {
@@ -85,6 +92,8 @@ const StellarWalletContext = createContext<StellarWalletContextType>({
   isFreighterInstalled: false,
   isLoading: false,
   error: null,
+  sessionExpired: false,
+  clearSessionExpired: () => {},
 });
 
 export function StellarWalletProvider({ children }: { children: ReactNode }) {
@@ -95,6 +104,7 @@ export function StellarWalletProvider({ children }: { children: ReactNode }) {
   const [isFreighterInstalled, setIsFreighterInstalled] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [sessionExpired, setSessionExpired] = useState(false);
 
   useEffect(() => {
     const check = async () => {
@@ -109,9 +119,22 @@ export function StellarWalletProvider({ children }: { children: ReactNode }) {
   }, []);
 
   useEffect(() => {
-    const stored = localStorage.getItem('stellar_address');
-    const storedIndex = localStorage.getItem('stellar_selected_account_index');
+    const stored = localStorage.getItem(STORAGE_KEY_ADDRESS);
+    const storedIndex = localStorage.getItem(STORAGE_KEY_INDEX);
+    const storedTimestamp = localStorage.getItem(STORAGE_KEY_TIMESTAMP);
     if (stored && isFreighterInstalled) {
+      const connectionTime = storedTimestamp ? parseInt(storedTimestamp, 10) : 0;
+      const now = Date.now();
+      if (now - connectionTime > SESSION_TTL_MS) {
+        localStorage.removeItem(STORAGE_KEY_ADDRESS);
+        localStorage.removeItem(STORAGE_KEY_INDEX);
+        localStorage.removeItem(STORAGE_KEY_TIMESTAMP);
+        setSessionExpired(true);
+        setConnection(defaultConnection);
+        setAccounts([]);
+        setSelectedAccountIndex(0);
+        return;
+      }
       getAddress()
         .then(async (addrResult) => {
           if (!addrResult.error && addrResult.address === stored) {
@@ -143,6 +166,7 @@ export function StellarWalletProvider({ children }: { children: ReactNode }) {
   const connect = useCallback(async () => {
     setIsLoading(true);
     setError(null);
+    setSessionExpired(false);
     try {
       const accessResult = await requestAccess();
       if (accessResult.error) throw new Error(String(accessResult.error));
@@ -154,7 +178,9 @@ export function StellarWalletProvider({ children }: { children: ReactNode }) {
       const accountsResult = await getFreighterAccounts();
 
       const addr = addrResult.address;
-      localStorage.setItem('stellar_address', addr);
+      const now = Date.now();
+      localStorage.setItem(STORAGE_KEY_ADDRESS, addr);
+      localStorage.setItem(STORAGE_KEY_TIMESTAMP, String(now));
 
       if (!accountsResult.error && accountsResult.accounts.length > 0) {
         const walletAccounts: WalletAccount[] = accountsResult.accounts.map((a: string, idx: number) => ({
@@ -164,7 +190,7 @@ export function StellarWalletProvider({ children }: { children: ReactNode }) {
         setAccounts(walletAccounts);
         const currentIndex = accountsResult.accounts.indexOf(addr);
         setSelectedAccountIndex(currentIndex >= 0 ? currentIndex : 0);
-        localStorage.setItem('stellar_selected_account_index', String(currentIndex >= 0 ? currentIndex : 0));
+        localStorage.setItem(STORAGE_KEY_INDEX, String(currentIndex >= 0 ? currentIndex : 0));
       }
 
       setConnection({
@@ -184,12 +210,14 @@ export function StellarWalletProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const disconnect = useCallback(() => {
-    localStorage.removeItem('stellar_address');
-    localStorage.removeItem('stellar_selected_account_index');
+    localStorage.removeItem(STORAGE_KEY_ADDRESS);
+    localStorage.removeItem(STORAGE_KEY_INDEX);
+    localStorage.removeItem(STORAGE_KEY_TIMESTAMP);
     setConnection(defaultConnection);
     setAccounts([]);
     setSelectedAccountIndex(0);
     setError(null);
+    setSessionExpired(false);
   }, []);
 
   const signTx = useCallback(
@@ -209,42 +237,49 @@ export function StellarWalletProvider({ children }: { children: ReactNode }) {
       if (index < 0 || index >= accounts.length) return;
       const selectedAccount = accounts[index];
       try {
-        await setFreighterAllowedBack(selectedAccount.address);
-        setSelectedAccountIndex(index);
-        localStorage.setItem('stellar_selected_account_index', String(index));
-        setConnection((prev) => ({
-          ...prev,
-          address: selectedAccount.address,
-          publicKey: selectedAccount.address,
-        }));
-        localStorage.setItem('stellar_address', selectedAccount.address);
-      } catch (err) {
-        setError(
-          err instanceof Error ? err.message : 'Failed to switch account',
-        );
-      }
-    },
-    [accounts],
-  );
+      await setFreighterAllowedBack(selectedAccount.address);
+      setSelectedAccountIndex(index);
+      localStorage.setItem(STORAGE_KEY_INDEX, String(index));
+      setConnection((prev) => ({
+        ...prev,
+        address: selectedAccount.address,
+        publicKey: selectedAccount.address,
+      }));
+      localStorage.setItem(STORAGE_KEY_ADDRESS, selectedAccount.address);
+      localStorage.setItem(STORAGE_KEY_TIMESTAMP, String(Date.now()));
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : 'Failed to switch account',
+      );
+    }
+  },
+  [accounts],
+);
 
-  return (
-    <StellarWalletContext.Provider
-      value={{
-        connection,
-        accounts,
-        selectedAccountIndex,
-        selectAccount,
-        connect,
-        disconnect,
-        signTx,
-        isFreighterInstalled,
-        isLoading,
-        error,
-      }}
-    >
-      {children}
-    </StellarWalletContext.Provider>
-  );
+const clearSessionExpired = useCallback(() => {
+  setSessionExpired(false);
+}, []);
+
+return (
+  <StellarWalletContext.Provider
+    value={{
+      connection,
+      accounts,
+      selectedAccountIndex,
+      selectAccount,
+      connect,
+      disconnect,
+      signTx,
+      isFreighterInstalled,
+      isLoading,
+      error,
+      sessionExpired,
+      clearSessionExpired,
+    }}
+  >
+    {children}
+  </StellarWalletContext.Provider>
+);
 }
 
 export function useStellarWallet() {


### PR DESCRIPTION
## Summary
- Store connection timestamp in localStorage and enforce 24-hour session expiry
- Clear stale wallet state on expiry with sessionExpired flag
- Show user-facing banner explaining expired session with reconnect option

## Changes
- **StellarWalletContext.tsx**: Added `SESSION_TTL_MS` constant (24 hours). Store connection timestamp on connect and account switch. Check TTL on auto-reconnect and clear state if expired. Added `sessionExpired` state and `clearSessionExpired` function to context.
- **StellarChatInterface.tsx**: Added banner component that displays when session expires, explaining the 24-hour limit and offering a reconnect button.

## Acceptance Criteria Met
- [x] Store connection timestamp and enforce 24-hour expiry
- [x] Clear stale wallet state on expiry and request reconnect
- [x] Show a user-facing message explaining expired session

Closes #31