### PR TITLE
feat: transaction fee estimate before submit

### DIFF
--- a/dex_with_fiat_frontend/src/components/StellarFiatModal.tsx
+++ b/dex_with_fiat_frontend/src/components/StellarFiatModal.tsx
@@ -15,6 +15,9 @@ import {
   getBridgeLimit,
   withdrawFromContract,
   stroopsToDisplay,
+  simulateDeposit,
+  simulateWithdraw,
+  FeeEstimate,
 } from '@/lib/stellarContract';
 import {
   getTokenPrice,
@@ -86,6 +89,8 @@ export default function StellarFiatModal({
   const [bridgeLimit, setBridgeLimit] = useState<bigint | null>(null);
   const [bridgeLimitError, setBridgeLimitError] = useState('');
   const [isLoadingBridgeLimit, setIsLoadingBridgeLimit] = useState(false);
+  const [feeEstimate, setFeeEstimate] = useState<FeeEstimate | null>(null);
+  const [isLoadingFee, setIsLoadingFee] = useState(false);
 
   useEffect(() => {
     if (isOpen) {
@@ -104,6 +109,7 @@ export default function StellarFiatModal({
     setStatus('idle');
     setTxHash('');
     setErrorMsg('');
+    setFeeEstimate(null);
 
     if (isAdminMode) {
       setBridgeLimit(null);
@@ -141,6 +147,50 @@ export default function StellarFiatModal({
       cancelled = true;
     };
   }, [defaultAmount, isAdminMode, isOpen, recipientAddress]);
+
+  useEffect(() => {
+    if (!isOpen || !connection.isConnected) {
+      setFeeEstimate(null);
+      return;
+    }
+    const currentStroops = parseAmountToStroops(amount);
+    if (!currentStroops || currentStroops <= BigInt(0)) {
+      setFeeEstimate(null);
+      return;
+    }
+
+    let cancelled = false;
+    setIsLoadingFee(true);
+
+    const simulateTransaction = async () => {
+      try {
+        let estimate: FeeEstimate | null;
+        if (isAdminMode) {
+          const to = recipient || connection.publicKey;
+          estimate = await simulateWithdraw(connection.publicKey, to, currentStroops);
+        } else {
+          estimate = await simulateDeposit(connection.publicKey, currentStroops);
+        }
+        if (!cancelled) {
+          setFeeEstimate(estimate);
+        }
+      } catch {
+        if (!cancelled) {
+          setFeeEstimate(null);
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoadingFee(false);
+        }
+      }
+    };
+
+    const debounceTimer = setTimeout(simulateTransaction, 500);
+    return () => {
+      cancelled = true;
+      clearTimeout(debounceTimer);
+    };
+  }, [amount, connection.isConnected, connection.publicKey, isAdminMode, isOpen, recipient]);
 
   // Live fiat estimate: recalculate whenever amount or fiatCurrency changes
   const updateFiatEstimate = useCallback(async () => {
@@ -357,15 +407,31 @@ export default function StellarFiatModal({
               />
             </div>
 
-            {/* Fiat estimate */}
-            {fiatEstimate && (
-              <p className="text-xs text-gray-400 -mt-2 mb-4">
-                ≈ <span className="text-white font-medium">{fiatEstimate}</span>{' '}
-                at current market rate
-              </p>
-            )}
+      {/* Fiat estimate */}
+      {fiatEstimate && (
+        <p className="text-xs text-gray-400 -mt-2 mb-4">
+          ≈ <span className="text-white font-medium">{fiatEstimate}</span>{' '}
+          at current market rate
+        </p>
+      )}
 
-            {isDepositFlow && (
+      {/* Fee estimate */}
+      {(isLoadingFee || feeEstimate) && (
+        <div className="flex items-center justify-between text-xs text-gray-400 mb-4">
+          <span>Est. transaction fee</span>
+          <span>
+            {isLoadingFee ? (
+              'Calculating...'
+            ) : feeEstimate ? (
+              `~${feeEstimate.fee.toFixed(7)} XLM`
+            ) : (
+              'Unavailable'
+            )}
+          </span>
+        </div>
+      )}
+
+      {isDepositFlow && (
               <div className="mb-4 rounded-xl border border-gray-700 bg-gray-800/60 px-4 py-3">
                 <div className="flex items-center justify-between text-xs text-gray-400 mb-2">
                   <span>On-chain per-deposit limit</span>

--- a/dex_with_fiat_frontend/src/lib/stellarContract.ts
+++ b/dex_with_fiat_frontend/src/lib/stellarContract.ts
@@ -29,11 +29,16 @@ const server = new rpc.Server(RPC_URL, { allowHttp: false });
 
 // ── Helpers ───────────────────────────────────────────────────────────────
 
-/** Build, simulate, and assemble a transaction. Returns the assembled XDR. */
+export interface FeeEstimate {
+  minFee: string;
+  fee: number;
+}
+
+/** Build, simulate, and assemble a transaction. Returns the assembled XDR and fee estimate. */
 async function buildAndSimulate(
   publicKey: string,
   operation: ReturnType<Contract['call']>,
-): Promise<string> {
+): Promise<{ assembledXdr: string; feeEstimate: FeeEstimate | null }> {
   const account = await server.getAccount(publicKey);
   const tx = new TransactionBuilder(account, {
     fee: BASE_FEE,
@@ -47,7 +52,21 @@ async function buildAndSimulate(
   if (rpc.Api.isSimulationError(sim)) {
     throw new Error(`Simulation failed: ${sim.error}`);
   }
-  return rpc.assembleTransaction(tx, sim).build().toXDR();
+
+  let feeEstimate: FeeEstimate | null = null;
+  const successSim = sim as rpc.Api.SimulateTransactionSuccessResponse;
+  if (successSim.minResourceFee !== undefined) {
+    const feeInStroops = BigInt(successSim.minResourceFee);
+    feeEstimate = {
+      minFee: successSim.minResourceFee,
+      fee: Number(feeInStroops) / 10_000_000,
+    };
+  }
+
+  return {
+    assembledXdr: rpc.assembleTransaction(tx, sim).build().toXDR(),
+    feeEstimate,
+  };
 }
 
 /** Submit a signed XDR and wait for confirmation. */
@@ -74,6 +93,47 @@ async function submitAndWait(signedXdr: string): Promise<string> {
 
 // ── Write functions (require wallet signature) ────────────────────────────
 
+export interface TransactionResult {
+  hash: string;
+  feeEstimate: FeeEstimate | null;
+}
+
+/**
+ * Simulate a deposit transaction and return fee estimate without submitting.
+ */
+export async function simulateDeposit(
+  publicKey: string,
+  amount: bigint,
+): Promise<FeeEstimate | null> {
+  await validateBridgeAmountLimit(amount);
+  const contract = new Contract(CONTRACT_ID);
+  const op = contract.call(
+    'deposit',
+    new Address(publicKey).toScVal(),
+    nativeToScVal(amount, { type: 'i128' }),
+  );
+  const { feeEstimate } = await buildAndSimulate(publicKey, op);
+  return feeEstimate;
+}
+
+/**
+ * Simulate a withdraw transaction and return fee estimate without submitting.
+ */
+export async function simulateWithdraw(
+  adminPublicKey: string,
+  recipientPublicKey: string,
+  amount: bigint,
+): Promise<FeeEstimate | null> {
+  const contract = new Contract(CONTRACT_ID);
+  const op = contract.call(
+    'withdraw',
+    new Address(recipientPublicKey).toScVal(),
+    nativeToScVal(amount, { type: 'i128' }),
+  );
+  const { feeEstimate } = await buildAndSimulate(adminPublicKey, op);
+  return feeEstimate;
+}
+
 /**
  * Deposit `amount` stroops of the bridged token from `publicKey` into the contract.
  * Returns the transaction hash on success.
@@ -90,8 +150,8 @@ export async function depositToContract(
     new Address(publicKey).toScVal(),
     nativeToScVal(amount, { type: 'i128' }),
   );
-  const assembled = await buildAndSimulate(publicKey, op);
-  const signed = await signTx(assembled);
+  const { assembledXdr } = await buildAndSimulate(publicKey, op);
+  const signed = await signTx(assembledXdr);
   return submitAndWait(signed);
 }
 
@@ -111,8 +171,8 @@ export async function withdrawFromContract(
     new Address(recipientPublicKey).toScVal(),
     nativeToScVal(amount, { type: 'i128' }),
   );
-  const assembled = await buildAndSimulate(adminPublicKey, op);
-  const signed = await signTx(assembled);
+  const { assembledXdr } = await buildAndSimulate(adminPublicKey, op);
+  const signed = await signTx(assembledXdr);
   return submitAndWait(signed);
 }
 


### PR DESCRIPTION
## Summary
- Extract estimated fee from simulation response using minResourceFee
- Display fee estimate in XLM in deposit and withdraw flow
- Gracefully handle unavailable estimate without blocking submit

## Changes
- stellarContract.ts: Added FeeEstimate interface and simulateDeposit/simulateWithdraw functions
- StellarFiatModal.tsx: Added fee estimate display with loading state

## Acceptance Criteria Met
- [x] Extract estimated fee from simulation response
- [x] Display fee estimate in XLM in deposit and withdraw flow
- [x] Gracefully handle unavailable estimate without blocking submit

Closes #33