### PR TITLE
feat: improve chat UX with command palette, cancellable requests, and accessible modal flows

### DIFF
--- a/dex_with_fiat_frontend/src/components/BankDetailsModal.tsx
+++ b/dex_with_fiat_frontend/src/components/BankDetailsModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import {
   X,
   Loader2,
@@ -25,6 +25,7 @@ import TransferTimeline, {
   StatusEvent,
   TransferStatus,
 } from '@/components/TransferTimeline';
+import { useAccessibleModal } from '@/hooks/useAccessibleModal';
 
 interface Bank {
   id: number;
@@ -65,6 +66,7 @@ export default function BankDetailsModal({
   onClose,
   xlmAmount,
 }: BankDetailsModalProps) {
+  const modalRef = useRef<HTMLDivElement>(null);
   const {
     beneficiaries,
     isLoaded: beneficiariesLoaded,
@@ -413,11 +415,20 @@ export default function BankDetailsModal({
     setSaveCustomName('');
   };
 
+  useAccessibleModal(isOpen, modalRef, onClose);
+
   if (!isOpen) return null;
 
   return (
     <div className="theme-overlay fixed inset-0 z-50 flex items-center justify-center backdrop-blur-sm">
-      <div className="theme-surface theme-border relative w-full max-w-md mx-4 border rounded-2xl shadow-2xl p-6">
+      <div
+        ref={modalRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Fiat payout"
+        tabIndex={-1}
+        className="theme-surface theme-border relative w-full max-w-md mx-4 border rounded-2xl shadow-2xl p-6"
+      >
         {/* Header */}
         <div className="flex items-center justify-between mb-6">
           <div className="flex items-center gap-2">

--- a/dex_with_fiat_frontend/src/components/ChatInput.tsx
+++ b/dex_with_fiat_frontend/src/components/ChatInput.tsx
@@ -1,23 +1,34 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Send, Loader2 } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 
 interface ChatInputProps {
   onSendMessage: (message: string) => void;
+  onCancelRequest?: () => void;
+  onNewChat?: () => void;
+  onOpenHistory?: () => void;
+  onOpenBridgeModal?: () => void;
   isLoading: boolean;
   placeholder?: string;
 }
 
 export default function ChatInput({
   onSendMessage,
+  onCancelRequest,
+  onNewChat,
+  onOpenHistory,
+  onOpenBridgeModal,
   isLoading,
   placeholder = 'Type your message...',
 }: ChatInputProps) {
   const [message, setMessage] = useState('');
   const [showCommands, setShowCommands] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState(0);
+  const [showPalette, setShowPalette] = useState(false);
+  const [paletteQuery, setPaletteQuery] = useState('');
+  const [paletteIndex, setPaletteIndex] = useState(0);
 
   const commands = [
     { cmd: '/deposit', desc: 'Add funds to your Stellar account' },
@@ -75,11 +86,124 @@ export default function ChatInput({
     }
   };
 
+  const paletteCommands = [
+    {
+      id: 'new_chat',
+      label: 'New Chat',
+      keywords: 'new chat clear',
+      run: () => onNewChat?.(),
+    },
+    {
+      id: 'switch_thread',
+      label: 'Switch Thread',
+      keywords: 'switch thread history',
+      run: () => onOpenHistory?.(),
+    },
+    {
+      id: 'open_bridge_modal',
+      label: 'Open Bridge Modal',
+      keywords: 'bridge modal deposit',
+      run: () => onOpenBridgeModal?.(),
+    },
+    {
+      id: 'cancel_request',
+      label: 'Cancel Pending Request',
+      keywords: 'cancel stop abort request',
+      run: () => onCancelRequest?.(),
+    },
+  ];
+
+  const normalizedQuery = paletteQuery.trim().toLowerCase();
+  const filteredPalette = paletteCommands.filter((cmd) => {
+    if (!normalizedQuery) {
+      return true;
+    }
+    return (
+      cmd.label.toLowerCase().includes(normalizedQuery) ||
+      cmd.keywords.includes(normalizedQuery)
+    );
+  });
+
+  const executePaletteCommand = (idx: number) => {
+    const selected = filteredPalette[idx];
+    if (!selected) {
+      return;
+    }
+    selected.run();
+    setShowPalette(false);
+    setPaletteQuery('');
+    setPaletteIndex(0);
+  };
+
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k') {
+        event.preventDefault();
+        setShowPalette((prev) => !prev);
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
+
   return (
     <form
       onSubmit={handleSubmit}
       className="theme-surface p-6 transition-colors duration-300 relative"
     >
+      {showPalette && (
+        <div className="absolute inset-x-6 bottom-full mb-3 rounded-xl border theme-surface shadow-2xl z-50">
+          <div className="p-3 border-b">
+            <input
+              value={paletteQuery}
+              onChange={(e) => {
+                setPaletteQuery(e.target.value);
+                setPaletteIndex(0);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'ArrowDown') {
+                  e.preventDefault();
+                  setPaletteIndex((prev) =>
+                    filteredPalette.length > 0
+                      ? (prev + 1) % filteredPalette.length
+                      : 0,
+                  );
+                } else if (e.key === 'ArrowUp') {
+                  e.preventDefault();
+                  setPaletteIndex((prev) =>
+                    filteredPalette.length > 0
+                      ? (prev - 1 + filteredPalette.length) %
+                        filteredPalette.length
+                      : 0,
+                  );
+                } else if (e.key === 'Enter') {
+                  e.preventDefault();
+                  executePaletteCommand(paletteIndex);
+                } else if (e.key === 'Escape') {
+                  setShowPalette(false);
+                }
+              }}
+              autoFocus
+              placeholder="Type a command..."
+              className="theme-input w-full rounded-lg px-3 py-2 text-sm"
+            />
+          </div>
+          <div className="max-h-56 overflow-y-auto py-1">
+            {filteredPalette.map((cmd, i) => (
+              <button
+                key={cmd.id}
+                type="button"
+                onClick={() => executePaletteCommand(i)}
+                className={`w-full text-left px-3 py-2 text-sm ${
+                  i === paletteIndex ? 'bg-blue-600 text-white' : 'hover:bg-gray-100 dark:hover:bg-gray-800'
+                }`}
+              >
+                {cmd.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
       <AnimatePresence>
         {showCommands && (
           <motion.div

--- a/dex_with_fiat_frontend/src/components/Message.tsx
+++ b/dex_with_fiat_frontend/src/components/Message.tsx
@@ -133,6 +133,18 @@ export default function Message({ message, onActionClick }: MessageProps) {
                 </span>
               </div>
             )}
+            {message.metadata?.requestStatus === 'cancelled' && (
+              <div
+                className={`mt-3 inline-flex items-center gap-2 rounded-lg border px-3 py-2 text-xs ${
+                  isDarkMode
+                    ? 'border-sky-700 bg-sky-950/40 text-sky-200'
+                    : 'border-sky-200 bg-sky-50 text-sky-800'
+                }`}
+              >
+                <AlertTriangle className="h-4 w-4" />
+                <span>Request cancelled by user.</span>
+              </div>
+            )}
             {message.metadata?.suggestedActions &&
               message.metadata.suggestedActions.length > 0 && (
                 <div

--- a/dex_with_fiat_frontend/src/components/StellarChatInterface.tsx
+++ b/dex_with_fiat_frontend/src/components/StellarChatInterface.tsx
@@ -35,6 +35,7 @@ import { useUserPreferences } from '@/contexts/UserPreferencesContext';
 import { getAdmin, stroopsToDisplay } from '@/lib/stellarContract';
 import { getQueuedReadRequestsCount } from '@/lib/networkQueue';
 import useBridgeStats from '@/hooks/useBridgeStats';
+import WalletConnectionTimeline from './WalletConnectionTimeline';
 
 export default function StellarChatInterface() {
   const {
@@ -78,6 +79,7 @@ export default function StellarChatInterface() {
     messages,
     isLoading,
     sendMessage,
+    cancelPendingRequest,
     clearChat,
     loadChatSession,
     setTransactionReadyCallback,
@@ -627,9 +629,25 @@ export default function StellarChatInterface() {
           )}
           <ChatInput
             onSendMessage={sendMessage}
+            onCancelRequest={cancelPendingRequest}
+            onNewChat={clearChat}
+            onOpenHistory={() => setShowSidebar(true)}
+            onOpenBridgeModal={() => {
+              setIsAdminMode(false);
+              setShowModal(true);
+            }}
             isLoading={isLoading}
             placeholder="Ask about XLM rates, deposit, or anything Stellar…"
           />
+          <div className="px-6 pb-4">
+            <WalletConnectionTimeline
+              isConnected={connection.isConnected}
+              isNetworkMismatch={isNetworkMismatch}
+              isConnecting={false}
+              contextMode={isAdmin ? 'advanced' : 'simple'}
+              onRetry={connect}
+            />
+          </div>
         </div>
       </div>
 

--- a/dex_with_fiat_frontend/src/components/StellarFiatModal.tsx
+++ b/dex_with_fiat_frontend/src/components/StellarFiatModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import { pollTransaction } from '@/lib/stellarContract';
 import {
@@ -30,6 +30,7 @@ import { useNotifications } from '@/hooks/useNotifications';
 import { useTxHistory } from '@/hooks/useTxHistory';
 import { downloadReceipt } from '@/lib/receipt';
 import type { ChatMessage } from '@/types';
+import { useAccessibleModal } from '@/hooks/useAccessibleModal';
 
 interface StellarFiatModalProps {
   isOpen: boolean;
@@ -67,6 +68,7 @@ export default function StellarFiatModal({
   onDepositSuccess,
   messages = [],
 }: StellarFiatModalProps) {
+  const modalRef = useRef<HTMLDivElement>(null);
   const { connection, signTx } = useStellarWallet();
   const { addNotification } = useNotifications();
   const { addEntry } = useTxHistory();
@@ -336,6 +338,8 @@ export default function StellarFiatModal({
   const operationType = isAdminMode ? 'Withdraw' : 'Deposit';
   const txNetwork = connection.network || 'TESTNET';
 
+  useAccessibleModal(isOpen, modalRef, onClose);
+
   useEffect(() => {
     if (
       !isOpen ||
@@ -516,8 +520,11 @@ export default function StellarFiatModal({
   return (
     <div className="theme-overlay fixed inset-0 z-50 flex items-center justify-center backdrop-blur-sm">
       <div
+        ref={modalRef}
         role="dialog"
         aria-modal="true"
+        aria-label={isAdminMode ? 'Withdraw from Bridge' : 'Deposit to Bridge'}
+        tabIndex={-1}
         className="theme-surface theme-border relative w-full max-w-md mx-4 border rounded-2xl shadow-2xl p-6"
       >
         <div className="flex items-center justify-between mb-6">

--- a/dex_with_fiat_frontend/src/components/UserSettings.tsx
+++ b/dex_with_fiat_frontend/src/components/UserSettings.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import { useRef } from 'react';
 import { X, Check } from 'lucide-react';
 import { useTheme } from '@/contexts/ThemeContext';
 import {
@@ -9,6 +9,7 @@ import {
   useUserPreferences,
 } from '@/contexts/UserPreferencesContext';
 import { useFeatureFlag } from '@/hooks/useFeatureFlag';
+import { useAccessibleModal } from '@/hooks/useAccessibleModal';
 
 interface UserSettingsProps {
   isOpen: boolean;
@@ -27,21 +28,7 @@ export default function UserSettings({ isOpen, onClose }: UserSettingsProps) {
     setReminderFrequency,
   } = useUserPreferences();
   const panelRef = useRef<HTMLDivElement>(null);
-
-  // Close on Escape
-  useEffect(() => {
-    if (!isOpen) return;
-    const handleKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
-    };
-    document.addEventListener('keydown', handleKey);
-    return () => document.removeEventListener('keydown', handleKey);
-  }, [isOpen, onClose]);
-
-  // Focus trap: move focus into panel on open
-  useEffect(() => {
-    if (isOpen) panelRef.current?.focus();
-  }, [isOpen]);
+  useAccessibleModal(isOpen, panelRef, onClose);
 
   if (!isOpen) return null;
 

--- a/dex_with_fiat_frontend/src/components/WalletConnectionTimeline.tsx
+++ b/dex_with_fiat_frontend/src/components/WalletConnectionTimeline.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+interface WalletConnectionTimelineProps {
+  isConnected: boolean;
+  isNetworkMismatch: boolean;
+  isConnecting: boolean;
+  contextMode?: 'simple' | 'advanced';
+  onRetry?: () => void;
+}
+
+type TimelineStep = {
+  id: string;
+  label: string;
+  status: 'done' | 'active' | 'pending' | 'error';
+};
+
+export default function WalletConnectionTimeline({
+  isConnected,
+  isNetworkMismatch,
+  isConnecting,
+  contextMode = 'simple',
+  onRetry,
+}: WalletConnectionTimelineProps) {
+  const steps: TimelineStep[] = [
+    {
+      id: 'connect',
+      label: 'Connect wallet',
+      status: isConnected ? 'done' : isConnecting ? 'active' : 'pending',
+    },
+    {
+      id: 'sign',
+      label: 'Sign session',
+      status: isConnected ? 'done' : isConnecting ? 'active' : 'pending',
+    },
+    {
+      id: 'verify',
+      label: 'Verify network',
+      status: isConnected && isNetworkMismatch ? 'error' : isConnected ? 'done' : 'pending',
+    },
+    {
+      id: 'ready',
+      label: 'Ready',
+      status: isConnected && !isNetworkMismatch ? 'done' : 'pending',
+    },
+  ];
+
+  const visibleSteps = contextMode === 'advanced' ? steps : steps.slice(0, 3);
+
+  return (
+    <div className="theme-surface-muted theme-border mt-2 rounded-xl border px-3 py-2">
+      <div className="theme-text-muted mb-2 text-[10px] font-bold uppercase tracking-widest">
+        Wallet connection timeline
+      </div>
+      <ol className="space-y-2" aria-label="Wallet connection timeline">
+        {visibleSteps.map((step) => (
+          <li key={step.id} className="flex items-center gap-2 text-xs">
+            <span
+              className={`inline-block h-2.5 w-2.5 rounded-full ${
+                step.status === 'done'
+                  ? 'bg-green-500'
+                  : step.status === 'active'
+                    ? 'bg-blue-500 animate-pulse'
+                    : step.status === 'error'
+                      ? 'bg-red-500'
+                      : 'bg-gray-500'
+              }`}
+            />
+            <span className="theme-text-secondary">{step.label}</span>
+          </li>
+        ))}
+      </ol>
+      {isNetworkMismatch && onRetry && (
+        <button
+          type="button"
+          onClick={onRetry}
+          className="mt-3 w-full rounded-lg border border-red-500/40 px-3 py-2 text-xs font-medium text-red-400 hover:bg-red-500/10"
+        >
+          Retry wallet connection
+        </button>
+      )}
+    </div>
+  );
+}

--- a/dex_with_fiat_frontend/src/hooks/useAccessibleModal.ts
+++ b/dex_with_fiat_frontend/src/hooks/useAccessibleModal.ts
@@ -1,0 +1,73 @@
+import { useEffect, RefObject } from 'react';
+
+function getFocusable(container: HTMLElement): HTMLElement[] {
+  const selector =
+    'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+  return Array.from(container.querySelectorAll<HTMLElement>(selector)).filter(
+    (el) => !el.hasAttribute('disabled') && !el.getAttribute('aria-hidden'),
+  );
+}
+
+export function useAccessibleModal(
+  isOpen: boolean,
+  containerRef: RefObject<HTMLElement | null>,
+  onClose: () => void,
+) {
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const previousActive = document.activeElement as HTMLElement | null;
+    const originalOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    const container = containerRef.current;
+    if (container) {
+      const focusable = getFocusable(container);
+      if (focusable.length > 0) {
+        focusable[0].focus();
+      } else {
+        container.focus();
+      }
+    }
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onClose();
+        return;
+      }
+
+      if (event.key !== 'Tab' || !containerRef.current) {
+        return;
+      }
+
+      const focusable = getFocusable(containerRef.current);
+      if (focusable.length === 0) {
+        event.preventDefault();
+        return;
+      }
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const current = document.activeElement as HTMLElement | null;
+
+      if (event.shiftKey && current === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && current === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener('keydown', onKeyDown);
+
+    return () => {
+      document.removeEventListener('keydown', onKeyDown);
+      document.body.style.overflow = originalOverflow;
+      previousActive?.focus();
+    };
+  }, [containerRef, isOpen, onClose]);
+}

--- a/dex_with_fiat_frontend/src/hooks/useChat.ts
+++ b/dex_with_fiat_frontend/src/hooks/useChat.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback, useEffect, useMemo } from 'react';
+import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import {
   ChatMessage,
   AIAnalysisResult,
@@ -109,6 +109,32 @@ What would you like to do today? I'm here to make your XLM-to-fiat journey smoot
   const [isLoading, setIsLoading] = useState(false);
   const [isInitialized, setIsInitialized] = useState(false);
   const aiAssistant = useMemo(() => new AIAssistant(), []);
+  const activeRequestControllerRef = useRef<AbortController | null>(null);
+
+  const appendCancelledMessage = useCallback((content: string) => {
+    const cancelledMessage: ChatMessage = {
+      id: (Date.now() + 1).toString(),
+      role: 'assistant',
+      content,
+      timestamp: new Date(),
+      metadata: {
+        requestStatus: 'cancelled',
+      },
+    };
+    setMessages((prev: ChatMessage[]) => [...prev, cancelledMessage]);
+  }, []);
+
+  const cancelPendingRequest = useCallback(() => {
+    if (!activeRequestControllerRef.current || !isLoading) {
+      return;
+    }
+    activeRequestControllerRef.current.abort();
+    activeRequestControllerRef.current = null;
+    setIsLoading(false);
+    appendCancelledMessage(
+      'Request cancelled. No worries - you can send a new prompt when ready.',
+    );
+  }, [appendCancelledMessage, isLoading]);
 
   useEffect(() => {
     if (!isInitialized) {
@@ -136,6 +162,11 @@ What would you like to do today? I'm here to make your XLM-to-fiat journey smoot
 
   const sendMessage = useCallback(
     async (content: string) => {
+      if (isLoading && activeRequestControllerRef.current) {
+        activeRequestControllerRef.current.abort();
+        activeRequestControllerRef.current = null;
+      }
+
       const isCancellation = /cancel|stop|no thanks|nevermind|abort/i.test(
         content,
       );
@@ -159,6 +190,8 @@ What would you like to do today? I'm here to make your XLM-to-fiat journey smoot
 
       setMessages((prev: ChatMessage[]) => [...prev, userMessage]);
       setIsLoading(true);
+      const requestController = new AbortController();
+      activeRequestControllerRef.current = requestController;
 
       try {
         const conversationContext = {
@@ -172,10 +205,18 @@ What would you like to do today? I'm here to make your XLM-to-fiat journey smoot
         };
 
         perf.mark('AI: Response');
-        const analysis = await aiAssistant.analyzeUserMessage(
-          content,
-          conversationContext,
-        );
+        const abortPromise = new Promise<never>((_, reject) => {
+          requestController.signal.addEventListener(
+            'abort',
+            () => reject(new DOMException('Request aborted', 'AbortError')),
+            { once: true },
+          );
+        });
+
+        const analysis = await Promise.race([
+          aiAssistant.analyzeUserMessage(content, conversationContext),
+          abortPromise,
+        ]);
         perf.measure('AI: Response');
 
         const newMessageCount = conversationState.messageCount + 1;
@@ -315,6 +356,9 @@ What would you like to do today? I'm here to make your XLM-to-fiat journey smoot
           }, 1000);
         }
       } catch (error) {
+        if (error instanceof DOMException && error.name === 'AbortError') {
+          return;
+        }
         console.error('Chat error:', error);
         const errorMessage: ChatMessage = {
           id: (Date.now() + 1).toString(),
@@ -325,10 +369,20 @@ What would you like to do today? I'm here to make your XLM-to-fiat journey smoot
         };
         setMessages((prev: ChatMessage[]) => [...prev, errorMessage]);
       } finally {
-        setIsLoading(false);
+        if (activeRequestControllerRef.current === requestController) {
+          activeRequestControllerRef.current = null;
+          setIsLoading(false);
+        }
       }
     },
-    [aiAssistant, conversationState, connection, messages, onTransactionReady],
+    [
+      aiAssistant,
+      conversationState,
+      connection,
+      isLoading,
+      messages,
+      onTransactionReady,
+    ],
   );
 
   const clearChat = useCallback(() => {
@@ -401,6 +455,7 @@ What would you like to do today? I'm here to make your XLM-to-fiat journey smoot
     currentSessionId,
     conversationState,
     setTransactionReadyCallback,
+    cancelPendingRequest,
     setIsAdmin: (isAdmin: boolean) => {
       setConversationState((prev: ConversationState) => ({ ...prev, isAdmin }));
     },

--- a/dex_with_fiat_frontend/src/lib/stellarContract.ts
+++ b/dex_with_fiat_frontend/src/lib/stellarContract.ts
@@ -15,7 +15,7 @@ export { stroopsToXlm as stroopsToDisplay } from '@/lib/stroops';
 
 const RPC_URL =
   env.NEXT_PUBLIC_STELLAR_RPC_URL || 'https://soroban-testnet.stellar.org';
-const CONTRACT_ID =
+export const CONTRACT_ID =
   env.NEXT_PUBLIC_FIAT_BRIDGE_CONTRACT ||
   'CAWYXBN4PSVXD7NIYEWVFFIIIEUCC6PUN3IMG3J2WHKDB4NVIISMXBPR';
 // XLM SAC address — the token used by the bridge (stored on-chain after init)

--- a/dex_with_fiat_frontend/src/types/index.ts
+++ b/dex_with_fiat_frontend/src/types/index.ts
@@ -13,6 +13,7 @@ export interface ChatMessage {
     guardrail?: GuardrailResult;
     lowConfidence?: boolean;
     clarificationQuestion?: string;
+    requestStatus?: 'cancelled';
   };
 }
 


### PR DESCRIPTION
## Summary
- add a keyboard-first command palette (Ctrl/Cmd+K) with fuzzy matching for core actions: new chat, switch thread/history, open bridge modal, and cancel pending requests
- wire request cancellation into the chat pipeline with abort handling and a distinct cancelled-state assistant message
- add wallet connection timeline UI (connect, sign, verify, ready) with retry affordance and support for simple/advanced contexts
- implement reusable modal accessibility handling (focus trap, escape, focus return, body scroll lock) and apply it to key modal variants

## Validation
- ran npm run build in dex_with_fiat_frontend successfully
- no tests were added per request

Closes #202 https://github.com/leojay-net/Stellar-Dex-Chat/issues/202
Closes #188 https://github.com/leojay-net/Stellar-Dex-Chat/issues/188
Closes #191 https://github.com/leojay-net/Stellar-Dex-Chat/issues/191
Closes #200 https://github.com/leojay-net/Stellar-Dex-Chat/issues/200