### PR TITLE
feat(frontend): improve transaction safety and theming

### DIFF
--- a/dex_with_fiat_frontend/src/app/globals.css
+++ b/dex_with_fiat_frontend/src/app/globals.css
@@ -1,13 +1,51 @@
 @import 'tailwindcss';
 
 :root {
-  --background: #ffffff;
-  --foreground: #000000;
+  --background: #f4f7fb;
+  --foreground: #111827;
+  --color-surface: #ffffff;
+  --color-surface-muted: #eef2f7;
+  --color-surface-elevated: #e2e8f0;
+  --color-text-primary: #111827;
+  --color-text-secondary: #475569;
+  --color-text-muted: #64748b;
+  --color-border: #d6deea;
+  --color-primary: #2563eb;
+  --color-primary-hover: #1d4ed8;
+  --color-primary-soft: rgba(37, 99, 235, 0.12);
+  --color-success: #16a34a;
+  --color-success-soft: rgba(22, 163, 74, 0.14);
+  --color-warning: #d97706;
+  --color-warning-soft: rgba(217, 119, 6, 0.14);
+  --color-danger: #dc2626;
+  --color-danger-soft: rgba(220, 38, 38, 0.14);
+  --color-overlay: rgba(15, 23, 42, 0.62);
+  --color-scrollbar-track: #e2e8f0;
+  --color-scrollbar-thumb: #94a3b8;
 }
 
 [data-theme='dark'] {
-  --background: #0f0f0f;
-  --foreground: #ffffff;
+  --background: #020617;
+  --foreground: #f8fafc;
+  --color-surface: #0f172a;
+  --color-surface-muted: #111c31;
+  --color-surface-elevated: #1e293b;
+  --color-text-primary: #f8fafc;
+  --color-text-secondary: #cbd5e1;
+  --color-text-muted: #94a3b8;
+  --color-border: #243244;
+  --color-primary: #60a5fa;
+  --color-primary-hover: #3b82f6;
+  --color-primary-soft: rgba(96, 165, 250, 0.16);
+  --color-success: #4ade80;
+  --color-success-soft: rgba(74, 222, 128, 0.16);
+  --color-warning: #fbbf24;
+  --color-warning-soft: rgba(251, 191, 36, 0.18);
+  --color-danger: #f87171;
+  --color-danger-soft: rgba(248, 113, 113, 0.18);
+  --color-overlay: rgba(2, 6, 23, 0.76);
+  --color-scrollbar-track: #111827;
+  --color-scrollbar-thumb: #475569;
 }
 
 body {
@@ -23,6 +61,11 @@ body {
   transition:
     background-color 0.3s ease,
     color 0.3s ease;
+  color-scheme: light;
+}
+
+[data-theme='dark'] body {
+  color-scheme: dark;
 }
 
 html {
@@ -102,29 +145,29 @@ html {
 }
 
 ::-webkit-scrollbar-track {
-  background: #f1f1f1;
+  background: var(--color-scrollbar-track);
   border-radius: 4px;
 }
 
 /* Dark theme scrollbar */
 [data-theme='dark'] ::-webkit-scrollbar-track {
-  background: #1a1a1a;
+  background: var(--color-scrollbar-track);
 }
 
 ::-webkit-scrollbar-thumb {
-  background: #4a5568;
+  background: var(--color-scrollbar-thumb);
   border-radius: 4px;
   transition: background 0.2s ease;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: #6b7280;
+  background: var(--color-text-muted);
 }
 
 /* Better scrolling for chat */
 .chat-container {
   scrollbar-width: thin;
-  scrollbar-color: #4a5568 #1a1a1a;
+  scrollbar-color: var(--color-scrollbar-thumb) var(--color-scrollbar-track);
   scroll-behavior: smooth;
   overflow-anchor: none;
 }
@@ -135,16 +178,16 @@ html {
 }
 
 .chat-messages::-webkit-scrollbar-track {
-  background: rgba(31, 31, 31, 0.3);
+  background: color-mix(in srgb, var(--color-surface) 55%, transparent);
 }
 
 .chat-messages::-webkit-scrollbar-thumb {
-  background: rgba(68, 68, 68, 0.8);
+  background: color-mix(in srgb, var(--color-scrollbar-thumb) 80%, transparent);
   border-radius: 3px;
 }
 
 .chat-messages::-webkit-scrollbar-thumb:hover {
-  background: rgba(85, 85, 85, 0.9);
+  background: var(--color-scrollbar-thumb);
 }
 
 /* Focus styles for accessibility */
@@ -152,7 +195,7 @@ button:focus,
 input:focus,
 textarea:focus,
 select:focus {
-  outline: 2px solid #3b82f6;
+  outline: 2px solid var(--color-primary);
   outline-offset: 2px;
 }
 
@@ -257,6 +300,86 @@ select:focus {
 
 .btn-modern:hover::before {
   left: 100%;
+}
+
+.theme-app {
+  background: var(--background);
+  color: var(--color-text-primary);
+}
+
+.theme-surface {
+  background: var(--color-surface);
+  color: var(--color-text-primary);
+}
+
+.theme-surface-muted {
+  background: var(--color-surface-muted);
+}
+
+.theme-border {
+  border-color: var(--color-border);
+}
+
+.theme-text-primary {
+  color: var(--color-text-primary);
+}
+
+.theme-text-secondary {
+  color: var(--color-text-secondary);
+}
+
+.theme-text-muted {
+  color: var(--color-text-muted);
+}
+
+.theme-input {
+  background: var(--color-surface-muted);
+  border-color: var(--color-border);
+  color: var(--color-text-primary);
+}
+
+.theme-input::placeholder {
+  color: var(--color-text-muted);
+}
+
+.theme-primary-button {
+  background: var(--color-primary);
+  color: #fff;
+  transition:
+    background-color 0.2s ease,
+    opacity 0.2s ease;
+}
+
+.theme-primary-button:hover {
+  background: var(--color-primary-hover);
+}
+
+.theme-secondary-button {
+  background: var(--color-surface-muted);
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-border);
+}
+
+.theme-overlay {
+  background: var(--color-overlay);
+}
+
+.theme-soft-success {
+  background: var(--color-success-soft);
+  color: var(--color-success);
+  border-color: color-mix(in srgb, var(--color-success) 35%, transparent);
+}
+
+.theme-soft-warning {
+  background: var(--color-warning-soft);
+  color: var(--color-warning);
+  border-color: color-mix(in srgb, var(--color-warning) 35%, transparent);
+}
+
+.theme-soft-danger {
+  background: var(--color-danger-soft);
+  color: var(--color-danger);
+  border-color: color-mix(in srgb, var(--color-danger) 35%, transparent);
 }
 
 /* Enhanced shadows */

--- a/dex_with_fiat_frontend/src/components/BankDetailsModal.tsx
+++ b/dex_with_fiat_frontend/src/components/BankDetailsModal.tsx
@@ -18,6 +18,7 @@ import {
 import { convertCryptoToFiat } from '@/lib/cryptoPriceService';
 import { useNotifications } from '@/hooks/useNotifications';
 import { useBeneficiaries, Beneficiary } from '@/hooks/useBeneficiaries';
+import { useTxHistory } from '@/hooks/useTxHistory';
 
 interface Bank {
   id: number;
@@ -67,6 +68,7 @@ export default function BankDetailsModal({
   } = useBeneficiaries();
 
   const { addNotification } = useNotifications();
+  const { addEntry } = useTxHistory();
 
   const [step, setStep] = useState<Step>(1);
 
@@ -78,27 +80,28 @@ export default function BankDetailsModal({
   const [showSavePrompt, setShowSavePrompt] = useState(false);
   const [saveCustomName, setSaveCustomName] = useState('');
 
-  // Step 1 — bank selection
+  // Step 1 - bank selection
   const [banks, setBanks] = useState<Bank[]>([]);
   const [banksLoading, setBanksLoading] = useState(false);
   const [banksError, setBanksError] = useState('');
   const [bankSearch, setBankSearch] = useState('');
   const [selectedBank, setSelectedBank] = useState<Bank | null>(null);
 
-  // Step 2 — account details
+  // Step 2 - account details
   const [accountNumber, setAccountNumber] = useState('');
   const [verifying, setVerifying] = useState(false);
   const [verifyError, setVerifyError] = useState('');
   const [verifiedAccount, setVerifiedAccount] =
     useState<VerifyAccountData | null>(null);
 
-  // Step 3 — confirm payout
+  // Step 3 - confirm payout
   const [ngnAmount, setNgnAmount] = useState<number | null>(null);
   const [ngnLoading, setNgnLoading] = useState(false);
   const [payoutLoading, setPayoutLoading] = useState(false);
   const [payoutError, setPayoutError] = useState('');
+  const [payoutNote, setPayoutNote] = useState('');
 
-  // Step 4 — success
+  // Step 4 - success
   const [transferReference, setTransferReference] = useState('');
 
   // Fetch banks when modal opens
@@ -202,7 +205,7 @@ export default function BankDetailsModal({
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           source: 'balance',
-          reason: `XLM to NGN — ${xlmAmount} XLM`,
+          reason: `XLM to NGN - ${xlmAmount} XLM`,
           amount: ngnValue,
           recipient: recipientJson.data.recipient_code,
         }),
@@ -221,6 +224,24 @@ export default function BankDetailsModal({
       setTransferReference(
         transferJson.data.reference || transferJson.data.transfer_code || '',
       );
+      addEntry({
+        kind: 'payout',
+        status: 'completed',
+        amount: String(xlmAmount),
+        asset: 'XLM',
+        fiatAmount:
+          ngnAmount !== null
+            ? ngnAmount.toLocaleString('en-NG', {
+                minimumFractionDigits: 2,
+                maximumFractionDigits: 2,
+              })
+            : undefined,
+        fiatCurrency: 'NGN',
+        note: payoutNote.trim() || undefined,
+        reference:
+          transferJson.data.reference || transferJson.data.transfer_code || '',
+        message: `Fiat payout initiated to ${selectedBank.name}.`,
+      });
       // Simulation block
       await new Promise(resolve => setTimeout(resolve, 2500));
       setStep(4);
@@ -250,6 +271,7 @@ export default function BankDetailsModal({
     setNgnLoading(false);
     setPayoutLoading(false);
     setPayoutError('');
+    setPayoutNote('');
     setTransferReference('');
     setShowSavedBeneficiaries(false);
     setSelectedSavedBeneficiary(null);
@@ -309,23 +331,23 @@ export default function BankDetailsModal({
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
-      <div className="relative w-full max-w-md mx-4 bg-gray-900 border border-gray-700 rounded-2xl shadow-2xl p-6">
+    <div className="theme-overlay fixed inset-0 z-50 flex items-center justify-center backdrop-blur-sm">
+      <div className="theme-surface theme-border relative w-full max-w-md mx-4 border rounded-2xl shadow-2xl p-6">
         {/* Header */}
         <div className="flex items-center justify-between mb-6">
           <div className="flex items-center gap-2">
             <Building2 className="w-5 h-5 text-blue-400" />
-            <h2 className="text-lg font-semibold text-white">Fiat Payout</h2>
+            <h2 className="theme-text-primary text-lg font-semibold">Fiat Payout</h2>
           </div>
           <button
             onClick={handleClose}
-            className="text-gray-400 hover:text-white transition-colors"
+            className="theme-text-muted hover:theme-text-primary transition-colors"
           >
             <X className="w-5 h-5" />
           </button>
         </div>
 
-        {/* Step indicators — hidden on the success screen */}
+        {/* Step indicators - hidden on the success screen */}
         {step < 4 && (
           <div className="flex items-center gap-1 mb-6">
             {([1, 2, 3] as const).map((s) => (
@@ -626,24 +648,24 @@ export default function BankDetailsModal({
         {/* ── Step 3: Confirm Payout ── */}
         {step === 3 && (
           <div>
-            <p className="text-sm text-gray-400 mb-4">
+            <p className="theme-text-secondary text-sm mb-4">
               Review your payout details
             </p>
 
-            <div className="bg-gray-800 rounded-xl p-4 space-y-3 mb-4">
+            <div className="theme-surface-muted theme-border rounded-xl border p-4 space-y-3 mb-4">
               <div className="flex justify-between text-sm">
-                <span className="text-gray-400">XLM deposited</span>
-                <span className="text-white font-medium">
+                <span className="theme-text-secondary">XLM deposited</span>
+                <span className="theme-text-primary font-medium">
                   {xlmAmount} XLM
                 </span>
               </div>
 
               <div className="flex justify-between text-sm items-center">
-                <span className="text-gray-400">Estimated NGN</span>
+                <span className="theme-text-secondary">Estimated NGN</span>
                 {ngnLoading ? (
                   <Loader2 className="w-4 h-4 text-blue-400 animate-spin" />
                 ) : ngnAmount !== null ? (
-                  <span className="text-white font-medium">
+                  <span className="theme-text-primary font-medium">
                     ₦
                     {ngnAmount.toLocaleString('en-NG', {
                       minimumFractionDigits: 2,
@@ -651,34 +673,48 @@ export default function BankDetailsModal({
                     })}
                   </span>
                 ) : (
-                  <span className="text-gray-500">—</span>
+                  <span className="theme-text-muted">-</span>
                 )}
               </div>
 
-              <div className="border-t border-gray-700 pt-3 space-y-3">
+              <div className="theme-border border-t pt-3 space-y-3">
                 <div className="flex justify-between text-sm">
-                  <span className="text-gray-400">Bank</span>
-                  <span className="text-white font-medium">
+                  <span className="theme-text-secondary">Bank</span>
+                  <span className="theme-text-primary font-medium">
                     {selectedBank?.name}
                   </span>
                 </div>
                 <div className="flex justify-between text-sm">
-                  <span className="text-gray-400">Account name</span>
-                  <span className="text-white font-medium">
+                  <span className="theme-text-secondary">Account name</span>
+                  <span className="theme-text-primary font-medium">
                     {verifiedAccount?.account_name}
                   </span>
                 </div>
                 <div className="flex justify-between text-sm">
-                  <span className="text-gray-400">Account number</span>
-                  <span className="text-white font-medium font-mono">
+                  <span className="theme-text-secondary">Account number</span>
+                  <span className="theme-text-primary font-medium font-mono">
                     {accountNumber}
                   </span>
                 </div>
               </div>
             </div>
 
+            <div className="mb-4">
+              <label className="theme-text-secondary block text-sm mb-1">
+                Optional payout note
+              </label>
+              <textarea
+                value={payoutNote}
+                onChange={(e) => setPayoutNote(e.target.value)}
+                placeholder="Add a note for this payout"
+                rows={2}
+                maxLength={160}
+                className="theme-input w-full border rounded-lg px-4 py-3 text-sm focus:outline-none focus:border-blue-500 resize-none"
+              />
+            </div>
+
             {payoutError && (
-              <div className="flex items-center gap-2 text-red-400 text-sm mb-4 bg-red-400/10 rounded-lg px-3 py-2">
+              <div className="theme-soft-danger flex items-center gap-2 text-sm mb-4 rounded-lg px-3 py-2 border">
                 <AlertCircle className="w-4 h-4 flex-shrink-0" />
                 <span>{payoutError}</span>
               </div>
@@ -689,7 +725,7 @@ export default function BankDetailsModal({
                 type="button"
                 onClick={() => setStep(2)}
                 disabled={payoutLoading}
-                className="flex-1 bg-gray-700 hover:bg-gray-600 disabled:opacity-50 text-white py-3 rounded-lg font-medium transition-colors"
+                className="theme-secondary-button flex-1 disabled:opacity-50 py-3 rounded-lg font-medium transition-colors"
               >
                 Back
               </button>
@@ -697,7 +733,7 @@ export default function BankDetailsModal({
                 type="button"
                 onClick={handleConfirmPayout}
                 disabled={payoutLoading}
-                className="flex-1 flex items-center justify-center gap-2 bg-blue-600 hover:bg-blue-700 disabled:bg-blue-800 disabled:opacity-70 text-white py-3 rounded-lg font-medium transition-colors"
+                className="theme-primary-button flex-1 flex items-center justify-center gap-2 disabled:bg-blue-800 disabled:opacity-70 text-white py-3 rounded-lg font-medium transition-colors"
               >
                 {payoutLoading ? (
                   <>
@@ -716,20 +752,25 @@ export default function BankDetailsModal({
         {step === 4 && (
           <div className="text-center py-4">
             <CheckCircle className="w-14 h-14 text-green-400 mx-auto mb-4" />
-            <p className="text-white font-semibold text-lg mb-2">
+            <p className="theme-text-primary font-semibold text-lg mb-2">
               Payout Initiated!
             </p>
-            <p className="text-gray-400 text-sm mb-6">
+            <p className="theme-text-secondary text-sm mb-6">
               Your bank transfer is processing. This usually takes a few
               minutes.
             </p>
+            {payoutNote && (
+              <p className="theme-text-secondary text-xs mb-6">
+                Note: <span className="theme-text-primary">{payoutNote}</span>
+              </p>
+            )}
 
             {transferReference && (
-              <div className="bg-gray-800 rounded-lg px-4 py-3 mb-6 text-left">
-                <p className="text-xs text-gray-500 mb-1">
+              <div className="theme-surface-muted rounded-lg px-4 py-3 mb-6 text-left">
+                <p className="theme-text-muted text-xs mb-1">
                   Transfer Reference
                 </p>
-                <p className="text-white font-mono text-sm break-all">
+                <p className="theme-text-primary font-mono text-sm break-all">
                   {transferReference}
                 </p>
               </div>
@@ -738,7 +779,7 @@ export default function BankDetailsModal({
             <button
               type="button"
               onClick={handleClose}
-              className="w-full bg-blue-600 hover:bg-blue-700 text-white py-3 rounded-lg font-medium transition-colors"
+              className="theme-primary-button w-full py-3 rounded-lg font-medium transition-colors"
             >
               Close
             </button>

--- a/dex_with_fiat_frontend/src/components/ChatHistorySidebar.tsx
+++ b/dex_with_fiat_frontend/src/components/ChatHistorySidebar.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { useChatHistory } from '@/hooks/useChatHistory';
-import { useTheme } from '@/contexts/ThemeContext';
+import { useTxHistory } from '@/hooks/useTxHistory';
 import {
   MessageSquare,
   Trash2,
@@ -11,6 +11,7 @@ import {
   Clock,
   Plus,
   Download,
+  Coins,
 } from 'lucide-react';
 import SkeletonSidebar from '@/components/ui/skeleton/SkeletonSidebar';
 
@@ -32,8 +33,8 @@ export default function ChatHistorySidebar({
     searchSessions,
     hasHistory,
   } = useChatHistory();
+  const { entries, exportEntries, clearEntries } = useTxHistory();
 
-  const { isDarkMode } = useTheme();
   const [searchQuery, setSearchQuery] = useState('');
   const [showDeleteConfirm, setShowDeleteConfirm] = useState<string | null>(
     null,
@@ -54,17 +55,31 @@ export default function ChatHistorySidebar({
 
   const handleExportSession = (sessionId: string) => {
     const exportData = exportSession(sessionId);
-    if (exportData) {
-      const blob = new Blob([exportData], { type: 'application/json' });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = `chat-session-${sessionId}.json`;
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      URL.revokeObjectURL(url);
+    if (!exportData) {
+      return;
     }
+
+    const blob = new Blob([exportData], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `chat-session-${sessionId}.json`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  };
+
+  const handleExportTransactions = () => {
+    const blob = new Blob([exportEntries()], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'transaction-history.json';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
   };
 
   const formatDate = (date: Date) => {
@@ -87,33 +102,14 @@ export default function ChatHistorySidebar({
   };
 
   return (
-    <div
-      className={`h-full flex flex-col transition-colors duration-300 ${
-        isDarkMode ? 'bg-gray-800' : 'bg-white'
-      }`}
-    >
-      {/* Header */}
-      <div
-        className={`p-4 border-b transition-colors duration-300 ${
-          isDarkMode ? 'border-gray-700' : 'border-gray-200'
-        }`}
-      >
+    <div className="theme-surface h-full flex flex-col transition-colors duration-300">
+      <div className="theme-border p-4 border-b transition-colors duration-300">
         <div className="flex items-center justify-between mb-4">
-          <h2
-            className={`text-lg font-semibold transition-colors duration-300 ${
-              isDarkMode ? 'text-gray-100' : 'text-gray-900'
-            }`}
-          >
-            Chat History
-          </h2>
+          <h2 className="theme-text-primary text-lg font-semibold">Activity</h2>
           <div className="flex items-center gap-1">
             <button
               onClick={clearAllHistory}
-              className={`p-2 rounded-lg transition-all duration-200 hover:scale-110 ${
-                isDarkMode
-                  ? 'text-gray-400 hover:text-red-400 hover:bg-red-900/20'
-                  : 'text-gray-500 hover:text-red-600 hover:bg-red-50'
-              }`}
+              className="theme-text-muted hover:bg-[var(--color-danger-soft)] p-2 rounded-lg transition-all duration-200 hover:scale-110"
               title="Clear all history"
             >
               <Trash2 className="w-4 h-4" />
@@ -121,11 +117,7 @@ export default function ChatHistorySidebar({
             {onClose && (
               <button
                 onClick={onClose}
-                className={`p-2 rounded-lg transition-all duration-200 hover:scale-110 ${
-                  isDarkMode
-                    ? 'text-gray-400 hover:text-gray-200 hover:bg-gray-700'
-                    : 'text-gray-500 hover:text-gray-700 hover:bg-gray-100'
-                }`}
+                className="theme-text-muted hover:bg-[var(--color-surface-muted)] p-2 rounded-lg transition-all duration-200 hover:scale-110"
                 title="Close"
                 aria-label="Close chat history"
               >
@@ -135,32 +127,19 @@ export default function ChatHistorySidebar({
           </div>
         </div>
 
-        {/* Search */}
         <div className="relative">
-          <Search
-            className={`absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 ${
-              isDarkMode ? 'text-gray-400' : 'text-gray-400'
-            }`}
-          />
+          <Search className="theme-text-muted absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4" />
           <input
             type="text"
             placeholder="Search conversations..."
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            className={`w-full pl-10 pr-4 py-2 rounded-lg text-sm transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-blue-500 ${
-              isDarkMode
-                ? 'bg-gray-700 border border-gray-600 text-gray-100 placeholder-gray-400 focus:border-blue-500'
-                : 'bg-gray-50 border border-gray-200 text-gray-900 placeholder-gray-500 focus:border-blue-500'
-            }`}
+            className="theme-input w-full pl-10 pr-4 py-2 rounded-lg text-sm border transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-blue-500"
           />
           {searchQuery && (
             <button
               onClick={() => setSearchQuery('')}
-              className={`absolute right-3 top-1/2 transform -translate-y-1/2 transition-colors ${
-                isDarkMode
-                  ? 'text-gray-400 hover:text-gray-200'
-                  : 'text-gray-400 hover:text-gray-600'
-              }`}
+              className="theme-text-muted hover:theme-text-primary absolute right-3 top-1/2 transform -translate-y-1/2 transition-colors"
             >
               <X className="w-4 h-4" />
             </button>
@@ -168,14 +147,11 @@ export default function ChatHistorySidebar({
         </div>
       </div>
 
-      {/* Sessions List */}
       <div className="flex-1 overflow-y-auto">
         {isLoading ? (
           <SkeletonSidebar />
         ) : !hasHistory ? (
-          <div
-            className={`p-4 text-center ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
-          >
+          <div className="theme-text-muted p-4 text-center">
             <MessageSquare className="w-8 h-8 mx-auto mb-2 opacity-50" />
             <p className="text-sm">No conversations yet</p>
             <p className="text-xs mt-1 opacity-70">
@@ -183,9 +159,7 @@ export default function ChatHistorySidebar({
             </p>
           </div>
         ) : filteredSessions.length === 0 ? (
-          <div
-            className={`p-4 text-center ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}
-          >
+          <div className="theme-text-muted p-4 text-center">
             <Search className="w-6 h-6 mx-auto mb-2 opacity-50" />
             <p className="text-sm">No conversations found</p>
           </div>
@@ -194,31 +168,19 @@ export default function ChatHistorySidebar({
             {filteredSessions.map((session) => (
               <div
                 key={session.id}
-                className={`group relative p-3 mb-2 rounded-lg cursor-pointer transition-all duration-200 ${
+                className={`group relative p-3 mb-2 rounded-lg cursor-pointer transition-all duration-200 border ${
                   currentSessionId === session.id
-                    ? isDarkMode
-                      ? 'bg-blue-900/30 border border-blue-500/50 shadow-lg'
-                      : 'bg-blue-50 border border-blue-200 shadow-md'
-                    : isDarkMode
-                      ? 'hover:bg-gray-700/50 border border-transparent hover:border-gray-600/30'
-                      : 'hover:bg-gray-50 border border-transparent hover:border-gray-200'
+                    ? 'bg-[var(--color-primary-soft)] border-[var(--color-primary)] shadow-md'
+                    : 'border-transparent hover:border-[var(--color-border)] hover:bg-[var(--color-surface-muted)]'
                 }`}
                 onClick={() => onLoadSession(session.id)}
               >
                 <div className="flex items-start justify-between">
                   <div className="flex-1 min-w-0">
-                    <h3
-                      className={`text-sm font-medium truncate transition-colors duration-200 ${
-                        isDarkMode ? 'text-gray-100' : 'text-gray-900'
-                      }`}
-                    >
+                    <h3 className="theme-text-primary text-sm font-medium truncate">
                       {session.title || 'New Conversation'}
                     </h3>
-                    <div
-                      className={`flex items-center mt-1 text-xs transition-colors duration-200 ${
-                        isDarkMode ? 'text-gray-400' : 'text-gray-500'
-                      }`}
-                    >
+                    <div className="theme-text-muted flex items-center mt-1 text-xs">
                       <Clock className="w-3 h-3 mr-1" />
                       <span>
                         {formatDate(
@@ -232,11 +194,7 @@ export default function ChatHistorySidebar({
                       </span>
                     </div>
                     {session.messages && session.messages.length > 0 && (
-                      <p
-                        className={`text-xs mt-1 truncate transition-colors duration-200 ${
-                          isDarkMode ? 'text-gray-500' : 'text-gray-600'
-                        }`}
-                      >
+                      <p className="theme-text-secondary text-xs mt-1 truncate">
                         {session.messages[
                           session.messages.length - 1
                         ]?.content?.substring(0, 50)}
@@ -251,11 +209,7 @@ export default function ChatHistorySidebar({
                         e.stopPropagation();
                         handleExportSession(session.id);
                       }}
-                      className={`p-1 rounded transition-all hover:scale-110 ${
-                        isDarkMode
-                          ? 'text-gray-400 hover:text-blue-400 hover:bg-blue-900/20'
-                          : 'text-gray-400 hover:text-blue-600 hover:bg-blue-50'
-                      }`}
+                      className="theme-text-muted hover:bg-[var(--color-primary-soft)] p-1 rounded transition-all hover:scale-110"
                       title="Export conversation"
                     >
                       <Download className="w-3 h-3" />
@@ -265,11 +219,7 @@ export default function ChatHistorySidebar({
                         e.stopPropagation();
                         setShowDeleteConfirm(session.id);
                       }}
-                      className={`p-1 rounded transition-all hover:scale-110 ${
-                        isDarkMode
-                          ? 'text-gray-400 hover:text-red-400 hover:bg-red-900/20'
-                          : 'text-gray-400 hover:text-red-600 hover:bg-red-50'
-                      }`}
+                      className="theme-text-muted hover:bg-[var(--color-danger-soft)] p-1 rounded transition-all hover:scale-110"
                       title="Delete conversation"
                     >
                       <Trash2 className="w-3 h-3" />
@@ -282,56 +232,102 @@ export default function ChatHistorySidebar({
         )}
       </div>
 
-      {/* New Chat Button */}
-      <div
-        className={`p-4 border-t transition-colors duration-300 ${
-          isDarkMode ? 'border-gray-700' : 'border-gray-200'
-        }`}
-      >
+      <div className="theme-border border-t p-4">
+        <div className="flex items-center justify-between mb-3">
+          <div className="flex items-center gap-2">
+            <Coins className="w-4 h-4 text-[var(--color-primary)]" />
+            <h3 className="theme-text-primary text-sm font-semibold">
+              Transaction History
+            </h3>
+          </div>
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              onClick={handleExportTransactions}
+              className="theme-text-muted hover:bg-[var(--color-surface-muted)] p-1.5 rounded-md transition-colors"
+              title="Export transaction history"
+            >
+              <Download className="w-3.5 h-3.5" />
+            </button>
+            <button
+              type="button"
+              onClick={clearEntries}
+              className="theme-text-muted hover:bg-[var(--color-danger-soft)] p-1.5 rounded-md transition-colors"
+              title="Clear transaction history"
+            >
+              <Trash2 className="w-3.5 h-3.5" />
+            </button>
+          </div>
+        </div>
+
+        {entries.length === 0 ? (
+          <p className="theme-text-muted text-xs">
+            Deposits, payouts, risk checks, and notes will appear here.
+          </p>
+        ) : (
+          <div className="space-y-2 max-h-56 overflow-y-auto pr-1">
+            {entries.slice(0, 8).map((entry) => (
+              <div
+                key={entry.id}
+                className="theme-surface-muted theme-border rounded-lg border p-3"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <p className="theme-text-primary text-xs font-semibold capitalize">
+                      {entry.kind.replace('_', ' ')}
+                    </p>
+                    <p className="theme-text-secondary text-xs mt-1">
+                      {entry.message}
+                    </p>
+                  </div>
+                  <span className="theme-text-muted text-[11px] whitespace-nowrap">
+                    {formatDate(entry.createdAt)}
+                  </span>
+                </div>
+                {(entry.amount || entry.fiatAmount) && (
+                  <p className="theme-text-muted text-[11px] mt-2">
+                    {entry.amount ? `${entry.amount} ${entry.asset || 'XLM'}` : ''}
+                    {entry.amount && entry.fiatAmount ? ' · ' : ''}
+                    {entry.fiatAmount
+                      ? `${entry.fiatAmount} ${entry.fiatCurrency || 'NGN'}`
+                      : ''}
+                  </p>
+                )}
+                {entry.note && (
+                  <p className="theme-text-primary text-xs mt-2">
+                    Note: <span className="theme-text-secondary">{entry.note}</span>
+                  </p>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="theme-border p-4 border-t transition-colors duration-300">
         <button
           onClick={() => window.location.reload()}
-          className={`w-full flex items-center justify-center px-4 py-3 rounded-lg transition-all duration-200 font-medium hover:scale-[1.02] ${
-            isDarkMode
-              ? 'bg-blue-600 hover:bg-blue-700 text-white shadow-lg hover:shadow-blue-500/25'
-              : 'bg-blue-600 hover:bg-blue-700 text-white shadow-md hover:shadow-lg'
-          }`}
+          className="theme-primary-button w-full flex items-center justify-center px-4 py-3 rounded-lg transition-all duration-200 font-medium hover:scale-[1.02]"
         >
           <Plus className="w-4 h-4 mr-2" />
           New Conversation
         </button>
       </div>
 
-      {/* Delete Confirmation Modal */}
       {showDeleteConfirm && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 backdrop-blur-sm">
-          <div
-            className={`rounded-lg p-6 max-w-sm mx-4 shadow-2xl transition-colors duration-300 ${
-              isDarkMode ? 'bg-gray-800 border border-gray-700' : 'bg-white'
-            }`}
-          >
-            <h3
-              className={`text-lg font-semibold mb-2 transition-colors duration-300 ${
-                isDarkMode ? 'text-gray-100' : 'text-gray-900'
-              }`}
-            >
+        <div className="theme-overlay fixed inset-0 flex items-center justify-center z-50 backdrop-blur-sm">
+          <div className="theme-surface theme-border rounded-lg p-6 max-w-sm mx-4 shadow-2xl border">
+            <h3 className="theme-text-primary text-lg font-semibold mb-2">
               Delete Conversation
             </h3>
-            <p
-              className={`mb-4 transition-colors duration-300 ${
-                isDarkMode ? 'text-gray-300' : 'text-gray-600'
-              }`}
-            >
+            <p className="theme-text-secondary mb-4">
               Are you sure you want to delete this conversation? This action
               cannot be undone.
             </p>
             <div className="flex space-x-3">
               <button
                 onClick={() => setShowDeleteConfirm(null)}
-                className={`flex-1 px-4 py-2 rounded-lg transition-all duration-200 font-medium ${
-                  isDarkMode
-                    ? 'text-gray-300 bg-gray-700 hover:bg-gray-600 border border-gray-600'
-                    : 'text-gray-700 bg-gray-100 hover:bg-gray-200'
-                }`}
+                className="theme-secondary-button flex-1 px-4 py-2 rounded-lg transition-all duration-200 font-medium"
               >
                 Cancel
               </button>

--- a/dex_with_fiat_frontend/src/components/ChatInput.tsx
+++ b/dex_with_fiat_frontend/src/components/ChatInput.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from 'react';
 import { Send, Loader2 } from 'lucide-react';
-import { useTheme } from '@/contexts/ThemeContext';
 
 interface ChatInputProps {
   onSendMessage: (message: string) => void;
@@ -16,7 +15,6 @@ export default function ChatInput({
   placeholder = 'Type your message...',
 }: ChatInputProps) {
   const [message, setMessage] = useState('');
-  const { isDarkMode } = useTheme();
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -36,9 +34,7 @@ export default function ChatInput({
   return (
     <form
       onSubmit={handleSubmit}
-      className={`p-6 transition-colors duration-300 ${
-        isDarkMode ? 'bg-gray-900' : 'bg-white'
-      }`}
+      className="theme-surface p-6 transition-colors duration-300"
     >
       <div className="flex items-end space-x-3">
         <div className="flex-1 relative">
@@ -48,11 +44,7 @@ export default function ChatInput({
             onKeyPress={handleKeyPress}
             placeholder={placeholder}
             disabled={isLoading}
-            className={`w-full resize-none border rounded-lg px-4 py-3 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed ${
-              isDarkMode
-                ? 'border-gray-600 bg-gray-800 text-gray-100 placeholder-gray-400 focus:border-blue-500'
-                : 'border-gray-300 bg-white text-gray-900 placeholder-gray-500 focus:border-blue-500'
-            }`}
+            className="theme-input w-full resize-none border rounded-lg px-4 py-3 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
             rows={1}
             style={{
               minHeight: '48px',
@@ -70,7 +62,7 @@ export default function ChatInput({
         <button
           type="submit"
           disabled={!message.trim() || isLoading}
-          className="flex items-center justify-center w-12 h-12 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-300 text-white rounded-lg transition-all duration-200 disabled:cursor-not-allowed transform hover:scale-105 disabled:hover:scale-100 shadow-lg"
+          className="theme-primary-button flex items-center justify-center w-12 h-12 disabled:bg-gray-300 text-white rounded-lg transition-all duration-200 disabled:cursor-not-allowed transform hover:scale-105 disabled:hover:scale-100 shadow-lg"
         >
           {isLoading ? (
             <Loader2 className="w-5 h-5 animate-spin" />
@@ -91,11 +83,7 @@ export default function ChatInput({
             key={index}
             type="button"
             onClick={() => setMessage(suggestion)}
-            className={`px-3 py-2 text-sm rounded-lg border transition-all duration-200 transform hover:scale-105 ${
-              isDarkMode
-                ? 'bg-gray-800 hover:bg-gray-700 text-gray-300 border-gray-600'
-                : 'bg-gray-100 hover:bg-gray-200 text-gray-700 border-gray-200'
-            }`}
+            className="theme-secondary-button px-3 py-2 text-sm rounded-lg transition-all duration-200 transform hover:scale-105"
           >
             {suggestion}
           </button>

--- a/dex_with_fiat_frontend/src/components/Message.tsx
+++ b/dex_with_fiat_frontend/src/components/Message.tsx
@@ -175,17 +175,17 @@ export default function Message({ message, onActionClick }: MessageProps) {
             {/* Transaction Data Preview */}
             {message.metadata?.transactionData && (
               <div
-                className={`mt-4 p-4 bg-gray-50 border border-gray-200 rounded-xl text-sm ${isUser ? 'text-right' : 'text-left'}`}
+                className={`theme-surface-muted theme-border mt-4 p-4 border rounded-xl text-sm ${isUser ? 'text-right' : 'text-left'}`}
               >
-                <div className="flex items-center space-x-2 text-gray-700 font-medium mb-3">
+                <div className="theme-text-primary flex items-center space-x-2 font-medium mb-3">
                   <Coins className="w-4 h-4" />
                   <span>Transaction Details</span>
                 </div>
-                <div className="space-y-2 text-gray-600">
+                <div className="theme-text-secondary space-y-2">
                   {message.metadata.transactionData.type && (
                     <div className="flex justify-between">
                       <span>Type:</span>
-                      <span className="text-gray-900 font-medium capitalize">
+                      <span className="theme-text-primary font-medium capitalize">
                         {message.metadata.transactionData.type}
                       </span>
                     </div>
@@ -193,7 +193,7 @@ export default function Message({ message, onActionClick }: MessageProps) {
                   {message.metadata.transactionData.tokenIn && (
                     <div className="flex justify-between">
                       <span>Token:</span>
-                      <span className="text-gray-900 font-medium">
+                      <span className="theme-text-primary font-medium">
                         {message.metadata.transactionData.tokenIn}
                       </span>
                     </div>
@@ -201,7 +201,7 @@ export default function Message({ message, onActionClick }: MessageProps) {
                   {message.metadata.transactionData.amountIn && (
                     <div className="flex justify-between">
                       <span>Amount:</span>
-                      <span className="text-gray-900 font-medium">
+                      <span className="theme-text-primary font-medium">
                         {message.metadata.transactionData.amountIn}
                       </span>
                     </div>
@@ -209,16 +209,24 @@ export default function Message({ message, onActionClick }: MessageProps) {
                   {message.metadata.transactionData.fiatAmount && (
                     <div className="flex justify-between">
                       <span>Fiat:</span>
-                      <span className="text-gray-900 font-medium">
+                      <span className="theme-text-primary font-medium">
                         {message.metadata.transactionData.fiatAmount}{' '}
                         {message.metadata.transactionData.fiatCurrency || 'USD'}
+                      </span>
+                    </div>
+                  )}
+                  {message.metadata.transactionData.note && (
+                    <div className="flex justify-between gap-3">
+                      <span>Note:</span>
+                      <span className="theme-text-primary font-medium">
+                        {message.metadata.transactionData.note}
                       </span>
                     </div>
                   )}
                 </div>
 
                 {message.metadata.confirmationRequired && (
-                  <div className="mt-3 p-3 bg-amber-50 border border-amber-200 rounded-lg text-amber-800 text-xs">
+                  <div className="theme-soft-warning mt-3 p-3 border rounded-lg text-xs">
                     <div className="flex items-center space-x-2">
                       <AlertTriangle className="w-4 h-4" />
                       <span>This transaction requires your confirmation</span>
@@ -226,8 +234,18 @@ export default function Message({ message, onActionClick }: MessageProps) {
                   </div>
                 )}
 
+                {message.metadata.lowConfidence &&
+                  message.metadata.clarificationQuestion && (
+                    <div className="theme-soft-warning mt-3 p-3 border rounded-lg text-xs">
+                      <div className="flex items-center space-x-2">
+                        <AlertTriangle className="w-4 h-4" />
+                        <span>{message.metadata.clarificationQuestion}</span>
+                      </div>
+                    </div>
+                  )}
+
                 {!connection.isConnected && (
-                  <div className="mt-3 p-3 bg-red-50 border border-red-200 rounded-lg text-red-800 text-xs">
+                  <div className="theme-soft-danger mt-3 p-3 border rounded-lg text-xs">
                     <div className="flex items-center space-x-2">
                       <Link className="w-4 h-4" />
                       <span>Connect your wallet to proceed</span>

--- a/dex_with_fiat_frontend/src/components/NotificationsCenter.tsx
+++ b/dex_with_fiat_frontend/src/components/NotificationsCenter.tsx
@@ -38,6 +38,7 @@ export default function NotificationsCenter() {
       case 'payout_pending': return 'text-yellow-500';
       case 'payout_success': return 'text-green-500';
       case 'payout_fail': return 'text-red-500';
+      case 'risk_warning': return 'text-amber-500';
       default: return 'text-gray-500';
     }
   };

--- a/dex_with_fiat_frontend/src/components/StellarChatInterface.tsx
+++ b/dex_with_fiat_frontend/src/components/StellarChatInterface.tsx
@@ -235,10 +235,10 @@ export default function StellarChatInterface() {
   }, []);
 
   // After a successful deposit, close the deposit modal and open bank details
-  const handleDepositSuccess = useCallback((xlmAmount: number) => {
+  const handleDepositSuccess = useCallback((result: { xlmAmount: number; note?: string }) => {
     setShowModal(false);
     setDefaultAmount('');
-    setBankDetailsXlmAmount(xlmAmount);
+    setBankDetailsXlmAmount(result.xlmAmount);
     setShowBankDetails(true);
   }, []);
 
@@ -284,10 +284,8 @@ export default function StellarChatInterface() {
   );
 
   return (
-    <div
-      className={`flex h-screen w-screen overflow-hidden transition-colors duration-300 ${isDarkMode ? 'bg-gray-900 text-white' : 'bg-gray-50 text-gray-900'}`}
-    >
-      {/* Desktop sidebar — only rendered on md+ viewports */}
+    <div className="theme-app flex h-screen w-screen overflow-hidden transition-colors duration-300">
+      {/* Desktop sidebar - only rendered on md+ viewports */}
       {!isMobile && showSidebar && (
         <div className="shrink-0 w-72">
           {isLoading ? (
@@ -305,9 +303,7 @@ export default function StellarChatInterface() {
       {/* Main */}
       <div className="flex flex-col flex-1 min-w-0">
         {/* Header */}
-        <header
-          className={`flex-shrink-0 flex items-center justify-between px-4 py-3 border-b transition-colors duration-300 ${isDarkMode ? 'bg-gray-900 border-gray-700' : 'bg-white border-gray-200'}`}
-        >
+        <header className="theme-surface theme-border flex-shrink-0 flex items-center justify-between px-4 py-3 border-b transition-colors duration-300">
           <div className="flex items-center gap-3">
             <button
               onClick={() => setShowSidebar(!showSidebar)}
@@ -503,7 +499,7 @@ export default function StellarChatInterface() {
         </div>
       </div>
 
-      {/* Mobile bottom-sheet — only rendered when isSheetMounted */}
+      {/* Mobile bottom-sheet - only rendered when isSheetMounted */}
       {isSheetMounted && (
         <>
           {/* Backdrop */}

--- a/dex_with_fiat_frontend/src/components/StellarFiatModal.tsx
+++ b/dex_with_fiat_frontend/src/components/StellarFiatModal.tsx
@@ -22,6 +22,7 @@ import useBridgeStats from '@/hooks/useBridgeStats';
 import { getTokenPrice, formatFiatAmount } from '@/lib/cryptoPriceService';
 import SkeletonPayout from '@/components/ui/skeleton/SkeletonPayout';
 import { useNotifications } from '@/hooks/useNotifications';
+import { useTxHistory } from '@/hooks/useTxHistory';
 
 interface StellarFiatModalProps {
   isOpen: boolean;
@@ -30,12 +31,14 @@ interface StellarFiatModalProps {
   fiatCurrency?: string;
   isAdminMode?: boolean;
   recipientAddress?: string;
-  onDepositSuccess?: (xlmAmount: number) => void;
+  onDepositSuccess?: (result: { xlmAmount: number; note?: string }) => void;
 }
 
 type TxStatus = 'idle' | 'loading' | 'success' | 'error';
 
 const PENDING_TX_KEY = 'stellar_pending_tx';
+const LARGE_AMOUNT_RISK_THRESHOLD = 500;
+const RISK_CONFIRMATION_PHRASE = 'CONFIRM LARGE AMOUNT';
 
 interface PendingTxRecord {
   hash: string;
@@ -46,9 +49,21 @@ interface PendingTxRecord {
 
 function parseAmountToStroops(value: string): bigint | null {
   const normalized = value.trim();
-  if (!normalized) return null;
-  if (!/^.\d*(?:\.\d{0,7})?$/.test(normalized)) return null;
+
+  if (!normalized) {
+    return null;
+  }
+
+  if (!/^\d*(?:\.\d{0,7})?$/.test(normalized)) {
+    return null;
+  }
+
   const [wholePart = '0', fractionalPart = ''] = normalized.split('.');
+
+  if (!wholePart && !fractionalPart) {
+    return null;
+  }
+
   const whole = wholePart || '0';
   const fraction = (fractionalPart || '').padEnd(7, '0');
   return BigInt(whole) * 10_000_000n + BigInt(fraction || '0');
@@ -65,22 +80,17 @@ export default function StellarFiatModal({
 }: StellarFiatModalProps) {
   const { connection, signTx } = useStellarWallet();
   const { addNotification } = useNotifications();
+  const { addEntry } = useTxHistory();
 
   const [amount, setAmount] = useState(defaultAmount);
   const [activePreset, setActivePreset] = useState<number | null>(null);
   const [recipient, setRecipient] = useState(recipientAddress);
   const [fiatEstimate, setFiatEstimate] = useState<string | null>(null);
-
+  const [note, setNote] = useState('');
+  const [riskConfirmation, setRiskConfirmation] = useState('');
+  const [lastLoggedRiskAmount, setLastLoggedRiskAmount] = useState('');
   const [feeEstimate, setFeeEstimate] = useState<FeeEstimate | null>(null);
   const [isLoadingFee, setIsLoadingFee] = useState(false);
-
-  const AMOUNT_PRESETS = [5, 10, 25, 50, 100];
-
-  const handlePreset = (value: number) => {
-    setAmount(String(value));
-    setActivePreset(value);
-  };
-
   const [status, setStatus] = useState<TxStatus>('idle');
   const [txHash, setTxHash] = useState('');
   const [errorMsg, setErrorMsg] = useState('');
@@ -91,19 +101,28 @@ export default function StellarFiatModal({
     loading: isLoadingBridgeLimit,
     error: bridgeLimitError,
     refetchStats,
-    refresh,
   } = useBridgeStats();
+
+  const AMOUNT_PRESETS = [5, 10, 25, 50, 100];
+
+  const handlePreset = (value: number) => {
+    setAmount(String(value));
+    setActivePreset(value);
+  };
 
   useEffect(() => {
     if (isOpen) {
       setIsLoadingUI(true);
-      const t = setTimeout(() => setIsLoadingUI(false), 500);
-      return () => clearTimeout(t);
+      const timer = setTimeout(() => setIsLoadingUI(false), 500);
+      return () => clearTimeout(timer);
     }
   }, [isOpen]);
 
   useEffect(() => {
-    if (!isOpen) return;
+    if (!isOpen) {
+      return;
+    }
+
     setAmount(defaultAmount);
     setRecipient(recipientAddress);
     setActivePreset(null);
@@ -111,23 +130,36 @@ export default function StellarFiatModal({
     setTxHash('');
     setErrorMsg('');
     setFeeEstimate(null);
+    setNote('');
+    setRiskConfirmation('');
+    setLastLoggedRiskAmount('');
 
-    if (isAdminMode) return;
+    if (isAdminMode) {
+      return;
+    }
+
     let cancelled = false;
     void (async () => {
-      if (cancelled) return;
-      await refetchStats();
+      if (!cancelled) {
+        await refetchStats();
+      }
     })();
+
     return () => {
       cancelled = true;
     };
   }, [defaultAmount, isAdminMode, isOpen, recipientAddress, refetchStats]);
 
-  // Pending tx recovery
   useEffect(() => {
-    if (!isOpen) return;
+    if (!isOpen) {
+      return;
+    }
+
     const stored = localStorage.getItem(PENDING_TX_KEY);
-    if (!stored) return;
+    if (!stored) {
+      return;
+    }
+
     let pending: PendingTxRecord;
     try {
       pending = JSON.parse(stored) as PendingTxRecord;
@@ -135,6 +167,7 @@ export default function StellarFiatModal({
       localStorage.removeItem(PENDING_TX_KEY);
       return;
     }
+
     setAmount(pending.amount);
     setRecipient(pending.recipient);
     setStatus('loading');
@@ -142,18 +175,19 @@ export default function StellarFiatModal({
     setTxHash('');
 
     let cancelled = false;
-    // pollTransaction is exported from stellarContract
-   
-   
     pollTransaction(pending.hash)
-      .then((h: string) => {
-        if (cancelled) return;
-        setTxHash(h);
+      .then((hash) => {
+        if (cancelled) {
+          return;
+        }
+        setTxHash(hash);
         setStatus('success');
         localStorage.removeItem(PENDING_TX_KEY);
       })
       .catch(() => {
-        if (cancelled) return;
+        if (cancelled) {
+          return;
+        }
         setErrorMsg('Recovered transaction failed on-chain');
         setStatus('error');
         localStorage.removeItem(PENDING_TX_KEY);
@@ -164,12 +198,12 @@ export default function StellarFiatModal({
     };
   }, [isOpen]);
 
-  // Fee simulation debounce
   useEffect(() => {
     if (!isOpen || !connection.isConnected) {
       setFeeEstimate(null);
       return;
     }
+
     const currentStroops = parseAmountToStroops(amount);
     if (!currentStroops || currentStroops <= BigInt(0)) {
       setFeeEstimate(null);
@@ -184,18 +218,27 @@ export default function StellarFiatModal({
         let estimate: FeeEstimate | null = null;
         if (isAdminMode) {
           const to = recipient || connection.publicKey;
-          // dynamic import to avoid circulars
           const { simulateWithdraw } = await import('@/lib/stellarContract');
-          estimate = await simulateWithdraw(connection.publicKey, to, currentStroops);
+          estimate = await simulateWithdraw(
+            connection.publicKey,
+            to,
+            currentStroops,
+          );
         } else {
           const { simulateDeposit } = await import('@/lib/stellarContract');
           estimate = await simulateDeposit(connection.publicKey, currentStroops);
         }
-        if (!cancelled) setFeeEstimate(estimate);
+        if (!cancelled) {
+          setFeeEstimate(estimate);
+        }
       } catch {
-        if (!cancelled) setFeeEstimate(null);
+        if (!cancelled) {
+          setFeeEstimate(null);
+        }
       } finally {
-        if (!cancelled) setIsLoadingFee(false);
+        if (!cancelled) {
+          setIsLoadingFee(false);
+        }
       }
     };
 
@@ -224,30 +267,89 @@ export default function StellarFiatModal({
     void updateFiatEstimate();
   }, [updateFiatEstimate]);
 
-  if (!isOpen) return null;
-
   const stroopsAmount = parseAmountToStroops(amount);
+  const numericAmount = Number.parseFloat(amount);
   const hasValidAmount = stroopsAmount !== null && stroopsAmount > BigInt(0);
+  const isRiskyAmount =
+    Number.isFinite(numericAmount) &&
+    numericAmount >= LARGE_AMOUNT_RISK_THRESHOLD;
   const isDepositFlow = !isAdminMode;
   const isLimitUnavailable =
-    isDepositFlow && !isLoadingBridgeLimit && (bridgeLimit === null || !!bridgeLimitError);
+    isDepositFlow &&
+    !isLoadingBridgeLimit &&
+    (bridgeLimit === null || !!bridgeLimitError);
   const isOverLimit =
-    isDepositFlow && bridgeLimit !== null && hasValidAmount && stroopsAmount! > bridgeLimit;
+    isDepositFlow &&
+    bridgeLimit !== null &&
+    hasValidAmount &&
+    stroopsAmount !== null &&
+    stroopsAmount > bridgeLimit;
   const usagePercent =
-    isDepositFlow && bridgeLimit !== null && bridgeLimit > BigInt(0) && stroopsAmount !== null
-      ? Number((stroopsAmount! * 10_000n) / bridgeLimit) / 100
+    isDepositFlow &&
+    bridgeLimit !== null &&
+    bridgeLimit > BigInt(0) &&
+    stroopsAmount !== null
+      ? Number((stroopsAmount * 10_000n) / bridgeLimit) / 100
       : 0;
   const isHighLimitUsage =
-    isDepositFlow && !isOverLimit && hasValidAmount && usagePercent >= BRIDGE_LIMIT_WARNING_PERCENT;
+    isDepositFlow &&
+    !isOverLimit &&
+    hasValidAmount &&
+    usagePercent >= BRIDGE_LIMIT_WARNING_PERCENT;
   const remainingLimit =
-    isDepositFlow && bridgeLimit !== null && stroopsAmount !== null && bridgeLimit > stroopsAmount!
-      ? bridgeLimit - stroopsAmount!
+    isDepositFlow &&
+    bridgeLimit !== null &&
+    stroopsAmount !== null &&
+    bridgeLimit > stroopsAmount
+      ? bridgeLimit - stroopsAmount
       : BigInt(0);
   const isSubmitDisabled =
-    status === 'loading' || !connection.isConnected || (isDepositFlow && (isLoadingBridgeLimit || isLimitUnavailable || isOverLimit));
+    status === 'loading' ||
+    !connection.isConnected ||
+    (isDepositFlow &&
+      (isLoadingBridgeLimit || isLimitUnavailable || isOverLimit)) ||
+    (isRiskyAmount &&
+      riskConfirmation.trim().toUpperCase() !== RISK_CONFIRMATION_PHRASE);
+
+  useEffect(() => {
+    if (
+      !isOpen ||
+      !isRiskyAmount ||
+      !hasValidAmount ||
+      amount === lastLoggedRiskAmount
+    ) {
+      return;
+    }
+
+    addEntry({
+      kind: 'risk_warning',
+      status: 'warning',
+      amount,
+      asset: 'XLM',
+      note: note.trim() || undefined,
+      message: `Large deposit warning shown for ${amount} XLM`,
+    });
+    addNotification(
+      'risk_warning',
+      `Large amount warning: ${amount} XLM requires typed confirmation.`,
+    );
+    setLastLoggedRiskAmount(amount);
+  }, [
+    addEntry,
+    addNotification,
+    amount,
+    hasValidAmount,
+    isOpen,
+    isRiskyAmount,
+    lastLoggedRiskAmount,
+    note,
+  ]);
+
+  if (!isOpen) return null;
 
   const handleAction = async () => {
     if (!connection.isConnected) return;
+
     if (!amount || stroopsAmount === null || stroopsAmount <= BigInt(0)) {
       setErrorMsg('Please enter a valid amount.');
       setStatus('error');
@@ -259,12 +361,27 @@ export default function StellarFiatModal({
       return;
     }
     if (isDepositFlow && (bridgeLimit === null || bridgeLimitError)) {
-      setErrorMsg(bridgeLimitError || 'Unable to validate against the current bridge limit. Please try again.');
+      setErrorMsg(
+        bridgeLimitError ||
+          'Unable to validate against the current bridge limit. Please try again.',
+      );
       setStatus('error');
       return;
     }
-    if (isDepositFlow && bridgeLimit !== null && stroopsAmount! > bridgeLimit) {
-      setErrorMsg(`Requested amount exceeds the current bridge limit of ${stroopsToDisplay(bridgeLimit)} XLM.`);
+    if (
+      isRiskyAmount &&
+      riskConfirmation.trim().toUpperCase() !== RISK_CONFIRMATION_PHRASE
+    ) {
+      setErrorMsg(
+        `Type "${RISK_CONFIRMATION_PHRASE}" to confirm this large transfer.`,
+      );
+      setStatus('error');
+      return;
+    }
+    if (isDepositFlow && bridgeLimit !== null && stroopsAmount > bridgeLimit) {
+      setErrorMsg(
+        `Requested amount exceeds the current bridge limit of ${stroopsToDisplay(bridgeLimit)} XLM.`,
+      );
       setStatus('error');
       return;
     }
@@ -275,25 +392,61 @@ export default function StellarFiatModal({
     const onHashKnown = (hash: string) => {
       localStorage.setItem(
         PENDING_TX_KEY,
-        JSON.stringify({ hash, amount, isAdminMode, recipient } as PendingTxRecord),
+        JSON.stringify({ hash, amount, isAdminMode, recipient } satisfies PendingTxRecord),
       );
     };
 
     try {
-      addNotification('tx_submit', `Submitting ${isAdminMode ? 'withdrawal' : 'deposit'} transaction...`);
+      addNotification(
+        'tx_submit',
+        `Submitting ${isAdminMode ? 'withdrawal' : 'deposit'} transaction...`,
+      );
       let hash: string;
       if (isAdminMode) {
         const to = recipient || connection.publicKey;
-        hash = await withdrawFromContract(connection.publicKey, to, stroopsAmount!, signTx, onHashKnown);
+        hash = await withdrawFromContract(
+          connection.publicKey,
+          to,
+          stroopsAmount,
+          signTx,
+          onHashKnown,
+        );
       } else {
-        hash = await depositToContract(connection.publicKey, stroopsAmount!, signTx, onHashKnown);
+        hash = await depositToContract(
+          connection.publicKey,
+          stroopsAmount,
+          signTx,
+          onHashKnown,
+        );
       }
+
       setTxHash(hash);
       setStatus('success');
+      clearCache();
+      localStorage.removeItem(PENDING_TX_KEY);
+      addNotification(
+        'tx_confirm',
+        `Transaction confirmed successfully! (${hash.slice(0, 8)}...)`,
+      );
+      addEntry({
+        kind: isAdminMode ? 'payout' : 'deposit',
+        status: 'completed',
+        amount,
+        asset: 'XLM',
+        note: note.trim() || undefined,
+        txHash: hash,
+        message: `${isAdminMode ? 'Withdrawal' : 'Deposit'} confirmed on Stellar.`,
+      });
       try {
         await refetchStats();
       } catch {
-        // ignore
+        // ignore refresh failures after a confirmed transaction
+      }
+      if (!isAdminMode && onDepositSuccess) {
+        onDepositSuccess({
+          xlmAmount: parseFloat(amount || '0'),
+          note: note.trim() || undefined,
+        });
       }
     } catch (err) {
       setErrorMsg(err instanceof Error ? err.message : 'Transaction failed');
@@ -310,14 +463,24 @@ export default function StellarFiatModal({
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
-      <div role="dialog" aria-modal="true" className="relative w-full max-w-md mx-4 bg-gray-900 border border-gray-700 rounded-2xl shadow-2xl p-6">
+    <div className="theme-overlay fixed inset-0 z-50 flex items-center justify-center backdrop-blur-sm">
+      <div
+        role="dialog"
+        aria-modal="true"
+        className="theme-surface theme-border relative w-full max-w-md mx-4 border rounded-2xl shadow-2xl p-6"
+      >
         <div className="flex items-center justify-between mb-6">
           <div className="flex items-center gap-2">
             <ArrowDownUp className="w-5 h-5 text-blue-400" />
-            <h2 className="text-lg font-semibold text-white">{isAdminMode ? 'Withdraw from Bridge' : 'Deposit to Bridge'}</h2>
+            <h2 className="theme-text-primary text-lg font-semibold">
+              {isAdminMode ? 'Withdraw from Bridge' : 'Deposit to Bridge'}
+            </h2>
           </div>
-          <button onClick={handleClose} aria-label="Close" className="text-gray-400 hover:text-white transition-colors">
+          <button
+            onClick={handleClose}
+            aria-label="Close"
+            className="theme-text-muted hover:theme-text-primary transition-colors"
+          >
             <X className="w-5 h-5" />
           </button>
         </div>
@@ -325,40 +488,70 @@ export default function StellarFiatModal({
         {status === 'success' ? (
           <div data-testid="success-message" className="text-center py-6">
             <CheckCircle className="w-14 h-14 text-green-400 mx-auto mb-4" />
-            <p className="text-white font-semibold text-lg mb-2">Transaction Confirmed!</p>
-            <p className="text-gray-400 text-sm mb-4">
+            <p className="theme-text-primary font-semibold text-lg mb-2">
+              Transaction Confirmed!
+            </p>
+            <p className="theme-text-secondary text-sm mb-4">
               {isAdminMode ? 'Withdrawal' : 'Deposit'} of{' '}
-              <span className="text-white font-medium">{stroopsToDisplay(stroopsAmount ?? BigInt(0))} XLM</span>{' '}
+              <span className="theme-text-primary font-medium">
+                {stroopsToDisplay(stroopsAmount ?? BigInt(0))} XLM
+              </span>{' '}
               processed successfully.
             </p>
-            <a href={`https://stellar.expert/explorer/testnet/tx/${txHash}`} target="_blank" rel="noreferrer" className="text-blue-400 hover:underline text-xs break-all">
+            {note && (
+              <p className="theme-text-secondary text-xs mb-4">
+                Note: <span className="theme-text-primary">{note}</span>
+              </p>
+            )}
+            <a
+              href={`https://stellar.expert/explorer/testnet/tx/${txHash}`}
+              target="_blank"
+              rel="noreferrer"
+              className="text-blue-400 hover:underline text-xs break-all"
+            >
               {txHash}
             </a>
 
             {!isAdminMode && onDepositSuccess ? (
               <button
-                onClick={() => onDepositSuccess(parseFloat(amount || '0'))}
-                className="mt-6 w-full bg-blue-600 hover:bg-blue-700 text-white py-3 rounded-lg font-medium transition-colors"
+                onClick={() =>
+                  onDepositSuccess({
+                    xlmAmount: parseFloat(amount || '0'),
+                    note: note.trim() || undefined,
+                  })
+                }
+                className="theme-primary-button mt-6 w-full py-3 rounded-lg font-medium transition-colors"
               >
                 Continue to Fiat Payout
               </button>
             ) : (
-              <button onClick={handleClose} className="mt-6 w-full bg-blue-600 hover:bg-blue-700 text-white py-3 rounded-lg font-medium transition-colors">Close</button>
+              <button
+                onClick={handleClose}
+                className="theme-primary-button mt-6 w-full py-3 rounded-lg font-medium transition-colors"
+              >
+                Close
+              </button>
             )}
           </div>
         ) : isLoadingUI ? (
           <SkeletonPayout />
         ) : (
-          <React.Fragment>
+          <>
             <div className="mb-4">
-              <label className="block text-sm text-gray-400 mb-1">Amount (XLM)</label>
+              <label className="theme-text-secondary block text-sm mb-1">
+                Amount (XLM)
+              </label>
               <div className="flex gap-2 mb-2">
                 {AMOUNT_PRESETS.map((preset) => (
                   <button
                     key={preset}
                     type="button"
                     onClick={() => handlePreset(preset)}
-                    className={`flex-1 py-1.5 rounded-md text-xs font-medium border transition-colors ${activePreset === preset ? 'bg-blue-600 border-blue-500 text-white' : 'bg-gray-800 border-gray-600 text-gray-300 hover:border-blue-500 hover:text-white'}`}
+                    className={`flex-1 py-1.5 rounded-md text-xs font-medium border transition-colors ${
+                      activePreset === preset
+                        ? 'bg-blue-600 border-blue-500 text-white'
+                        : 'theme-surface-muted theme-border theme-text-secondary hover:border-blue-500 hover:text-[var(--color-text-primary)]'
+                    }`}
                   >
                     {preset}
                   </button>
@@ -369,85 +562,237 @@ export default function StellarFiatModal({
                 min="0"
                 step="0.0000001"
                 value={amount}
-                onChange={(e) => { setAmount(e.target.value); setActivePreset(null); }}
+                onChange={(e) => {
+                  setAmount(e.target.value);
+                  setActivePreset(null);
+                }}
                 placeholder="0.00"
                 aria-invalid={isOverLimit ? true : undefined}
-                className={`w-full bg-gray-800 border rounded-lg px-4 py-3 text-white placeholder-gray-500 focus:outline-none ${isOverLimit ? 'border-red-500 focus:border-red-400' : 'border-gray-600 focus:border-blue-500'}`}
+                className={`theme-input w-full border rounded-lg px-4 py-3 focus:outline-none ${
+                  isOverLimit
+                    ? 'border-red-500 focus:border-red-400'
+                    : 'focus:border-blue-500'
+                }`}
               />
             </div>
 
             {fiatEstimate && (
-              <p className="text-xs text-gray-400 -mt-2 mb-4">≈ <span className="text-white font-medium">{fiatEstimate}</span> at current market rate</p>
+              <p className="theme-text-secondary text-xs -mt-2 mb-4">
+                ~= <span className="theme-text-primary font-medium">{fiatEstimate}</span>{' '}
+                at current market rate
+              </p>
             )}
 
+            <div className="mb-4">
+              <label className="theme-text-secondary block text-sm mb-1">
+                Optional note
+              </label>
+              <textarea
+                value={note}
+                onChange={(e) => setNote(e.target.value)}
+                placeholder={
+                  isAdminMode
+                    ? 'Add a label for this withdrawal'
+                    : 'Add a note for this deposit'
+                }
+                rows={2}
+                maxLength={160}
+                className="theme-input w-full border rounded-lg px-4 py-3 text-sm focus:outline-none focus:border-blue-500 resize-none"
+              />
+            </div>
+
             {(isLoadingFee || feeEstimate) && (
-              <div className="mb-4 rounded-xl border border-gray-700 bg-gray-800/40 p-4">
+              <div className="theme-surface-muted theme-border mb-4 rounded-xl border p-4">
                 <div className="flex items-center justify-between mb-3">
-                  <h3 className="text-[10px] font-bold text-gray-500 uppercase tracking-widest">Simulation Results</h3>
-                  {isLoadingFee && <Loader2 className="w-3 h-3 text-blue-500 animate-spin" />}
+                  <h3 className="theme-text-muted text-[10px] font-bold uppercase tracking-widest">
+                    Simulation Results
+                  </h3>
+                  {isLoadingFee && (
+                    <Loader2 className="w-3 h-3 text-blue-500 animate-spin" />
+                  )}
                 </div>
+
                 <div className="space-y-2">
-                  <div className="flex justify-between text-[11px]"><span className="text-gray-500">Base Fee</span><span className="text-gray-300 font-mono">{isLoadingFee ? '...' : feeEstimate ? `${feeEstimate.baseFee.toFixed(7)} XLM` : '0.0000100 XLM'}</span></div>
-                  <div className="flex justify-between text-[11px]"><span className="text-gray-500">Resource Fee</span><span className="text-gray-300 font-mono">{isLoadingFee ? '...' : feeEstimate ? `${feeEstimate.resourceFee.toFixed(7)} XLM` : '0.0000000 XLM'}</span></div>
-                  <div className="pt-2 mt-1 border-t border-gray-700/50 flex justify-between text-xs font-semibold"><span className="text-gray-400">Total Network Fee</span><span className="text-blue-400 font-mono">{isLoadingFee ? 'Calculating...' : feeEstimate ? `${feeEstimate.fee.toFixed(7)} XLM` : 'N/A'}</span></div>
+                  <div className="flex justify-between text-[11px]">
+                    <span className="theme-text-muted">Base Fee</span>
+                    <span className="theme-text-secondary font-mono">
+                      {isLoadingFee
+                        ? '...'
+                        : feeEstimate
+                          ? `${feeEstimate.baseFee.toFixed(7)} XLM`
+                          : '0.0000100 XLM'}
+                    </span>
+                  </div>
+                  <div className="flex justify-between text-[11px]">
+                    <span className="theme-text-muted">Resource Fee</span>
+                    <span className="theme-text-secondary font-mono">
+                      {isLoadingFee
+                        ? '...'
+                        : feeEstimate
+                          ? `${feeEstimate.resourceFee.toFixed(7)} XLM`
+                          : '0.0000000 XLM'}
+                    </span>
+                  </div>
+                  <div className="theme-border pt-2 mt-1 border-t flex justify-between text-xs font-semibold">
+                    <span className="theme-text-secondary">Total Network Fee</span>
+                    <span className="text-blue-400 font-mono">
+                      {isLoadingFee
+                        ? 'Calculating...'
+                        : feeEstimate
+                          ? `${feeEstimate.fee.toFixed(7)} XLM`
+                          : 'N/A'}
+                    </span>
+                  </div>
                 </div>
               </div>
             )}
 
             {isDepositFlow && (
-              <div className="mb-4 rounded-xl border border-gray-700 bg-gray-800/60 px-4 py-3">
-                <div className="flex items-center justify-between text-xs text-gray-400 mb-2">
-                  <span>On-chain per-deposit limit</span>
-                  <div className="flex items-center gap-2">
-                    <span>{isLoadingBridgeLimit ? 'Loading...' : bridgeLimit !== null ? `${stroopsToDisplay(bridgeLimit)} XLM` : 'Unavailable'}</span>
-                    <button type="button" onClick={async () => { clearCache(); await refresh(); console.log('manual refresh'); }} className="text-xs text-blue-400 hover:underline">Refresh</button>
+              <div className="theme-surface-muted theme-border mb-4 rounded-xl border px-4 py-3">
+                <div className="flex items-center justify-between mb-3">
+                  <h3 className="theme-text-muted text-[10px] font-bold uppercase tracking-widest">
+                    Bridge Capacity
+                  </h3>
+                  <div
+                    className={`w-2 h-2 rounded-full ${
+                      isOverLimit
+                        ? 'bg-red-500 shadow-[0_0_8px_rgba(239,68,68,0.5)]'
+                        : isHighLimitUsage
+                          ? 'bg-amber-400 shadow-[0_0_8px_rgba(251,191,36,0.5)]'
+                          : 'bg-green-500 shadow-[0_0_8px_rgba(34,197,94,0.5)]'
+                    }`}
+                  />
+                </div>
+
+                <div className="flex items-center justify-between text-xs mb-2">
+                  <span className="theme-text-secondary">On-chain per-deposit limit</span>
+                  <span className="theme-text-primary font-mono">
+                    {isLoadingBridgeLimit
+                      ? 'Loading...'
+                      : bridgeLimit !== null
+                        ? `${stroopsToDisplay(bridgeLimit)} XLM`
+                        : 'Unavailable'}
+                  </span>
+                </div>
+
+                <div className="h-1.5 w-full rounded-full bg-[var(--color-surface-elevated)] overflow-hidden mb-2">
+                  <div
+                    className={`h-full rounded-full transition-all duration-500 ${
+                      isOverLimit
+                        ? 'bg-red-500'
+                        : isHighLimitUsage
+                          ? 'bg-amber-400'
+                          : 'bg-blue-500'
+                    }`}
+                    style={{ width: `${Math.min(usagePercent, 100)}%` }}
+                  />
+                </div>
+
+                <div className="theme-text-muted flex items-center justify-between text-[10px]">
+                  <span>
+                    {hasValidAmount && bridgeLimit !== null
+                      ? `${usagePercent.toFixed(1)}% used`
+                      : 'Limit utilized per transaction'}
+                  </span>
+                  <span>
+                    {hasValidAmount && bridgeLimit !== null
+                      ? `${stroopsToDisplay(remainingLimit)} XLM available`
+                      : ''}
+                  </span>
+                </div>
+
+                {bridgeLimitError && (
+                  <div className="theme-soft-danger mt-3 rounded-lg border px-3 py-2 text-[11px]">
+                    {bridgeLimitError}
                   </div>
-                </div>
+                )}
 
-                <div className="flex items-center justify-between text-sm text-gray-200 mb-2">
-                  <span>Requested amount</span>
-                  <span>{hasValidAmount && stroopsAmount !== null ? `${stroopsToDisplay(stroopsAmount)} XLM` : 'Enter an amount'}</span>
-                </div>
+                {isOverLimit && bridgeLimit !== null && stroopsAmount !== null && (
+                  <div className="theme-soft-danger mt-3 rounded-lg border px-3 py-2 text-[11px] leading-tight">
+                    Error: Amount exceeds the current bridge limit.
+                  </div>
+                )}
+              </div>
+            )}
 
-                <div className="h-2 w-full rounded-full bg-gray-700 overflow-hidden mb-2">
-                  <div className={`h-full rounded-full transition-all ${isOverLimit ? 'bg-red-500' : isHighLimitUsage ? 'bg-amber-400' : 'bg-blue-500'}`} style={{ width: `${Math.min(usagePercent, 100)}%` }} />
-                </div>
-
-                <div className="flex items-center justify-between text-xs text-gray-400">
-                  <span>{hasValidAmount && bridgeLimit !== null ? `${usagePercent.toFixed(2)}% of limit` : `High-usage warning at ${BRIDGE_LIMIT_WARNING_PERCENT}%`}</span>
-                  <span>{hasValidAmount && bridgeLimit !== null ? `${stroopsToDisplay(remainingLimit)} XLM remaining` : 'Awaiting input'}</span>
-                </div>
-
-                {bridgeLimitError && <div className="mt-3 rounded-lg border border-red-800 bg-red-900/20 px-3 py-2 text-sm text-red-300">{bridgeLimitError}</div>}
-                {isHighLimitUsage && bridgeLimit !== null && <div className="mt-3 rounded-lg border border-amber-700 bg-amber-900/20 px-3 py-2 text-sm text-amber-200">This request uses {usagePercent.toFixed(2)}% of the current on-chain limit of {stroopsToDisplay(bridgeLimit)} XLM.</div>}
-                {isOverLimit && bridgeLimit !== null && stroopsAmount !== null && <div className="mt-3 rounded-lg border border-red-800 bg-red-900/20 px-3 py-2 text-sm text-red-300">Requested {stroopsToDisplay(stroopsAmount)} XLM exceeds the current on-chain limit of {stroopsToDisplay(bridgeLimit)} XLM.</div>}
+            {isRiskyAmount && (
+              <div className="theme-soft-warning mb-4 rounded-xl border px-4 py-3">
+                <p className="font-semibold text-sm mb-2">
+                  Large amount confirmation required
+                </p>
+                <p className="text-xs mb-3">
+                  Amounts above {LARGE_AMOUNT_RISK_THRESHOLD} XLM require an
+                  additional confirmation phrase before submission.
+                </p>
+                <input
+                  type="text"
+                  value={riskConfirmation}
+                  onChange={(e) => setRiskConfirmation(e.target.value)}
+                  placeholder={RISK_CONFIRMATION_PHRASE}
+                  className="theme-input w-full border rounded-lg px-4 py-3 text-sm focus:outline-none focus:border-blue-500"
+                />
               </div>
             )}
 
             {isAdminMode && (
               <div className="mb-4">
-                <label className="block text-sm text-gray-400 mb-1">Recipient address (leave blank for self)</label>
-                <input type="text" value={recipient} onChange={(e) => setRecipient(e.target.value)} placeholder="G..." className="w-full bg-gray-800 border border-gray-600 rounded-lg px-4 py-3 text-white placeholder-gray-500 focus:outline-none focus:border-blue-500 font-mono text-sm" />
+                <label className="theme-text-secondary block text-sm mb-1">
+                  Recipient address (leave blank for self)
+                </label>
+                <input
+                  type="text"
+                  value={recipient}
+                  onChange={(e) => setRecipient(e.target.value)}
+                  placeholder="G..."
+                  className="theme-input w-full border rounded-lg px-4 py-3 focus:outline-none focus:border-blue-500 font-mono text-sm"
+                />
               </div>
             )}
 
-            <div data-testid="wallet-info" className="flex justify-between text-xs text-gray-500 mb-6"><span>Connected: {connection.address.slice(0, 8)}…{connection.address.slice(-4)}</span><span>Network: {connection.network || 'TESTNET'}</span></div>
+            <div data-testid="wallet-info" className="theme-text-muted flex justify-between text-xs mb-6">
+              <span>
+                Connected: {connection.address.slice(0, 8)}…
+                {connection.address.slice(-4)}
+              </span>
+              <span>Network: {connection.network || 'TESTNET'}</span>
+            </div>
 
             {status === 'error' && (
-              <div data-testid="error-message" className="flex items-center gap-2 text-red-400 bg-red-900/20 border border-red-800 rounded-lg px-3 py-2 mb-4 text-sm"><AlertCircle className="w-4 h-4 flex-shrink-0" /><span>{errorMsg}</span></div>
+              <div
+                data-testid="error-message"
+                className="theme-soft-danger flex items-center gap-2 border rounded-lg px-3 py-2 mb-4 text-sm"
+              >
+                <AlertCircle className="w-4 h-4 flex-shrink-0" />
+                <span>{errorMsg}</span>
+              </div>
             )}
 
-            <button onClick={handleAction} disabled={isSubmitDisabled} className="w-full flex items-center justify-center gap-2 bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 disabled:opacity-50 disabled:cursor-not-allowed text-white py-3 rounded-lg font-semibold transition-all">
+            <button
+              onClick={handleAction}
+              disabled={isSubmitDisabled}
+              className="theme-primary-button w-full flex items-center justify-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed text-white py-3 rounded-lg font-semibold transition-all"
+            >
               {status === 'loading' ? (
                 <>
-                  <Loader2 data-testid="loading-spinner" className="w-4 h-4 animate-spin" />
+                  <Loader2
+                    data-testid="loading-spinner"
+                    className="w-4 h-4 animate-spin"
+                  />
                   Signing & submitting…
                 </>
-              ) : isAdminMode ? 'Withdraw' : 'Deposit'}
+              ) : isAdminMode ? (
+                'Withdraw'
+              ) : (
+                'Deposit'
+              )}
             </button>
 
-            {!connection.isConnected && <p className="text-center text-xs text-gray-500 mt-3">Connect your Freighter wallet to continue.</p>}
-          </React.Fragment>
+            {!connection.isConnected && (
+              <p className="theme-text-muted text-center text-xs mt-3">
+                Connect your Freighter wallet to continue.
+              </p>
+            )}
+          </>
         )}
       </div>
     </div>

--- a/dex_with_fiat_frontend/src/hooks/useChat.ts
+++ b/dex_with_fiat_frontend/src/hooks/useChat.ts
@@ -18,6 +18,8 @@ interface ConversationState {
   pendingTransactionData: TransactionData | null;
   shouldTriggerTransaction: boolean;
   isAdmin: boolean;
+  awaitingClarification: boolean;
+  clarificationQuestion: string | null;
 }
 
 const useChat = () => {
@@ -38,6 +40,8 @@ const useChat = () => {
       pendingTransactionData: null,
       shouldTriggerTransaction: false,
       isAdmin: false,
+      awaitingClarification: false,
+      clarificationQuestion: null,
     },
   );
 
@@ -141,6 +145,8 @@ What would you like to do today? I'm here to make your XLM-to-fiat journey smoot
           hasUserCancelled: true,
           pendingTransactionData: null,
           shouldTriggerTransaction: false,
+          awaitingClarification: false,
+          clarificationQuestion: null,
         }));
       }
 
@@ -188,8 +194,15 @@ What would you like to do today? I'm here to make your XLM-to-fiat journey smoot
           (pendingTransactionData.tokenIn ||
             pendingTransactionData.amountIn ||
             pendingTransactionData.fiatAmount);
+        const needsClarification =
+          analysis.intent === 'fiat_conversion' &&
+          analysis.confidence < AIAssistant.LOW_CONFIDENCE_THRESHOLD;
+        const clarificationQuestion = needsClarification
+          ? aiAssistant.getClarificationQuestion(analysis)
+          : null;
 
         const shouldAutoTrigger =
+          !needsClarification &&
           !conversationState.hasUserCancelled &&
           (newMessageCount >= 5 ||
             (hasMinimalTransactionData &&
@@ -202,7 +215,12 @@ What would you like to do today? I'm here to make your XLM-to-fiat journey smoot
 
         let enhancedResponse = analysis.suggestedResponse;
 
+        if (needsClarification && clarificationQuestion) {
+          enhancedResponse = `**One quick clarification**: ${clarificationQuestion}`;
+        }
+
         if (
+          !needsClarification &&
           newMessageCount >= 3 &&
           hasMinimalTransactionData &&
           !conversationState.hasUserCancelled
@@ -211,6 +229,7 @@ What would you like to do today? I'm here to make your XLM-to-fiat journey smoot
 
 **Ready to Proceed**: I have the details needed for your conversion. Let me set this up for you to review and sign.`;
         } else if (
+          !needsClarification &&
           newMessageCount >= 4 &&
           !hasMinimalTransactionData &&
           !conversationState.hasUserCancelled
@@ -246,6 +265,8 @@ What would you like to do today? I'm here to make your XLM-to-fiat journey smoot
           hasUserCancelled: isCancellation ? true : prev.hasUserCancelled,
           pendingTransactionData,
           shouldTriggerTransaction,
+          awaitingClarification: needsClarification,
+          clarificationQuestion,
         }));
 
         const shouldShowTransactionData =
@@ -271,11 +292,14 @@ What would you like to do today? I'm here to make your XLM-to-fiat journey smoot
               hasTransactionData: !!pendingTransactionData,
               shouldAutoTrigger: !!shouldAutoTrigger,
               isAdmin: conversationState.isAdmin,
+              lowConfidence: needsClarification,
             }),
             confirmationRequired:
               analysis.intent === 'fiat_conversion' || shouldTriggerTransaction,
             autoTriggerTransaction: shouldTriggerTransaction,
             conversationCount: newMessageCount,
+            lowConfidence: needsClarification,
+            clarificationQuestion: clarificationQuestion || undefined,
           },
         };
 
@@ -315,6 +339,8 @@ What would you like to do today? I'm here to make your XLM-to-fiat journey smoot
       pendingTransactionData: null,
       shouldTriggerTransaction: false,
       isAdmin: prev.isAdmin,
+      awaitingClarification: false,
+      clarificationQuestion: null,
     }));
     createNewSession([]);
   }, [createNewSession]);
@@ -332,6 +358,8 @@ What would you like to do today? I'm here to make your XLM-to-fiat journey smoot
           pendingTransactionData: null,
           shouldTriggerTransaction: false,
           isAdmin: prev.isAdmin,
+          awaitingClarification: false,
+          clarificationQuestion: null,
         }));
       }
     },
@@ -393,6 +421,7 @@ function generateSuggestedActions(
     hasTransactionData?: boolean;
     shouldAutoTrigger?: boolean;
     isAdmin?: boolean;
+    lowConfidence?: boolean;
   },
 ) {
   const actions = [];
@@ -401,6 +430,7 @@ function generateSuggestedActions(
   const hasTransactionData = context?.hasTransactionData || false;
   const shouldAutoTrigger = context?.shouldAutoTrigger || false;
   const isAdmin = context?.isAdmin || false;
+  const lowConfidence = context?.lowConfidence || false;
 
   if (analysis.intent === 'guardrail' && analysis.guardrail) {
     return generateGuardrailActions(analysis.guardrail.category, isConnected);
@@ -421,7 +451,12 @@ function generateSuggestedActions(
     return actions;
   }
 
-  if (messageCount >= 3 && hasTransactionData && !shouldAutoTrigger) {
+  if (
+    messageCount >= 3 &&
+    hasTransactionData &&
+    !shouldAutoTrigger &&
+    !lowConfidence
+  ) {
     actions.push({
       id: 'proceed_now',
       type: 'confirm_fiat' as const,
@@ -445,7 +480,7 @@ function generateSuggestedActions(
       });
     }
 
-    if (!shouldAutoTrigger) {
+    if (!shouldAutoTrigger && !lowConfidence) {
       actions.push({
         id: 'proceed_conversion',
         type: 'confirm_fiat' as const,
@@ -504,7 +539,7 @@ function generateSuggestedActions(
       'withdraw',
       'sell',
     ].some((keyword) => content.includes(keyword));
-    if (hasConversionKeywords) {
+    if (hasConversionKeywords && !lowConfidence) {
       actions.push(
         {
           id: 'start_conversion',

--- a/dex_with_fiat_frontend/src/hooks/useNotifications.ts
+++ b/dex_with_fiat_frontend/src/hooks/useNotifications.ts
@@ -1,6 +1,12 @@
 import { useSyncExternalStore } from 'react';
 
-export type NotificationType = 'tx_submit' | 'tx_confirm' | 'payout_pending' | 'payout_success' | 'payout_fail';
+export type NotificationType =
+  | 'tx_submit'
+  | 'tx_confirm'
+  | 'payout_pending'
+  | 'payout_success'
+  | 'payout_fail'
+  | 'risk_warning';
 
 export interface AppNotification {
   id: string;

--- a/dex_with_fiat_frontend/src/hooks/useTxHistory.ts
+++ b/dex_with_fiat_frontend/src/hooks/useTxHistory.ts
@@ -1,0 +1,96 @@
+'use client';
+
+import { useSyncExternalStore } from 'react';
+import { TransactionHistoryEntry } from '@/types';
+
+const TX_HISTORY_KEY = 'stellar_tx_history';
+
+class TxHistoryStore {
+  private entries: TransactionHistoryEntry[] = [];
+  private listeners = new Set<() => void>();
+
+  constructor() {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const stored = localStorage.getItem(TX_HISTORY_KEY);
+    if (!stored) {
+      return;
+    }
+
+    try {
+      const parsed = JSON.parse(stored) as Array<
+        Omit<TransactionHistoryEntry, 'createdAt'> & { createdAt: string }
+      >;
+      this.entries = parsed.map((entry) => ({
+        ...entry,
+        createdAt: new Date(entry.createdAt),
+      }));
+    } catch {
+      this.entries = [];
+    }
+  }
+
+  private emit() {
+    this.listeners.forEach((listener) => listener());
+
+    if (typeof window !== 'undefined') {
+      localStorage.setItem(TX_HISTORY_KEY, this.exportEntries());
+    }
+  }
+
+  subscribe(listener: () => void) {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  getSnapshot() {
+    return this.entries;
+  }
+
+  addEntry(entry: Omit<TransactionHistoryEntry, 'id' | 'createdAt'>) {
+    const nextEntry: TransactionHistoryEntry = {
+      ...entry,
+      id: crypto.randomUUID(),
+      createdAt: new Date(),
+    };
+
+    this.entries = [nextEntry, ...this.entries].slice(0, 100);
+    this.emit();
+    return nextEntry;
+  }
+
+  clearEntries() {
+    this.entries = [];
+    this.emit();
+  }
+
+  exportEntries() {
+    return JSON.stringify(
+      this.entries.map((entry) => ({
+        ...entry,
+        createdAt: entry.createdAt.toISOString(),
+      })),
+      null,
+      2,
+    );
+  }
+}
+
+const txHistoryStore = new TxHistoryStore();
+
+export function useTxHistory() {
+  const entries = useSyncExternalStore(
+    (listener) => txHistoryStore.subscribe(listener),
+    () => txHistoryStore.getSnapshot(),
+    () => [],
+  );
+
+  return {
+    entries,
+    addEntry: txHistoryStore.addEntry.bind(txHistoryStore),
+    clearEntries: txHistoryStore.clearEntries.bind(txHistoryStore),
+    exportEntries: txHistoryStore.exportEntries.bind(txHistoryStore),
+  };
+}

--- a/dex_with_fiat_frontend/src/lib/aiAssistant.ts
+++ b/dex_with_fiat_frontend/src/lib/aiAssistant.ts
@@ -26,6 +26,7 @@ export class AIAssistant {
   };
 
   private model = genAI.getGenerativeModel({ model: 'gemini-1.5-flash' });
+  static readonly LOW_CONFIDENCE_THRESHOLD = 0.7;
 
   async analyzeUserMessage(
     message: string,
@@ -73,7 +74,7 @@ User Message: "${message}"
 Context: ${context ? JSON.stringify(context) : 'None'}
 
 CORE CAPABILITIES:
-1. XLM to fiat conversions (XLM → NGN, USD, EUR) — Primary Focus
+1. XLM to fiat conversions (XLM → NGN, USD, EUR) - Primary Focus
 2. Stellar FiatBridge smart contract interactions (deposit, withdraw, check limits)
 3. Real-time XLM market rate analysis
 4. Transaction tracking on Stellar Expert (testnet)
@@ -94,6 +95,8 @@ EXTRACTION GUIDELINES:
 - Set intent to "guardrail" for unsupported requests or risky requests involving private keys, bypassing compliance, exploits, scams, or guaranteed returns
 - Set intent to "unknown" only if completely unclear
 - Always assume XLM when referring to tokens (we support XLM on Stellar)
+- If the user seems to want a conversion but amount, payout target, or currency is missing or ambiguous, keep intent as "fiat_conversion", set confidence below 0.7, and include one targeted follow-up question in "requiredQuestions"
+- When confidence is below 0.7, keep "suggestedResponse" focused on that single clarification instead of saying the transaction is ready
 
 Respond with a JSON object in this exact format:
 {
@@ -312,11 +315,23 @@ Choose one of the next actions below and I’ll keep it moving.`;
       const jsonMatch = response.match(/\{[\s\S]*\}/);
       if (jsonMatch) {
         const parsed = JSON.parse(jsonMatch[0]);
+        const extractedData = parsed.extractedData || {};
+        const requiredQuestions = Array.isArray(parsed.requiredQuestions)
+          ? parsed.requiredQuestions
+          : [];
+        const clarificationQuestion =
+          requiredQuestions[0] ||
+          this.buildClarificationQuestion(extractedData, parsed.intent);
+
         return {
           intent: parsed.intent || 'unknown',
           confidence: parsed.confidence || 0.5,
-          extractedData: parsed.extractedData || {},
-          requiredQuestions: parsed.requiredQuestions || [],
+          extractedData,
+          requiredQuestions:
+            parsed.confidence < AIAssistant.LOW_CONFIDENCE_THRESHOLD &&
+            clarificationQuestion
+              ? [clarificationQuestion]
+              : requiredQuestions,
           suggestedResponse:
             parsed.suggestedResponse || 'How can I help you today?',
           guardrail: parsed.guardrail,
@@ -359,6 +374,36 @@ Be helpful and specific about what you need.
       console.error('Failed to generate follow-up question:', error);
       return 'Could you provide more details about your request?';
     }
+  }
+
+  getClarificationQuestion(analysis: AIAnalysisResult): string {
+    return (
+      analysis.requiredQuestions[0] ||
+      this.buildClarificationQuestion(analysis.extractedData, analysis.intent)
+    );
+  }
+
+  private buildClarificationQuestion(
+    extractedData: Partial<TransactionData>,
+    intent: AIAnalysisResult['intent'],
+  ): string {
+    if (intent !== 'fiat_conversion') {
+      return 'Could you clarify what you want to do with your XLM transfer?';
+    }
+
+    if (!extractedData.amountIn && !extractedData.fiatAmount) {
+      return 'What amount of XLM would you like to deposit or what fiat amount should I target?';
+    }
+
+    if (!extractedData.fiatCurrency) {
+      return 'Which fiat currency should I prepare the payout in, like NGN, USD, or EUR?';
+    }
+
+    if (!extractedData.recipient) {
+      return 'Should I prepare this as a standard deposit for later payout review?';
+    }
+
+    return 'Could you confirm the last missing detail so I can prepare the correct transaction?';
   }
 
   async validateTransactionData(data: TransactionData): Promise<{

--- a/dex_with_fiat_frontend/src/lib/chatHistory.ts
+++ b/dex_with_fiat_frontend/src/lib/chatHistory.ts
@@ -127,6 +127,7 @@ export class ChatHistoryManager {
         role: msg.role,
         content: msg.content,
         timestamp: msg.timestamp.toISOString(),
+        metadata: msg.metadata,
       })),
       createdAt: session.createdAt.toISOString(),
     };

--- a/dex_with_fiat_frontend/src/types/index.ts
+++ b/dex_with_fiat_frontend/src/types/index.ts
@@ -11,6 +11,8 @@ export interface ChatMessage {
     autoTriggerTransaction?: boolean;
     conversationCount?: number;
     guardrail?: GuardrailResult;
+    lowConfidence?: boolean;
+    clarificationQuestion?: string;
   };
 }
 
@@ -38,6 +40,22 @@ export interface TransactionData {
   recipient?: string;
   transactionId?: string;
   txHash?: string; // Transaction hash for completed transactions
+  note?: string;
+}
+
+export interface TransactionHistoryEntry {
+  id: string;
+  kind: 'deposit' | 'payout' | 'risk_warning';
+  status: 'pending' | 'completed' | 'warning' | 'failed';
+  amount?: string;
+  asset?: string;
+  fiatAmount?: string;
+  fiatCurrency?: string;
+  note?: string;
+  txHash?: string;
+  reference?: string;
+  message: string;
+  createdAt: Date;
 }
 
 export interface SuggestedAction {


### PR DESCRIPTION
## What
Improve the chat conversion flow with confidence gating, large-amount confirmations, transaction notes, transaction history, and shared theme tokens across the main frontend surfaces.

## Why
Closes #44
Closes #50
Closes #68
Closes #72

## How
Added a low-confidence clarification path so ambiguous conversion requests do not auto-open the transaction modal until the AI has enough signal. Added large-amount warnings with a typed confirmation phrase, optional notes for deposit and payout flows, and a persistent transaction history/export surface. Refactored the primary chat and modal surfaces to use shared theme tokens for light and dark parity.

## Testing
- npm run lint
- npm run build
- Verified low-confidence requests stay in clarification mode until confidence recovers
- Verified large deposit flows require the typed confirmation phrase before submission