### PR TITLE
feat: add configurable withdrawal cooldown after large deposit

### DIFF
--- a/stellar-contracts/src/lib.rs
+++ b/stellar-contracts/src/lib.rs
@@ -121,6 +121,10 @@ pub enum DataKey {
     WindowStart,
     WindowWithdrawn,
     CooldownLedgers,
+    // Withdrawal cooldown after large deposit
+    WithdrawCooldownLedgers,
+    WithdrawCooldownThreshold,
+    LastLargeDeposit(Address),
     UserDeposited(Address),
     NextActionID,
     QueuedAdminAction(u64),
@@ -274,6 +278,27 @@ impl FiatBridge {
             .instance()
             .set(&user_key, &(user_total + amount));
 
+        // Track large deposits for withdrawal cooldown
+        let withdraw_threshold: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::WithdrawCooldownThreshold)
+            .unwrap_or(0);
+        if withdraw_threshold > 0 && amount >= withdraw_threshold {
+            let large_key = DataKey::LastLargeDeposit(from.clone());
+            env.storage()
+                .temporary()
+                .set(&large_key, &env.ledger().sequence());
+            let cooldown_ledgers: u32 = env
+                .storage()
+                .instance()
+                .get(&DataKey::WithdrawCooldownLedgers)
+                .unwrap_or(0);
+            // Keep record alive at least as long as the cooldown period
+            let ttl = cooldown_ledgers.max(17_280); // min 24h
+            env.storage().temporary().extend_ttl(&large_key, ttl, ttl);
+        }
+
         env.events()
             .publish((Symbol::new(&env, "deposit"), from), amount);
         env.events()
@@ -363,6 +388,26 @@ impl FiatBridge {
         if amount <= 0 {
             return Err(Error::ZeroAmount);
         }
+
+        // Enforce withdrawal cooldown after large deposit
+        let withdraw_cooldown: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::WithdrawCooldownLedgers)
+            .unwrap_or(0);
+        if withdraw_cooldown > 0 {
+            let large_key = DataKey::LastLargeDeposit(to.clone());
+            if let Some(last_large) = env
+                .storage()
+                .temporary()
+                .get::<DataKey, u32>(&large_key)
+            {
+                if env.ledger().sequence() < last_large.saturating_add(withdraw_cooldown) {
+                    return Err(Error::CooldownActive);
+                }
+            }
+        }
+
         let lock_period: u32 = env
             .storage()
             .instance()
@@ -535,6 +580,30 @@ impl FiatBridge {
         env.storage()
             .instance()
             .set(&DataKey::CooldownLedgers, &ledgers);
+        Ok(())
+    }
+
+    /// Configure the withdrawal cooldown applied after a large deposit.
+    ///
+    /// - `ledgers`   – number of ledgers to wait before withdrawing.  0 disables the guard.
+    /// - `threshold` – minimum deposit amount (inclusive) that triggers the cooldown.  0 disables.
+    pub fn set_withdrawal_cooldown(
+        env: Env,
+        ledgers: u32,
+        threshold: i128,
+    ) -> Result<(), Error> {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::NotInitialized)?;
+        admin.require_auth();
+        env.storage()
+            .instance()
+            .set(&DataKey::WithdrawCooldownLedgers, &ledgers);
+        env.storage()
+            .instance()
+            .set(&DataKey::WithdrawCooldownThreshold, &threshold);
         Ok(())
     }
 
@@ -758,6 +827,18 @@ impl FiatBridge {
         env.storage()
             .instance()
             .get(&DataKey::CooldownLedgers)
+            .unwrap_or(0)
+    }
+    pub fn get_withdrawal_cooldown(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&DataKey::WithdrawCooldownLedgers)
+            .unwrap_or(0)
+    }
+    pub fn get_withdrawal_threshold(env: Env) -> i128 {
+        env.storage()
+            .instance()
+            .get(&DataKey::WithdrawCooldownThreshold)
             .unwrap_or(0)
     }
     pub fn get_withdrawal_request(env: Env, id: u64) -> Option<WithdrawRequest> {

--- a/stellar-contracts/src/test.rs
+++ b/stellar-contracts/src/test.rs
@@ -405,3 +405,97 @@ fn test_invariant_violation_insufficent_balance() {
     let result = bridge.try_deposit(&user, &10, &token_addr, &Bytes::new(&env));
     assert_eq!(result, Err(Ok(Error::InsufficientFunds)));
 }
+
+// ── withdrawal cooldown tests ─────────────────────────────────────────────
+
+#[test]
+fn test_withdrawal_cooldown_not_triggered_below_threshold() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_, bridge, admin, token_addr, _, token_sac) = setup_bridge(&env, 10_000);
+    let user = Address::generate(&env);
+    token_sac.mint(&user, &5_000);
+
+    // Set cooldown: 100 ledgers, threshold 500
+    bridge.set_withdrawal_cooldown(&100, &500);
+    assert_eq!(bridge.get_withdrawal_cooldown(), 100);
+    assert_eq!(bridge.get_withdrawal_threshold(), 500);
+
+    // Deposit below threshold — should NOT set LastLargeDeposit
+    bridge.deposit(&user, &100, &token_addr, &Bytes::new(&env));
+
+    // Withdrawal should succeed immediately (no cooldown recorded)
+    let req_id = bridge.request_withdrawal(&user, &50, &token_addr);
+    bridge.execute_withdrawal(&req_id, &None);
+    drop(admin);
+}
+
+#[test]
+fn test_withdrawal_cooldown_blocks_after_large_deposit() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_, bridge, _, token_addr, _, token_sac) = setup_bridge(&env, 10_000);
+    let user = Address::generate(&env);
+    token_sac.mint(&user, &5_000);
+
+    // 100-ledger cooldown, threshold 500
+    bridge.set_withdrawal_cooldown(&100, &500);
+
+    // Deposit at or above threshold
+    bridge.deposit(&user, &500, &token_addr, &Bytes::new(&env));
+
+    // Immediate withdrawal request should be blocked
+    let result = bridge.try_request_withdrawal(&user, &100, &token_addr);
+    assert_eq!(result, Err(Ok(Error::CooldownActive)));
+}
+
+#[test]
+fn test_withdrawal_cooldown_expires() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_, bridge, _, token_addr, token, token_sac) = setup_bridge(&env, 10_000);
+    let user = Address::generate(&env);
+    token_sac.mint(&user, &5_000);
+
+    bridge.set_withdrawal_cooldown(&100, &500);
+    let deposit_ledger = env.ledger().sequence();
+
+    bridge.deposit(&user, &500, &token_addr, &Bytes::new(&env));
+
+    // Still blocked before cooldown expires
+    let result = bridge.try_request_withdrawal(&user, &100, &token_addr);
+    assert_eq!(result, Err(Ok(Error::CooldownActive)));
+
+    // Advance past cooldown
+    env.ledger().with_mut(|li| {
+        li.sequence_number = deposit_ledger + 100;
+    });
+
+    // Now the request should succeed
+    let req_id = bridge.request_withdrawal(&user, &100, &token_addr);
+    bridge.execute_withdrawal(&req_id, &None);
+    assert_eq!(token.balance(&user), 4_600); // 5000 - 500 deposited + 100 withdrawn
+}
+
+#[test]
+fn test_withdrawal_cooldown_disabled_when_zeroed() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_, bridge, _, token_addr, _, token_sac) = setup_bridge(&env, 10_000);
+    let user = Address::generate(&env);
+    token_sac.mint(&user, &5_000);
+
+    // Enable then immediately disable
+    bridge.set_withdrawal_cooldown(&100, &500);
+    bridge.set_withdrawal_cooldown(&0, &0);
+
+    bridge.deposit(&user, &1_000, &token_addr, &Bytes::new(&env));
+
+    // No cooldown active — withdrawal should go through immediately
+    let req_id = bridge.request_withdrawal(&user, &200, &token_addr);
+    bridge.execute_withdrawal(&req_id, &None);
+}


### PR DESCRIPTION
Closes #216

## Summary
- Add `WithdrawCooldownLedgers`, `WithdrawCooldownThreshold`, `LastLargeDeposit(Address)` storage keys to the smart contract
- `deposit()` records the current ledger in `LastLargeDeposit` when `amount >= threshold`
- `request_withdrawal()` returns `CooldownActive` if within the cooldown window after a large deposit
- New admin function `set_withdrawal_cooldown(ledgers, threshold)` — setting both to 0 disables the guard
- New view functions: `get_withdrawal_cooldown()` and `get_withdrawal_threshold()`

## Test plan
- [ ] 23/23 contract tests pass (`cargo test`)
- [ ] `test_withdrawal_cooldown_not_triggered_below_threshold` — deposit below threshold bypasses guard
- [ ] `test_withdrawal_cooldown_blocks_after_large_deposit` — immediate withdrawal returns `CooldownActive`
- [ ] `test_withdrawal_cooldown_expires` — withdrawal succeeds after cooldown elapses
- [ ] `test_withdrawal_cooldown_disabled_when_zeroed` — setting `(0, 0)` disables the guard entirely