### PR TITLE
feat(fiat-payout): lock quote for 120s with countdown and fix XLM pri…

### DIFF
--- a/dex_with_fiat_frontend/package-lock.json
+++ b/dex_with_fiat_frontend/package-lock.json
@@ -1022,6 +1022,7 @@
       "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright": "1.58.2"
       },
@@ -1506,6 +1507,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
       "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -1586,6 +1588,7 @@
       "integrity": "sha512-3MyiDfrfLeK06bi/g9DqJxP5pV74LNv4rFTyvGDmT3x2p1yp1lOd+qYZfiRPIOf/oON+WRZR5wxxuF85qOar+w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.35.1",
         "@typescript-eslint/types": "8.35.1",
@@ -2108,6 +2111,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3267,6 +3271,7 @@
       "integrity": "sha512-zmxXPNMOXmwm9E0yQLi5uqXHs7uq2UIiqEKo3Gq+3fwo1XrJ+hijAZImyF7hclW3E6oHz43Yk3RP8at6OTKflQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3441,6 +3446,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -3945,6 +3951,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -6648,6 +6655,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6657,6 +6665,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -7559,6 +7568,7 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7747,6 +7757,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/dex_with_fiat_frontend/src/components/BankDetailsModal.tsx
+++ b/dex_with_fiat_frontend/src/components/BankDetailsModal.tsx
@@ -14,8 +14,10 @@ import {
   Save,
   UserPlus,
   Star,
+  Clock,
+  RefreshCw,
 } from 'lucide-react';
-import { convertCryptoToFiat } from '@/lib/cryptoPriceService';
+import { fetchLockedQuote, type LockedQuote } from '@/lib/cryptoPriceService';
 import { useNotifications } from '@/hooks/useNotifications';
 import { useBeneficiaries, Beneficiary } from '@/hooks/useBeneficiaries';
 import { useTxHistory } from '@/hooks/useTxHistory';
@@ -99,8 +101,9 @@ export default function BankDetailsModal({
     useState<VerifyAccountData | null>(null);
 
   // Step 3 - confirm payout
-  const [ngnAmount, setNgnAmount] = useState<number | null>(null);
-  const [ngnLoading, setNgnLoading] = useState(false);
+  const [lockedQuote, setLockedQuote] = useState<LockedQuote | null>(null);
+  const [quoteLoading, setQuoteLoading] = useState(false);
+  const [quoteSecondsLeft, setQuoteSecondsLeft] = useState(120);
   const [payoutLoading, setPayoutLoading] = useState(false);
   const [payoutError, setPayoutError] = useState('');
   const [payoutNote, setPayoutNote] = useState('');
@@ -137,15 +140,38 @@ export default function BankDetailsModal({
       .finally(() => setBanksLoading(false));
   }, [isOpen]);
 
-  // Fetch NGN estimate when the user reaches step 3
+  // Fetch a locked quote when the user reaches step 3
+  const fetchQuote = useCallback(() => {
+    if (xlmAmount <= 0) return;
+    setQuoteLoading(true);
+    setLockedQuote(null);
+    fetchLockedQuote('XLM', xlmAmount, 'ngn')
+      .then((quote) => {
+        setLockedQuote(quote);
+        setQuoteSecondsLeft(120);
+      })
+      .catch(() => setLockedQuote(null))
+      .finally(() => setQuoteLoading(false));
+  }, [xlmAmount]);
+
   useEffect(() => {
-    if (step !== 3 || xlmAmount <= 0) return;
-    setNgnLoading(true);
-    convertCryptoToFiat('XLM', xlmAmount, 'ngn')
-      .then(setNgnAmount)
-      .catch(() => setNgnAmount(null))
-      .finally(() => setNgnLoading(false));
-  }, [step, xlmAmount]);
+    if (step !== 3) return;
+    fetchQuote();
+  }, [step, fetchQuote]);
+
+  // Countdown timer — ticks every second while the quote is live
+  useEffect(() => {
+    if (!lockedQuote || step !== 3) return;
+    const interval = setInterval(() => {
+      const remaining = Math.max(
+        0,
+        Math.ceil((lockedQuote.expiresAt - Date.now()) / 1000),
+      );
+      setQuoteSecondsLeft(remaining);
+      if (remaining === 0) clearInterval(interval);
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [lockedQuote, step]);
 
   const filteredBanks = banks.filter((b) =>
     b.name.toLowerCase().includes(bankSearch.toLowerCase()),
@@ -183,7 +209,7 @@ export default function BankDetailsModal({
   }, [accountNumber, selectedBank]);
 
   const handleConfirmPayout = async () => {
-    if (!selectedBank || !verifiedAccount) return;
+    if (!selectedBank || !verifiedAccount || !lockedQuote || quoteSecondsLeft === 0) return;
     setPayoutLoading(true);
     setPayoutError('');
     setStatusEvents([]);
@@ -219,7 +245,7 @@ export default function BankDetailsModal({
       // 2. Initiate the NGN bank transfer
       // The route handler multiplies the amount by 100 before calling Paystack,
       // so we send the NGN value directly (not kobo).
-      const ngnValue = ngnAmount ?? xlmAmount * 1000;
+      const ngnValue = lockedQuote.ngnAmount;
       const transferRes = await fetch('/api/initiate-transfer', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -249,13 +275,10 @@ export default function BankDetailsModal({
         status: 'completed',
         amount: String(xlmAmount),
         asset: 'XLM',
-        fiatAmount:
-          ngnAmount !== null
-            ? ngnAmount.toLocaleString('en-NG', {
-                minimumFractionDigits: 2,
-                maximumFractionDigits: 2,
-              })
-            : undefined,
+        fiatAmount: lockedQuote.ngnAmount.toLocaleString('en-NG', {
+          minimumFractionDigits: 2,
+          maximumFractionDigits: 2,
+        }),
         fiatCurrency: 'NGN',
         note: payoutNote.trim() || undefined,
         reference:
@@ -291,8 +314,9 @@ export default function BankDetailsModal({
     setVerifying(false);
     setVerifyError('');
     setVerifiedAccount(null);
-    setNgnAmount(null);
-    setNgnLoading(false);
+    setLockedQuote(null);
+    setQuoteLoading(false);
+    setQuoteSecondsLeft(120);
     setPayoutLoading(false);
     setPayoutError('');
     setPayoutNote('');
@@ -688,12 +712,12 @@ export default function BankDetailsModal({
 
               <div className="flex justify-between text-sm items-center">
                 <span className="theme-text-secondary">Estimated NGN</span>
-                {ngnLoading ? (
+                {quoteLoading ? (
                   <Loader2 className="w-4 h-4 text-blue-400 animate-spin" />
-                ) : ngnAmount !== null ? (
+                ) : lockedQuote !== null ? (
                   <span className="theme-text-primary font-medium">
                     ₦
-                    {ngnAmount.toLocaleString('en-NG', {
+                    {lockedQuote.ngnAmount.toLocaleString('en-NG', {
                       minimumFractionDigits: 2,
                       maximumFractionDigits: 2,
                     })}
@@ -702,6 +726,32 @@ export default function BankDetailsModal({
                   <span className="theme-text-muted">-</span>
                 )}
               </div>
+
+              {/* Quote lock countdown */}
+              {lockedQuote && (
+                <div className="flex items-center justify-between text-xs pt-1">
+                  <span className="theme-text-muted flex items-center gap-1">
+                    <Clock className="w-3 h-3" />
+                    Quote locked
+                  </span>
+                  {quoteSecondsLeft > 0 ? (
+                    <span
+                      className={`font-mono font-medium tabular-nums ${
+                        quoteSecondsLeft > 30
+                          ? 'text-green-400'
+                          : quoteSecondsLeft > 10
+                            ? 'text-yellow-400'
+                            : 'text-red-400'
+                      }`}
+                    >
+                      {String(Math.floor(quoteSecondsLeft / 60)).padStart(2, '0')}:
+                      {String(quoteSecondsLeft % 60).padStart(2, '0')}
+                    </span>
+                  ) : (
+                    <span className="text-red-400 font-medium">Expired</span>
+                  )}
+                </div>
+              )}
 
               <div className="theme-border border-t pt-3 space-y-3">
                 <div className="flex justify-between text-sm">
@@ -739,6 +789,25 @@ export default function BankDetailsModal({
               />
             </div>
 
+            {/* Quote expiry warning */}
+            {lockedQuote && quoteSecondsLeft === 0 && (
+              <div className="flex items-center justify-between gap-2 text-red-400 text-sm mb-4 bg-red-400/10 rounded-lg px-3 py-2 border border-red-400/30">
+                <div className="flex items-center gap-2">
+                  <AlertCircle className="w-4 h-4 flex-shrink-0" />
+                  <span>Quote expired. Refresh to continue.</span>
+                </div>
+                <button
+                  type="button"
+                  onClick={fetchQuote}
+                  disabled={quoteLoading}
+                  className="flex items-center gap-1 text-blue-400 hover:text-blue-300 whitespace-nowrap disabled:opacity-50"
+                >
+                  <RefreshCw className={`w-3.5 h-3.5 ${quoteLoading ? 'animate-spin' : ''}`} />
+                  Refresh
+                </button>
+              </div>
+            )}
+
             {payoutError && (
               <div className="theme-soft-danger flex items-center gap-2 text-sm mb-4 rounded-lg px-3 py-2 border">
                 <AlertCircle className="w-4 h-4 flex-shrink-0" />
@@ -758,7 +827,7 @@ export default function BankDetailsModal({
               <button
                 type="button"
                 onClick={handleConfirmPayout}
-                disabled={payoutLoading}
+                disabled={payoutLoading || quoteLoading || !lockedQuote || quoteSecondsLeft === 0}
                 className="theme-primary-button flex-1 flex items-center justify-center gap-2 disabled:bg-blue-800 disabled:opacity-70 text-white py-3 rounded-lg font-medium transition-colors"
               >
                 {payoutLoading ? (

--- a/dex_with_fiat_frontend/src/lib/cryptoPriceService.ts
+++ b/dex_with_fiat_frontend/src/lib/cryptoPriceService.ts
@@ -220,6 +220,33 @@ export function clearPriceCache(): void {
   priceCache.clear();
 }
 
+export const QUOTE_LOCK_DURATION_MS = 120 * 1000; // 120 seconds
+
+export interface LockedQuote {
+  ngnAmount: number;
+  lockedAt: number;
+  expiresAt: number;
+}
+
+/**
+ * Fetch a one-time fiat quote and lock it for QUOTE_LOCK_DURATION_MS.
+ * The returned object carries the expiry timestamp so the UI can
+ * drive a countdown and gate the final submit.
+ */
+export async function fetchLockedQuote(
+  tokenSymbol: string,
+  amount: number,
+  fiatCurrency: string = 'ngn',
+): Promise<LockedQuote> {
+  const ngnAmount = await convertCryptoToFiat(tokenSymbol, amount, fiatCurrency);
+  const lockedAt = Date.now();
+  return {
+    ngnAmount,
+    lockedAt,
+    expiresAt: lockedAt + QUOTE_LOCK_DURATION_MS,
+  };
+}
+
 /**
  * Format a fiat amount with the correct locale and currency symbol.
  * Falls back to a plain number string if Intl is unavailable.


### PR DESCRIPTION
## Summary

- **Quote Lock Countdown**: When a user reaches the review step (Step 3) of the fiat payout process, the exchange rate from XLM to NGN is fetched once and locked for **120 seconds**. A timer in the format of `MM:SS` is displayed inside the summary card, changing colors from green to yellow to red as the countdown progresses. Once the time expires, the Confirm button becomes disabled, and a banner prompts the user to refresh the quote before submitting.

- **XLM Price Lookup Verified**: The `XLM: 'stellar'` entry is confirmed to be present in `TOKEN_IDS` and `fallbackPrices`, with `ngn: 180` set as a safety-net value. This ensures that the function `convertCryptoToFiat('XLM', ...)` never silently returns a value of 0.

close #23 
close #40 