### PR TITLE
feat: add per-thread pinning and priority ordering

### DIFF
--- a/dex_with_fiat_frontend/src/components/ChatHistorySidebar.tsx
+++ b/dex_with_fiat_frontend/src/components/ChatHistorySidebar.tsx
@@ -12,8 +12,87 @@ import {
   Plus,
   Download,
   Coins,
+  Pin,
+  PinOff,
 } from 'lucide-react';
 import SkeletonSidebar from '@/components/ui/skeleton/SkeletonSidebar';
+
+import { ChatSession } from '@/types';
+
+interface SessionRowProps {
+  session: ChatSession;
+  isActive: boolean;
+  onLoad: (id: string) => void;
+  onExport: (id: string) => void;
+  onDelete: (id: string) => void;
+  onTogglePin: (id: string) => void;
+  formatDate: (d: Date) => string;
+}
+
+function SessionRow({
+  session,
+  isActive,
+  onLoad,
+  onExport,
+  onDelete,
+  onTogglePin,
+  formatDate,
+}: SessionRowProps) {
+  return (
+    <div
+      className={`group relative p-3 mb-2 rounded-lg cursor-pointer transition-all duration-200 border ${
+        isActive
+          ? 'bg-[var(--color-primary-soft)] border-[var(--color-primary)] shadow-md'
+          : 'border-transparent hover:border-[var(--color-border)] hover:bg-[var(--color-surface-muted)]'
+      }`}
+      onClick={() => onLoad(session.id)}
+    >
+      <div className="flex items-start justify-between">
+        <div className="flex-1 min-w-0">
+          <h3 className="theme-text-primary text-sm font-medium truncate">
+            {session.title || 'New Conversation'}
+          </h3>
+          <div className="theme-text-muted flex items-center mt-1 text-xs">
+            <Clock className="w-3 h-3 mr-1" />
+            <span>
+              {formatDate(session.lastUpdated || session.createdAt || new Date())}
+            </span>
+            <span className="ml-2">{session.messages?.length || 0} messages</span>
+          </div>
+          {session.messages && session.messages.length > 0 && (
+            <p className="theme-text-secondary text-xs mt-1 truncate">
+              {session.messages[session.messages.length - 1]?.content?.substring(0, 50)}...
+            </p>
+          )}
+        </div>
+
+        <div className="flex items-center space-x-1 opacity-0 group-hover:opacity-100 transition-opacity">
+          <button
+            onClick={(e) => { e.stopPropagation(); onTogglePin(session.id); }}
+            className="theme-text-muted hover:bg-[var(--color-primary-soft)] p-1 rounded transition-all hover:scale-110"
+            title={session.pinned ? 'Unpin conversation' : 'Pin conversation'}
+          >
+            {session.pinned ? <PinOff className="w-3 h-3" /> : <Pin className="w-3 h-3" />}
+          </button>
+          <button
+            onClick={(e) => { e.stopPropagation(); onExport(session.id); }}
+            className="theme-text-muted hover:bg-[var(--color-primary-soft)] p-1 rounded transition-all hover:scale-110"
+            title="Export conversation"
+          >
+            <Download className="w-3 h-3" />
+          </button>
+          <button
+            onClick={(e) => { e.stopPropagation(); onDelete(session.id); }}
+            className="theme-text-muted hover:bg-[var(--color-danger-soft)] p-1 rounded transition-all hover:scale-110"
+            title="Delete conversation"
+          >
+            <Trash2 className="w-3 h-3" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
 
 interface ChatHistorySidebarProps {
   onLoadSession: (sessionId: string) => void;
@@ -25,12 +104,14 @@ export default function ChatHistorySidebar({
   onClose,
 }: ChatHistorySidebarProps) {
   const {
-    sessions,
+    pinnedSessions,
+    unpinnedSessions,
     currentSessionId,
     deleteSession,
     clearAllHistory,
     exportSession,
     searchSessions,
+    togglePin,
     hasHistory,
   } = useChatHistory();
   const { entries, exportEntries, clearEntries, updateEntry } = useTxHistory();
@@ -46,7 +127,10 @@ export default function ChatHistorySidebar({
     return () => clearTimeout(timer);
   }, []);
 
-  const filteredSessions = searchQuery ? searchSessions(searchQuery) : sessions;
+  const allSessions = [...pinnedSessions, ...unpinnedSessions];
+  const filteredSessions = searchQuery ? searchSessions(searchQuery) : allSessions;
+  const filteredPinned = filteredSessions.filter((s) => s.pinned);
+  const filteredUnpinned = filteredSessions.filter((s) => !s.pinned);
 
   const handleDeleteSession = (sessionId: string) => {
     deleteSession(sessionId);
@@ -165,68 +249,41 @@ export default function ChatHistorySidebar({
           </div>
         ) : (
           <div className="p-2">
-            {filteredSessions.map((session) => (
-              <div
+            {filteredPinned.length > 0 && (
+              <>
+                <p className="theme-text-muted text-xs font-semibold uppercase tracking-wider px-1 py-1 mt-1">
+                  Pinned
+                </p>
+                {filteredPinned.map((session) => (
+                  <SessionRow
+                    key={session.id}
+                    session={session}
+                    isActive={currentSessionId === session.id}
+                    onLoad={onLoadSession}
+                    onExport={handleExportSession}
+                    onDelete={(id) => setShowDeleteConfirm(id)}
+                    onTogglePin={togglePin}
+                    formatDate={formatDate}
+                  />
+                ))}
+                {filteredUnpinned.length > 0 && (
+                  <p className="theme-text-muted text-xs font-semibold uppercase tracking-wider px-1 py-1 mt-3">
+                    Recent
+                  </p>
+                )}
+              </>
+            )}
+            {filteredUnpinned.map((session) => (
+              <SessionRow
                 key={session.id}
-                className={`group relative p-3 mb-2 rounded-lg cursor-pointer transition-all duration-200 border ${
-                  currentSessionId === session.id
-                    ? 'bg-[var(--color-primary-soft)] border-[var(--color-primary)] shadow-md'
-                    : 'border-transparent hover:border-[var(--color-border)] hover:bg-[var(--color-surface-muted)]'
-                }`}
-                onClick={() => onLoadSession(session.id)}
-              >
-                <div className="flex items-start justify-between">
-                  <div className="flex-1 min-w-0">
-                    <h3 className="theme-text-primary text-sm font-medium truncate">
-                      {session.title || 'New Conversation'}
-                    </h3>
-                    <div className="theme-text-muted flex items-center mt-1 text-xs">
-                      <Clock className="w-3 h-3 mr-1" />
-                      <span>
-                        {formatDate(
-                          session.lastUpdated ||
-                            session.createdAt ||
-                            new Date(),
-                        )}
-                      </span>
-                      <span className="ml-2">
-                        {session.messages?.length || 0} messages
-                      </span>
-                    </div>
-                    {session.messages && session.messages.length > 0 && (
-                      <p className="theme-text-secondary text-xs mt-1 truncate">
-                        {session.messages[
-                          session.messages.length - 1
-                        ]?.content?.substring(0, 50)}
-                        ...
-                      </p>
-                    )}
-                  </div>
-
-                  <div className="flex items-center space-x-1 opacity-0 group-hover:opacity-100 transition-opacity">
-                    <button
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        handleExportSession(session.id);
-                      }}
-                      className="theme-text-muted hover:bg-[var(--color-primary-soft)] p-1 rounded transition-all hover:scale-110"
-                      title="Export conversation"
-                    >
-                      <Download className="w-3 h-3" />
-                    </button>
-                    <button
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        setShowDeleteConfirm(session.id);
-                      }}
-                      className="theme-text-muted hover:bg-[var(--color-danger-soft)] p-1 rounded transition-all hover:scale-110"
-                      title="Delete conversation"
-                    >
-                      <Trash2 className="w-3 h-3" />
-                    </button>
-                  </div>
-                </div>
-              </div>
+                session={session}
+                isActive={currentSessionId === session.id}
+                onLoad={onLoadSession}
+                onExport={handleExportSession}
+                onDelete={(id) => setShowDeleteConfirm(id)}
+                onTogglePin={togglePin}
+                formatDate={formatDate}
+              />
             ))}
           </div>
         )}

--- a/dex_with_fiat_frontend/src/hooks/useChatHistory.test.ts
+++ b/dex_with_fiat_frontend/src/hooks/useChatHistory.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import { ChatSession } from '@/types';
+
+// Pure utility tests for pin ordering logic (mirrors useChatHistory internals)
+
+function sortSessions(sessions: ChatSession[]): ChatSession[] {
+  return [...sessions].sort((a, b) => {
+    if (a.pinned && !b.pinned) return -1;
+    if (!a.pinned && b.pinned) return 1;
+    if (a.pinned && b.pinned) {
+      return (b.pinnedAt?.getTime() ?? 0) - (a.pinnedAt?.getTime() ?? 0);
+    }
+    return new Date(b.lastUpdated).getTime() - new Date(a.lastUpdated).getTime();
+  });
+}
+
+function makeSession(overrides: Partial<ChatSession> = {}): ChatSession {
+  const now = new Date();
+  return {
+    id: Math.random().toString(36).slice(2),
+    title: 'Test',
+    messages: [],
+    createdAt: now,
+    lastUpdated: now,
+    ...overrides,
+  };
+}
+
+describe('Thread pinning ordering', () => {
+  it('pinned sessions appear before unpinned ones', () => {
+    const older = makeSession({ lastUpdated: new Date('2024-01-01') });
+    const pinned = makeSession({
+      pinned: true,
+      pinnedAt: new Date('2024-06-01'),
+      lastUpdated: new Date('2024-01-01'),
+    });
+    const recent = makeSession({ lastUpdated: new Date('2024-12-01') });
+
+    const sorted = sortSessions([recent, older, pinned]);
+
+    expect(sorted[0].id).toBe(pinned.id);
+  });
+
+  it('multiple pinned sessions are sorted by pinnedAt descending', () => {
+    const first = makeSession({
+      pinned: true,
+      pinnedAt: new Date('2024-09-01'),
+      lastUpdated: new Date('2024-01-01'),
+    });
+    const second = makeSession({
+      pinned: true,
+      pinnedAt: new Date('2024-06-01'),
+      lastUpdated: new Date('2024-01-01'),
+    });
+
+    const sorted = sortSessions([second, first]);
+
+    expect(sorted[0].id).toBe(first.id);
+    expect(sorted[1].id).toBe(second.id);
+  });
+
+  it('unpinned sessions are sorted by lastUpdated descending', () => {
+    const older = makeSession({ lastUpdated: new Date('2024-01-01') });
+    const newer = makeSession({ lastUpdated: new Date('2024-12-01') });
+
+    const sorted = sortSessions([older, newer]);
+
+    expect(sorted[0].id).toBe(newer.id);
+    expect(sorted[1].id).toBe(older.id);
+  });
+
+  it('toggling pin sets pinned=true and pinnedAt', () => {
+    const session = makeSession({ pinned: false });
+    const now = new Date();
+
+    const toggled: ChatSession = {
+      ...session,
+      pinned: true,
+      pinnedAt: now,
+    };
+
+    expect(toggled.pinned).toBe(true);
+    expect(toggled.pinnedAt).toBe(now);
+  });
+
+  it('toggling pin off clears pinned and pinnedAt', () => {
+    const session = makeSession({ pinned: true, pinnedAt: new Date() });
+
+    const toggled: ChatSession = {
+      ...session,
+      pinned: false,
+      pinnedAt: undefined,
+    };
+
+    expect(toggled.pinned).toBe(false);
+    expect(toggled.pinnedAt).toBeUndefined();
+  });
+
+  it('sessions with no pinned field are treated as unpinned', () => {
+    const noPinField = makeSession({ lastUpdated: new Date('2024-12-01') });
+    const pinned = makeSession({ pinned: true, pinnedAt: new Date('2024-06-01') });
+
+    const sorted = sortSessions([noPinField, pinned]);
+
+    expect(sorted[0].id).toBe(pinned.id);
+    expect(sorted[1].id).toBe(noPinField.id);
+  });
+});

--- a/dex_with_fiat_frontend/src/hooks/useChatHistory.ts
+++ b/dex_with_fiat_frontend/src/hooks/useChatHistory.ts
@@ -148,9 +148,43 @@ export const useChatHistory = () => {
     );
   }, [historyState.currentSessionId, historyState.sessions]);
 
+  const togglePin = useCallback((sessionId: string) => {
+    setHistoryState((prev) => {
+      const idx = prev.sessions.findIndex((s) => s.id === sessionId);
+      if (idx === -1) return prev;
+
+      const session = prev.sessions[idx];
+      const nowPinned = !session.pinned;
+      const updatedSession: ChatSession = {
+        ...session,
+        pinned: nowPinned,
+        pinnedAt: nowPinned ? new Date() : undefined,
+      };
+
+      const updated = [...prev.sessions];
+      updated[idx] = updatedSession;
+      return { ...prev, sessions: updated };
+    });
+  }, []);
+
+  // Pinned sessions first (sorted by pinnedAt desc), then unpinned (by lastUpdated desc)
+  const sortedSessions = [...historyState.sessions].sort((a, b) => {
+    if (a.pinned && !b.pinned) return -1;
+    if (!a.pinned && b.pinned) return 1;
+    if (a.pinned && b.pinned) {
+      return (b.pinnedAt?.getTime() ?? 0) - (a.pinnedAt?.getTime() ?? 0);
+    }
+    return new Date(b.lastUpdated).getTime() - new Date(a.lastUpdated).getTime();
+  });
+
+  const pinnedSessions = sortedSessions.filter((s) => s.pinned);
+  const unpinnedSessions = sortedSessions.filter((s) => !s.pinned);
+
   return {
     // State
-    sessions: historyState.sessions,
+    sessions: sortedSessions,
+    pinnedSessions,
+    unpinnedSessions,
     currentSessionId: historyState.currentSessionId,
     currentSession: getCurrentSession(),
     isHistoryOpen,
@@ -163,6 +197,7 @@ export const useChatHistory = () => {
     clearAllHistory,
     exportSession,
     searchSessions,
+    togglePin,
     setIsHistoryOpen,
 
     // Utils

--- a/dex_with_fiat_frontend/src/types/index.ts
+++ b/dex_with_fiat_frontend/src/types/index.ts
@@ -41,6 +41,8 @@ export interface ChatSession {
   createdAt: Date;
   lastUpdated: Date;
   walletAddress?: string;
+  pinned?: boolean;
+  pinnedAt?: Date;
 }
 
 export interface ChatHistoryState {


### PR DESCRIPTION
Closes #204

## Summary
- Add `pinned` and `pinnedAt` fields to `ChatSession` type
- Add `togglePin` action to `useChatHistory`; pinned threads float above recents (sorted by `pinnedAt` desc, unpinned by `lastUpdated` desc)
- Update `ChatHistorySidebar` to render a **Pinned** section above **Recent**, with per-session pin/unpin button (lucide `Pin`/`PinOff` icons) visible on hover
- Pin metadata persists via existing localStorage-backed `ChatHistoryManager`

## Test plan
- [ ] Unit tests for pin ordering, toggle on/off, and sessions without `pinned` field pass (`useChatHistory.test.ts`)
- [ ] Pinned session stays at top after page reload
- [ ] Unpinning a session moves it back to the recents section