### PR TITLE
 Chore: add .gitignore entries for generated build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Root-level generated artifacts
+node_modules/
+dex_with_fiat_frontend/.next/
+dex_with_fiat_frontend/node_modules/
+stellar-contracts/target/
+
+# Local environment files
+.env.local
+
+# Contract build artifacts
+*.wasm
+


### PR DESCRIPTION
Updated ignore rules to prevent large generated artifacts from being staged and verified with a real install/build cycle.

-  Add required root .gitignore entries
-  Run npm install and cargo build to generate artifacts
-  Run git status to verify artifacts do not appear as untracked
-  Check whether any artifact paths were already tracked

closes #20 

```
git status                                                                                                                                                                              ─╯
On branch add-gitignore-entries
Your branch is up to date with 'origin/add-gitignore-entries'.

nothing to commit, working tree clean
```