### PR TITLE
feat: integrate oracle for USD-equivalent deposit limits

### DIFF
--- a/stellar-contracts/src/lib.rs
+++ b/stellar-contracts/src/lib.rs
@@ -3,6 +3,8 @@ use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, token, Address, Bytes, Env, Symbol, Vec,
 };
 
+pub mod oracle;
+
 // ── Constants ─────────────────────────────────────────────────────────────
 /// Minimum remaining ledgers for instance storage (~30 days)
 pub const MIN_TTL: u32 = 518_400;
@@ -48,6 +50,10 @@ pub enum Error {
     NoEmergencyRecoveryAddress = 18,
     /// The recipient address is invalid (e.g., contract address itself).
     InvalidRecipient = 19,
+    /// The deposit's USD-equivalent value exceeds the global fiat deposit limit.
+    ExceedsFiatLimit = 20,
+    /// No oracle contract has been configured yet.
+    OracleNotSet = 21,
 }
 
 // ── Models ────────────────────────────────────────────────────────────────
@@ -101,6 +107,19 @@ pub struct WithdrawEntry {
     pub amount: i128,
 }
 
+/// Tracks a user's rolling 24-hour deposit volume in USD-equivalent cents.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct UserDailyVolume {
+    /// Cumulative USD-equivalent value (in cents, 1 USD = 100) within the window.
+    pub usd_cents: i128,
+    /// Ledger sequence when the window started.
+    pub window_start: u32,
+}
+
+/// Oracle prices are returned with 7 decimal places (matching Stellar precision).
+pub const ORACLE_PRICE_DECIMALS: i128 = 10_000_000;
+
 /// Maximum allowed length for a deposit reference (bytes).
 const MAX_REFERENCE_LEN: u32 = 64;
 
@@ -152,6 +171,14 @@ pub enum DataKey {
     QueuedAdminAction(u64),
     /// Emergency recovery address
     EmergencyRecoveryAddress,
+
+    // ── Added for oracle-based fiat deposit limits (#159) ──
+    /// Address of the price oracle contract.
+    Oracle,
+    /// Global fiat-value deposit limit in USD cents (e.g. 1_000_000 = $10,000).
+    FiatLimit,
+    /// Rolling 24-hour USD-equivalent deposit volume per user.
+    UserDailyVolume(Address),
 }
 
 /// Approximate number of ledgers in a 24-hour window (5-second close time).
@@ -325,6 +352,9 @@ impl FiatBridge {
         if amount > config.limit {
             return Err(Error::ExceedsLimit);
         }
+
+        // ── Fiat-value limit check (if oracle + fiat limit are configured) ──
+        Self::validate_fiat_limit(&env, &from, &token, amount)?;
 
         let token_client = token::Client::new(&env, &token);
         token_client.transfer(&from, env.current_contract_address(), &amount);
@@ -661,6 +691,116 @@ impl FiatBridge {
         env.storage()
             .persistent()
             .set(&DataKey::TokenRegistry(token), &config);
+        Ok(())
+    }
+
+    // ── Oracle-based fiat deposit limits (#159) ──────────────────────────
+
+    /// Set the address of the price oracle contract. Admin only.
+    pub fn set_oracle(env: Env, oracle: Address) -> Result<(), Error> {
+        env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::NotInitialized)?;
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Oracle, &oracle);
+        Ok(())
+    }
+
+    /// Set the global fiat-value deposit limit (in USD cents). Admin only.
+    /// For example, `1_000_000` means a $10,000 limit.
+    pub fn set_fiat_limit(env: Env, limit_usd_cents: i128) -> Result<(), Error> {
+        env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
+        if limit_usd_cents <= 0 {
+            return Err(Error::ZeroAmount);
+        }
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::NotInitialized)?;
+        admin.require_auth();
+        env.storage()
+            .instance()
+            .set(&DataKey::FiatLimit, &limit_usd_cents);
+        Ok(())
+    }
+
+    /// Returns the current global fiat deposit limit in USD cents, if set.
+    pub fn get_fiat_limit(env: Env) -> Option<i128> {
+        env.storage().instance().get(&DataKey::FiatLimit)
+    }
+
+    /// Returns the oracle contract address, if set.
+    pub fn get_oracle(env: Env) -> Option<Address> {
+        env.storage().instance().get(&DataKey::Oracle)
+    }
+
+    /// Returns the current rolling 24-hour USD deposit volume for a user, if any.
+    pub fn get_user_daily_volume(env: Env, user: Address) -> Option<UserDailyVolume> {
+        env.storage()
+            .instance()
+            .get(&DataKey::UserDailyVolume(user))
+    }
+
+    /// Validate a deposit against the fiat limit (if oracle and limit are configured).
+    /// Calculates the USD-equivalent of `amount` for `token`, adds it to the user's
+    /// rolling 24-hour volume, and rejects if the total exceeds the fiat limit.
+    /// Updates the volume tracker on success. No-op if oracle or fiat limit is unset.
+    fn validate_fiat_limit(
+        env: &Env,
+        depositor: &Address,
+        token: &Address,
+        amount: i128,
+    ) -> Result<(), Error> {
+        let fiat_limit: i128 = match env.storage().instance().get(&DataKey::FiatLimit) {
+            Some(l) => l,
+            None => return Ok(()),
+        };
+
+        let oracle_addr: Address = match env.storage().instance().get(&DataKey::Oracle) {
+            Some(a) => a,
+            None => return Err(Error::OracleNotSet),
+        };
+
+        let oracle = crate::oracle::OracleClient::new(env, &oracle_addr);
+        let price: i128 = oracle
+            .get_price(token)
+            .unwrap_or(0);
+        if price <= 0 {
+            return Err(Error::OracleNotSet);
+        }
+
+        // Oracle returns price per token unit in USD with 7 decimal places.
+        // usd_value = amount * price / ORACLE_PRICE_DECIMALS
+        // usd_cents = usd_value * 100 = (amount * price) / (ORACLE_PRICE_DECIMALS / 100)
+        let usd_cents = (amount * price) / (ORACLE_PRICE_DECIMALS / 100);
+
+        let current_ledger = env.ledger().sequence();
+        let vol_key = DataKey::UserDailyVolume(depositor.clone());
+        let mut volume: UserDailyVolume = env
+            .storage()
+            .instance()
+            .get(&vol_key)
+            .unwrap_or(UserDailyVolume {
+                usd_cents: 0,
+                window_start: current_ledger,
+            });
+
+        if current_ledger - volume.window_start >= WINDOW_LEDGERS {
+            volume.usd_cents = 0;
+            volume.window_start = current_ledger;
+        }
+
+        if volume.usd_cents + usd_cents > fiat_limit {
+            return Err(Error::ExceedsFiatLimit);
+        }
+
+        volume.usd_cents += usd_cents;
+        env.storage().instance().set(&vol_key, &volume);
+
         Ok(())
     }
 

--- a/stellar-contracts/src/oracle.rs
+++ b/stellar-contracts/src/oracle.rs
@@ -1,0 +1,9 @@
+use soroban_sdk::{contractclient, Address, Env};
+
+/// Interface that any price oracle contract must implement.
+/// Returns the price of a token in USD with 7 decimal places
+/// (i.e. 1 USD = 10_000_000).
+#[contractclient(name = "OracleClient")]
+pub trait PriceOracle {
+    fn get_price(env: Env, token: Address) -> Option<i128>;
+}

--- a/stellar-contracts/src/test.rs
+++ b/stellar-contracts/src/test.rs
@@ -517,4 +517,173 @@ mod tests {
         let result = bridge.try_emergency_drain(&contract_id);
         assert_eq!(result, Err(Ok(Error::InvalidRecipient)));
     }
+
+    // ── Mock oracle contract ──────────────────────────────────────────
+    // Returns a fixed price for any token: 0.10 USD (1_000_000 in 7-decimal)
+    // Equivalent to $0.10 per token unit.
+    mod mock_oracle {
+        use soroban_sdk::{contract, contractimpl, Address, Env};
+
+        #[contract]
+        pub struct MockOracle;
+
+        #[contractimpl]
+        impl MockOracle {
+            /// Returns a fixed price per token (7 decimal places).
+            /// 1_000_000 = $0.10 per unit (XLM-like pricing).
+            pub fn get_price(_env: Env, _token: Address) -> Option<i128> {
+                Some(1_000_000) // $0.10
+            }
+        }
+    }
+
+    fn setup_oracle(env: &Env) -> Address {
+        env.register(mock_oracle::MockOracle, ())
+    }
+
+    // ── Oracle integration tests ──────────────────────────────────────
+
+    #[test]
+    fn test_set_and_get_oracle() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (_, bridge, _, _, _, _) = setup_bridge(&env, 500);
+        assert_eq!(bridge.get_oracle(), None);
+        let oracle_addr = setup_oracle(&env);
+        bridge.set_oracle(&oracle_addr);
+        assert_eq!(bridge.get_oracle(), Some(oracle_addr));
+    }
+
+    #[test]
+    fn test_set_and_get_fiat_limit() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (_, bridge, _, _, _, _) = setup_bridge(&env, 500);
+        assert_eq!(bridge.get_fiat_limit(), None);
+        bridge.set_fiat_limit(&1_000_000); // $10,000
+        assert_eq!(bridge.get_fiat_limit(), Some(1_000_000));
+    }
+
+    #[test]
+    fn test_set_fiat_limit_zero_fails() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (_, bridge, _, _, _, _) = setup_bridge(&env, 500);
+        let result = bridge.try_set_fiat_limit(&0);
+        assert_eq!(result, Err(Ok(Error::ZeroAmount)));
+    }
+
+    #[test]
+    fn test_deposit_within_fiat_limit() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (_, bridge, _, token_addr, _, token_sac) = setup_bridge(&env, 10_000);
+        let oracle_addr = setup_oracle(&env);
+        bridge.set_oracle(&oracle_addr);
+        // $10,000 limit in cents = 1_000_000
+        bridge.set_fiat_limit(&1_000_000);
+
+        let user = Address::generate(&env);
+        token_sac.mint(&user, &50_000);
+
+        // 100 tokens at $0.10 = $10 = 1000 cents. Well within $10,000.
+        let receipt_id = bridge.deposit(&user, &100, &token_addr, &Bytes::new(&env));
+        assert!(receipt_id >= 0);
+        assert_eq!(bridge.get_balance(), 100);
+    }
+
+    #[test]
+    fn test_deposit_exceeds_fiat_limit() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (_, bridge, _, token_addr, _, token_sac) = setup_bridge(&env, 100_000);
+        let oracle_addr = setup_oracle(&env);
+        bridge.set_oracle(&oracle_addr);
+        // $5 limit = 500 cents
+        bridge.set_fiat_limit(&500);
+
+        let user = Address::generate(&env);
+        token_sac.mint(&user, &100_000);
+
+        // 100 tokens at $0.10 = $10 = 1,000 cents → over $5 (500 cents) limit
+        let result = bridge.try_deposit(&user, &100, &token_addr, &Bytes::new(&env));
+        assert_eq!(result, Err(Ok(Error::ExceedsFiatLimit)));
+    }
+
+    #[test]
+    fn test_daily_volume_accumulates() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (_, bridge, _, token_addr, _, token_sac) = setup_bridge(&env, 10_000);
+        let oracle_addr = setup_oracle(&env);
+        bridge.set_oracle(&oracle_addr);
+        // $25 limit = 2_500 cents
+        bridge.set_fiat_limit(&2_500);
+
+        let user = Address::generate(&env);
+        token_sac.mint(&user, &100_000);
+
+        // 100 tokens at $0.10 = $10 = 1,000 cents → fine (within $25)
+        bridge.deposit(&user, &100, &token_addr, &Bytes::new(&env));
+        // 100 more at $0.10 = $10 = 1,000 cents → total 2,000 → still fine
+        bridge.deposit(&user, &100, &token_addr, &Bytes::new(&env));
+        // 100 more → total would be 3,000 > 2,500 → rejected
+        let result = bridge.try_deposit(&user, &100, &token_addr, &Bytes::new(&env));
+        assert_eq!(result, Err(Ok(Error::ExceedsFiatLimit)));
+    }
+
+    #[test]
+    fn test_daily_volume_resets_after_window() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (_, bridge, _, token_addr, _, token_sac) = setup_bridge(&env, 10_000);
+        let oracle_addr = setup_oracle(&env);
+        bridge.set_oracle(&oracle_addr);
+        // $15 limit = 1_500 cents
+        bridge.set_fiat_limit(&1_500);
+
+        let user = Address::generate(&env);
+        token_sac.mint(&user, &100_000);
+
+        // 100 tokens at $0.10 = $10 = 1_000 cents → fine (within $15)
+        bridge.deposit(&user, &100, &token_addr, &Bytes::new(&env));
+
+        // Another 100 = $10 = 1,000 cents → total 2,000 > 1,500 → rejected
+        let result = bridge.try_deposit(&user, &100, &token_addr, &Bytes::new(&env));
+        assert_eq!(result, Err(Ok(Error::ExceedsFiatLimit)));
+
+        // Advance past 24h window (17_280 ledgers)
+        let current = env.ledger().sequence();
+        env.ledger().with_mut(|li| {
+            li.sequence_number = current + 17_280;
+        });
+
+        // Now the window has reset — 100 tokens = $10 = 1,000 cents → within limit
+        bridge.deposit(&user, &100, &token_addr, &Bytes::new(&env));
+    }
+
+    #[test]
+    fn test_deposit_without_fiat_limit_skips_check() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (_, bridge, _, token_addr, _, token_sac) = setup_bridge(&env, 500);
+        // No oracle or fiat limit set — deposit should work as before
+        let user = Address::generate(&env);
+        token_sac.mint(&user, &1000);
+        bridge.deposit(&user, &100, &token_addr, &Bytes::new(&env));
+        assert_eq!(bridge.get_balance(), 100);
+    }
+
+    #[test]
+    fn test_fiat_limit_set_but_no_oracle_fails() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (_, bridge, _, token_addr, _, token_sac) = setup_bridge(&env, 10_000);
+        // Set fiat limit but no oracle
+        bridge.set_fiat_limit(&1_000_000);
+        let user = Address::generate(&env);
+        token_sac.mint(&user, &5000);
+        let result = bridge.try_deposit(&user, &100, &token_addr, &Bytes::new(&env));
+        assert_eq!(result, Err(Ok(Error::OracleNotSet)));
+    }
 }


### PR DESCRIPTION
Add Soroban price oracle integration so the bridge can enforce a uniform fiat-value deposit limit across all whitelisted assets, rather than relying solely on per-token amount limits.

Contract changes (src/lib.rs):
- Add PriceOracle trait + OracleClient in new src/oracle.rs module
- Add ExceedsFiatLimit and OracleNotSet error variants
- Add UserDailyVolume struct for rolling 24h volume tracking
- Add DataKey::Oracle, DataKey::FiatLimit, DataKey::UserDailyVolume(Address)
- Add set_oracle(), set_fiat_limit(), get_oracle(), get_fiat_limit(), get_user_daily_volume() public functions
- Add validate_fiat_limit() private helper called during deposit: queries oracle for token price, computes USD cents value, checks rolling 24h user volume against the global fiat limit
- deposit() now calls validate_fiat_limit() after the per-token limit check (no-op when oracle/fiat limit are not configured)

Tests (src/test.rs):
- Add MockOracle contract returning $0.10 per token
- 8 new tests: set/get oracle, set/get fiat limit, deposit within limit, deposit exceeding limit, daily volume accumulation, window reset after 24h, no-fiat-limit passthrough, fiat-limit-without-oracle

All 43 tests pass. No change in behaviour for existing deployments that have not configured an oracle and fiat limit.

Closes #159
