### PR TITLE
chore: extract XLM stroop conversion utilities into shared helper module

### DIFF
--- a/dex_with_fiat_frontend/src/components/StellarFiatModal.tsx
+++ b/dex_with_fiat_frontend/src/components/StellarFiatModal.tsx
@@ -17,9 +17,9 @@ import {
   BRIDGE_LIMIT_WARNING_PERCENT,
   depositToContract,
   withdrawFromContract,
-  stroopsToDisplay,
   clearCache,
 } from '@/lib/stellarContract';
+import { xlmToStroops, stroopsToXlm as stroopsToDisplay } from '@/lib/stroops';
 import type { FeeEstimate } from '@/lib/stellarContract';
 import useBridgeStats from '@/hooks/useBridgeStats';
 import { getTokenPrice, formatFiatAmount } from '@/lib/cryptoPriceService';
@@ -51,28 +51,6 @@ interface PendingTxRecord {
   amount: string;
   isAdminMode: boolean;
   recipient: string;
-}
-
-function parseAmountToStroops(value: string): bigint | null {
-  const normalized = value.trim();
-
-  if (!normalized) {
-    return null;
-  }
-
-  if (!/^\d*(?:\.\d{0,7})?$/.test(normalized)) {
-    return null;
-  }
-
-  const [wholePart = '0', fractionalPart = ''] = normalized.split('.');
-
-  if (!wholePart && !fractionalPart) {
-    return null;
-  }
-
-  const whole = wholePart || '0';
-  const fraction = (fractionalPart || '').padEnd(7, '0');
-  return BigInt(whole) * 10_000_000n + BigInt(fraction || '0');
 }
 
 export default function StellarFiatModal({
@@ -220,7 +198,7 @@ export default function StellarFiatModal({
       return;
     }
 
-    const currentStroops = parseAmountToStroops(amount);
+    const currentStroops = xlmToStroops(amount);
     if (!currentStroops || currentStroops <= BigInt(0)) {
       setFeeEstimate(null);
       return;
@@ -283,7 +261,7 @@ export default function StellarFiatModal({
     void updateFiatEstimate();
   }, [updateFiatEstimate]);
 
-  const stroopsAmount = parseAmountToStroops(amount);
+  const stroopsAmount = xlmToStroops(amount);
   const numericAmount = Number.parseFloat(amount);
   const hasValidAmount = stroopsAmount !== null && stroopsAmount > BigInt(0);
   const isRiskyAmount =

--- a/dex_with_fiat_frontend/src/lib/stellarContract.ts
+++ b/dex_with_fiat_frontend/src/lib/stellarContract.ts
@@ -8,6 +8,9 @@ import {
   scValToNative,
   rpc,
 } from '@stellar/stellar-sdk';
+import { stroopsToXlm } from '@/lib/stroops';
+
+export { stroopsToXlm as stroopsToDisplay } from '@/lib/stroops';
 
 const RPC_URL =
   process.env.NEXT_PUBLIC_STELLAR_RPC_URL ||
@@ -316,7 +319,7 @@ export async function validateBridgeAmountLimit(amount: bigint): Promise<bigint>
 
   if (amount > limit) {
     throw new Error(
-      `Requested amount exceeds the current bridge limit of ${stroopsToDisplay(limit)} XLM.`,
+      `Requested amount exceeds the current bridge limit of ${stroopsToXlm(limit)} XLM.`,
     );
   }
 
@@ -328,11 +331,3 @@ export async function getTotalDeposited(): Promise<bigint> {
   return viewCall<bigint>('get_total_deposited');
 }
 
-/** Formats a raw stroop (1e-7 XLM) bigint as a human-readable string. */
-export function stroopsToDisplay(stroops: bigint, decimals = 7): string {
-  const divisor = BigInt(10 ** decimals);
-  const whole = stroops / divisor;
-  const frac = stroops % divisor;
-  const fracStr = frac.toString().padStart(decimals, '0').replace(/0+$/, '');
-  return fracStr ? `${whole}.${fracStr}` : `${whole}`;
-}

--- a/dex_with_fiat_frontend/src/lib/stroops.ts
+++ b/dex_with_fiat_frontend/src/lib/stroops.ts
@@ -1,0 +1,44 @@
+const DECIMALS = 7;
+const DIVISOR = BigInt(10 ** DECIMALS);
+
+/**
+ * Convert a decimal XLM value to stroops (1 XLM = 10,000,000 stroops).
+ * Uses string-based arithmetic to avoid floating-point rounding errors.
+ * Returns `null` when the input is empty or not a valid XLM amount.
+ */
+export function xlmToStroops(xlm: string | number): bigint | null {
+  const normalized = String(xlm).trim();
+
+  if (!normalized) {
+    return null;
+  }
+
+  if (!/^\d*(?:\.\d{0,7})?$/.test(normalized)) {
+    return null;
+  }
+
+  const [wholePart = '0', fractionalPart = ''] = normalized.split('.');
+
+  if (!wholePart && !fractionalPart) {
+    return null;
+  }
+
+  const whole = wholePart || '0';
+  const fraction = (fractionalPart || '').padEnd(DECIMALS, '0');
+  return BigInt(whole) * DIVISOR + BigInt(fraction || '0');
+}
+
+/**
+ * Format a raw stroop value as a human-readable XLM string.
+ * Trailing zeros are trimmed (e.g. 50_000_000n → "5").
+ */
+export function stroopsToXlm(stroops: bigint | string): string {
+  const value = typeof stroops === 'string' ? BigInt(stroops) : stroops;
+  const whole = value / DIVISOR;
+  const frac = value % DIVISOR;
+  const fracStr = frac.toString().padStart(DECIMALS, '0').replace(/0+$/, '');
+  return fracStr ? `${whole}.${fracStr}` : `${whole}`;
+}
+
+/** @deprecated Use {@link stroopsToXlm} instead. */
+export const stroopsToDisplay = stroopsToXlm;


### PR DESCRIPTION
Consolidate stroop ↔ XLM conversion logic into a single shared file (src/lib/stroops.ts) to eliminate duplication and reduce the risk of rounding inconsistencies across the codebase.

- Create src/lib/stroops.ts with xlmToStroops and stroopsToXlm exports
- Move stroopsToDisplay from stellarContract.ts into stroops.ts, re-exporting it as a deprecated alias for backward compatibility
- Replace the local parseAmountToStroops in StellarFiatModal.tsx with the shared xlmToStroops import

Closes #21
