### PR TITLE
Add AI guardrails for unsupported requests

### DIFF
--- a/dex_with_fiat_frontend/src/components/Message.tsx
+++ b/dex_with_fiat_frontend/src/components/Message.tsx
@@ -118,6 +118,21 @@ export default function Message({ message, onActionClick }: MessageProps) {
                 minute: '2-digit',
               })}
             </div>
+            {message.metadata?.guardrail?.triggered && (
+              <div
+                className={`mt-3 inline-flex items-center gap-2 rounded-lg border px-3 py-2 text-xs ${
+                  isDarkMode
+                    ? 'border-amber-700 bg-amber-950/40 text-amber-200'
+                    : 'border-amber-200 bg-amber-50 text-amber-800'
+                }`}
+              >
+                <AlertTriangle className="h-4 w-4" />
+                <span>
+                  Guardrail:{' '}
+                  {message.metadata.guardrail.category.replaceAll('_', ' ')}
+                </span>
+              </div>
+            )}
             {message.metadata?.suggestedActions &&
               message.metadata.suggestedActions.length > 0 && (
                 <div

--- a/dex_with_fiat_frontend/src/hooks/useChat.ts
+++ b/dex_with_fiat_frontend/src/hooks/useChat.ts
@@ -1,7 +1,12 @@
 'use client';
 
 import { useState, useCallback, useEffect, useMemo } from 'react';
-import { ChatMessage, AIAnalysisResult, TransactionData } from '@/types';
+import {
+  ChatMessage,
+  AIAnalysisResult,
+  GuardrailCategory,
+  TransactionData,
+} from '@/types';
 import { AIAssistant } from '@/lib/aiAssistant';
 import { useStellarWallet } from '@/contexts/StellarWalletContext';
 import { useChatHistory } from './useChatHistory';
@@ -256,6 +261,7 @@ What would you like to do today? I'm here to make your XLM-to-fiat journey smoot
           content: enhancedResponse,
           timestamp: new Date(),
           metadata: {
+            guardrail: analysis.guardrail,
             transactionData: shouldShowTransactionData
               ? (analysis.extractedData as TransactionData)
               : undefined,
@@ -395,6 +401,10 @@ function generateSuggestedActions(
   const hasTransactionData = context?.hasTransactionData || false;
   const shouldAutoTrigger = context?.shouldAutoTrigger || false;
   const isAdmin = context?.isAdmin || false;
+
+  if (analysis.intent === 'guardrail' && analysis.guardrail) {
+    return generateGuardrailActions(analysis.guardrail.category, isConnected);
+  }
 
   if (shouldAutoTrigger && hasTransactionData) {
     actions.push({
@@ -555,6 +565,46 @@ function generateSuggestedActions(
       },
     );
   }
+
+  return actions;
+}
+
+function generateGuardrailActions(
+  category: GuardrailCategory,
+  isWalletConnected: boolean,
+) {
+  const actions = [];
+
+  if (!isWalletConnected) {
+    actions.push({
+      id: 'guardrail_connect_wallet',
+      type: 'connect_wallet' as const,
+      label: 'Connect Freighter',
+    });
+  }
+
+  if (category === 'unsupported_request') {
+    actions.push({
+      id: 'guardrail_supported_question',
+      type: 'query' as const,
+      label: 'Show Supported Tasks',
+      data: {
+        query:
+          'What supported actions can you help me with in Stellar Dex Chat?',
+      },
+    });
+  }
+
+  actions.push({
+    id: 'guardrail_market_rates',
+    type: 'market_rates' as const,
+    label: 'Check XLM Rates',
+  });
+  actions.push({
+    id: 'guardrail_learn_more',
+    type: 'learn_more' as const,
+    label: 'How It Works',
+  });
 
   return actions;
 }

--- a/dex_with_fiat_frontend/src/lib/aiAssistant.ts
+++ b/dex_with_fiat_frontend/src/lib/aiAssistant.ts
@@ -1,11 +1,30 @@
 import { GoogleGenerativeAI } from '@google/generative-ai';
-import { AIAnalysisResult, TransactionData } from '@/types';
+import {
+  AIAnalysisResult,
+  GuardrailCategory,
+  GuardrailResult,
+  TransactionData,
+} from '@/types';
+import { telemetry } from '@/lib/telemetry';
 
 const genAI = new GoogleGenerativeAI(
   process.env.NEXT_PUBLIC_GEMINI_API_KEY || '',
 );
 
+type GuardrailMatch = {
+  category: GuardrailCategory;
+  reason: string;
+};
+
 export class AIAssistant {
+  private static guardrailCounts: Record<GuardrailCategory, number> = {
+    unsupported_request: 0,
+    wallet_security: 0,
+    compliance_evasion: 0,
+    malicious_activity: 0,
+    financial_guarantee: 0,
+  };
+
   private model = genAI.getGenerativeModel({ model: 'gemini-1.5-flash' });
 
   async analyzeUserMessage(
@@ -13,6 +32,11 @@ export class AIAssistant {
     context?: Record<string, unknown>,
   ): Promise<AIAnalysisResult> {
     try {
+      const guardrailMatch = this.classifyGuardrail(message);
+      if (guardrailMatch) {
+        return this.buildGuardrailResponse(guardrailMatch, message);
+      }
+
       const prompt = this.buildAnalysisPrompt(message, context);
       const result = await this.model.generateContent(prompt);
       const response = result.response.text();
@@ -27,6 +51,7 @@ export class AIAssistant {
         requiredQuestions: [],
         suggestedResponse:
           "I'm having trouble understanding your request. Could you please rephrase it?",
+        guardrail: undefined,
       };
     }
   }
@@ -66,12 +91,13 @@ EXTRACTION GUIDELINES:
 - Set intent to "fiat_conversion" only when user explicitly wants to deposit XLM or convert XLM to fiat
 - Set intent to "query" for questions, information requests, or casual conversation
 - Set intent to "portfolio" for XLM balance checks, asset inquiries about Stellar assets
+- Set intent to "guardrail" for unsupported requests or risky requests involving private keys, bypassing compliance, exploits, scams, or guaranteed returns
 - Set intent to "unknown" only if completely unclear
 - Always assume XLM when referring to tokens (we support XLM on Stellar)
 
 Respond with a JSON object in this exact format:
 {
-    "intent": "fiat_conversion|query|portfolio|technical_support|unknown",
+    "intent": "fiat_conversion|query|portfolio|technical_support|guardrail|unknown",
   "confidence": 0.8,
   "extractedData": {
     "type": "fiat_conversion",
@@ -81,7 +107,12 @@ Respond with a JSON object in this exact format:
     "fiatCurrency": "NGN"
   },
   "requiredQuestions": ["What amount of XLM would you like to deposit/convert?"],
-  "suggestedResponse": "I'd be happy to help you convert your XLM to Nigerian Naira via the Stellar FiatBridge!"
+  "suggestedResponse": "I'd be happy to help you convert your XLM to Nigerian Naira via the Stellar FiatBridge!",
+  "guardrail": {
+    "triggered": false,
+    "category": "unsupported_request",
+    "reason": ""
+  }
 }
 
 EXAMPLE RESPONSES BY INTENT:
@@ -131,6 +162,150 @@ Be conversational and helpful. Ask clarifying questions when information is miss
 `;
   }
 
+  private classifyGuardrail(message: string): GuardrailMatch | null {
+    const normalized = message.toLowerCase();
+    const mentionsSupportedDomain =
+      /(xlm|stellar|soroban|freighter|wallet|fiat|deposit|withdraw|bank transfer|portfolio|contract|offramp|naira|ngn|usd|eur)/i.test(
+        message,
+      );
+
+    if (
+      /(seed phrase|secret phrase|private key|recovery phrase|mnemonic|passphrase|wallet secret)/i.test(
+        normalized,
+      )
+    ) {
+      return {
+        category: 'wallet_security',
+        reason:
+          'Request involves sensitive wallet credentials or recovery data.',
+      };
+    }
+
+    if (
+      /(bypass kyc|avoid kyc|skip kyc|evade aml|avoid aml|bypass compliance|sanction|launder|money laundering|wash trading|hide funds)/i.test(
+        normalized,
+      )
+    ) {
+      return {
+        category: 'compliance_evasion',
+        reason:
+          'Request appears to seek compliance evasion or illicit fund flows.',
+      };
+    }
+
+    if (
+      /(hack|exploit|drain|phish|steal|scam|spoof|backdoor|malware|keylogger|credential stuffing|rug pull)/i.test(
+        normalized,
+      )
+    ) {
+      return {
+        category: 'malicious_activity',
+        reason:
+          'Request appears to facilitate fraud, exploits, or other malicious activity.',
+      };
+    }
+
+    if (
+      /(guarantee profit|guaranteed profit|risk-free return|sure profit|double my money|insider tip|pump this|financial advice)/i.test(
+        normalized,
+      )
+    ) {
+      return {
+        category: 'financial_guarantee',
+        reason:
+          'Request asks for unsafe financial guarantees or promotional investment advice.',
+      };
+    }
+
+    if (
+      !mentionsSupportedDomain &&
+      /(write|build|book|plan|recommend|recipe|summarize|translate|homework|essay|poem|code|movie|weather|hotel|flight|calendar|email)/i.test(
+        normalized,
+      )
+    ) {
+      return {
+        category: 'unsupported_request',
+        reason: 'Request falls outside the Stellar conversion assistant scope.',
+      };
+    }
+
+    return null;
+  }
+
+  private buildGuardrailResponse(
+    match: GuardrailMatch,
+    message: string,
+  ): AIAnalysisResult {
+    const guardrail = this.recordGuardrailTrigger(match, message);
+
+    return {
+      intent: 'guardrail',
+      confidence: 0.99,
+      extractedData: {},
+      requiredQuestions: [],
+      suggestedResponse: this.buildSafeGuardrailTemplate(match.category),
+      guardrail,
+    };
+  }
+
+  private recordGuardrailTrigger(
+    match: GuardrailMatch,
+    message: string,
+  ): GuardrailResult {
+    AIAssistant.guardrailCounts[match.category] += 1;
+
+    const totalTriggerCount = Object.values(AIAssistant.guardrailCounts).reduce(
+      (sum, count) => sum + count,
+      0,
+    );
+
+    const traceId = telemetry.generateTraceId();
+    const spanId = telemetry.generateSpanId();
+
+    telemetry.logWithTrace('warn', 'AI guardrail triggered', traceId, spanId, {
+      category: match.category,
+      reason: match.reason,
+      triggerCount: AIAssistant.guardrailCounts[match.category],
+      totalTriggerCount,
+      messagePreview: message.slice(0, 120),
+    });
+
+    return {
+      triggered: true,
+      category: match.category,
+      reason: match.reason,
+      triggerCount: AIAssistant.guardrailCounts[match.category],
+      totalTriggerCount,
+    };
+  }
+
+  private buildSafeGuardrailTemplate(category: GuardrailCategory): string {
+    const categoryLine = {
+      unsupported_request:
+        'I can only help with Stellar wallet, XLM conversion, and fiat off-ramp tasks in this app.',
+      wallet_security:
+        'I can’t process or help expose private keys, seed phrases, or recovery credentials.',
+      compliance_evasion:
+        'I can’t help bypass KYC, AML, sanctions, or other compliance controls.',
+      malicious_activity:
+        'I can’t assist with exploits, scams, phishing, or unauthorized access.',
+      financial_guarantee:
+        'I can’t promise profits or provide unsafe guaranteed-return guidance.',
+    }[category];
+
+    return `**Request Blocked by Guardrails**
+
+${categoryLine}
+
+**What I can help with instead**
+- Deposit XLM into the Stellar FiatBridge flow
+- Check XLM market rates and conversion estimates
+- Explain how the Stellar offramp works
+- Help connect your Freighter wallet safely
+
+Choose one of the next actions below and I’ll keep it moving.`;
+  }
+
   private parseAIResponse(response: string): AIAnalysisResult {
     try {
       // Extract JSON from response
@@ -144,6 +319,7 @@ Be conversational and helpful. Ask clarifying questions when information is miss
           requiredQuestions: parsed.requiredQuestions || [],
           suggestedResponse:
             parsed.suggestedResponse || 'How can I help you today?',
+          guardrail: parsed.guardrail,
         };
       }
     } catch (error) {
@@ -158,6 +334,7 @@ Be conversational and helpful. Ask clarifying questions when information is miss
       suggestedResponse:
         response ||
         "How can I help you with your DeFi needs today? You can also say 'bridge tokens from Sepolia to Optimism' to use the CCIP bridge.",
+      guardrail: undefined,
     };
   }
 

--- a/dex_with_fiat_frontend/src/types/index.ts
+++ b/dex_with_fiat_frontend/src/types/index.ts
@@ -10,6 +10,7 @@ export interface ChatMessage {
     confirmationRequired?: boolean;
     autoTriggerTransaction?: boolean;
     conversationCount?: number;
+    guardrail?: GuardrailResult;
   };
 }
 
@@ -48,10 +49,26 @@ export interface SuggestedAction {
     | 'check_portfolio'
     | 'market_rates'
     | 'learn_more'
-    | 'cancel';
+    | 'cancel'
+    | 'query';
   label: string;
   data?: Record<string, unknown>;
   priority?: boolean;
+}
+
+export type GuardrailCategory =
+  | 'unsupported_request'
+  | 'wallet_security'
+  | 'compliance_evasion'
+  | 'malicious_activity'
+  | 'financial_guarantee';
+
+export interface GuardrailResult {
+  triggered: boolean;
+  category: GuardrailCategory;
+  reason: string;
+  triggerCount?: number;
+  totalTriggerCount?: number;
 }
 
 export interface Token {
@@ -76,11 +93,13 @@ export interface AIAnalysisResult {
     | 'query'
     | 'portfolio'
     | 'technical_support'
+    | 'guardrail'
     | 'unknown';
   confidence: number;
   extractedData: Partial<TransactionData>;
   requiredQuestions: string[];
   suggestedResponse: string;
+  guardrail?: GuardrailResult;
 }
 
 // Paystack Types


### PR DESCRIPTION
Closes #45 

 Summary
Adds AI guardrails for unsupported and risky chat requests.

Changes
- Classifies blocked requests before normal AI handling
- Returns a safe response template with valid next actions
- Logs and counts guardrail triggers for maintainers
- Shows guardrail state in chat metadata/UI

Validation
Smoke-tested blocked and safe request flows and confirmed guardrail trigger logs were emitted.
