### PR TITLE
feat: add health endpoint and status badge (#53)

### DIFF
--- a/dex_with_fiat_frontend/src/app/api/health/route.ts
+++ b/dex_with_fiat_frontend/src/app/api/health/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server';
+
+export const runtime = 'edge';
+
+export async function GET() {
+  return NextResponse.json(
+    {
+      status: 'ok',
+      timestamp: new Date().toISOString(),
+    },
+    { status: 200 },
+  );
+}

--- a/dex_with_fiat_frontend/src/components/StellarChatInterface.tsx
+++ b/dex_with_fiat_frontend/src/components/StellarChatInterface.tsx
@@ -37,6 +37,11 @@ import { getQueuedReadRequestsCount } from '@/lib/networkQueue';
 import useBridgeStats from '@/hooks/useBridgeStats';
 import WalletConnectionTimeline from './WalletConnectionTimeline';
 
+/** Possible states for the API health badge */
+type HealthStatus = 'checking' | 'ok' | 'degraded';
+
+const HEALTH_POLL_INTERVAL_MS = 60_000;
+
 export default function StellarChatInterface() {
   const {
     connection,
@@ -67,6 +72,12 @@ export default function StellarChatInterface() {
     typeof window !== 'undefined' ? window.navigator.onLine : true,
   );
   const [queuedReadables, setQueuedReadables] = useState(0);
+
+  // ── Health badge state ──────────────────────────────────────────────────────
+  const [healthStatus, setHealthStatus] = useState<HealthStatus>('checking');
+  const healthIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  // ───────────────────────────────────────────────────────────────────────────
+
   const accountDropdownRef = useRef<HTMLDivElement>(null);
 
   const sheetRef = useRef<HTMLDivElement>(null);
@@ -127,6 +138,25 @@ export default function StellarChatInterface() {
       }
     };
   }, []);
+
+  // ── Health endpoint polling ─────────────────────────────────────────────────
+  const pollHealth = useCallback(async () => {
+    try {
+      const res = await fetch('/api/health');
+      setHealthStatus(res.ok ? 'ok' : 'degraded');
+    } catch {
+      setHealthStatus('degraded');
+    }
+  }, []);
+
+  useEffect(() => {
+    pollHealth();
+    healthIntervalRef.current = setInterval(pollHealth, HEALTH_POLL_INTERVAL_MS);
+    return () => {
+      if (healthIntervalRef.current) clearInterval(healthIntervalRef.current);
+    };
+  }, [pollHealth]);
+  // ───────────────────────────────────────────────────────────────────────────
 
   // Check if current user is admin
   useEffect(() => {
@@ -331,6 +361,26 @@ export default function StellarChatInterface() {
     [connect, isNetworkMismatch, sendMessage],
   );
 
+  // ── Health badge helper ─────────────────────────────────────────────────────
+  const healthBadge = {
+    checking: {
+      dot: 'bg-yellow-400 animate-pulse',
+      label: 'Checking…',
+      title: 'Verifying API health',
+    },
+    ok: {
+      dot: 'bg-green-400',
+      label: 'API Healthy',
+      title: 'API is operational',
+    },
+    degraded: {
+      dot: 'bg-red-500',
+      label: 'API Degraded',
+      title: 'API health check failed',
+    },
+  }[healthStatus];
+  // ───────────────────────────────────────────────────────────────────────────
+
   return (
     <div className="theme-app flex h-screen w-screen overflow-hidden transition-colors duration-300">
       {/* Desktop sidebar - only rendered on md+ viewports */}
@@ -379,6 +429,22 @@ export default function StellarChatInterface() {
                 </p>
               </div>
             </div>
+
+            {/* ── Health badge ─────────────────────────────────────────────── */}
+            <div
+              title={healthBadge.title}
+              aria-label={healthBadge.title}
+              role="status"
+              className={`hidden sm:flex items-center gap-1.5 px-2 py-1 rounded-full text-[11px] font-medium select-none ${
+                isDarkMode
+                  ? 'bg-gray-800 text-gray-300'
+                  : 'bg-gray-100 text-gray-600'
+              }`}
+            >
+              <span className={`w-2 h-2 rounded-full flex-shrink-0 ${healthBadge.dot}`} />
+              {healthBadge.label}
+            </div>
+            {/* ─────────────────────────────────────────────────────────────── */}
           </div>
 
           <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
Implements a production-ready API health endpoint and a live status badge
in the chat header as scoped in issue #53.

## Changes

### `src/app/api/health/route.ts` *(new file)*
- `GET /api/health` returns `{ status: "ok", timestamp: "<ISO string>" }`
- Runs on the Edge runtime for low-latency responses

### `src/components/StellarChatInterface.tsx`
- Added `HealthStatus` type: `'checking' | 'ok' | 'degraded'`
- `pollHealth()` — fetches `/api/health`; sets status to `ok` on 2xx,
  `degraded` on any non-ok response or network failure
- `useEffect` runs `pollHealth()` immediately on mount, then every 60 s;
  interval is cleared on unmount (no memory leaks)
- Health badge inserted in the header, right of the DexFiat logo:
  - 🟡 pulsing yellow → `Checking…`
  - 🟢 green → `API Healthy`
  - 🔴 red → `API Degraded`
- Badge hidden on xs screens (`hidden sm:flex`) to respect mobile layout

## Acceptance Criteria
- [x] `GET /api/health` returns `status` and `timestamp`
- [x] Health badge visible in chat header
- [x] Badge polls every 60 seconds

## Validation
Curl the endpoint after `npm run dev`:
```bash
curl http://localhost:3000/api/health
# {"status":"ok","timestamp":"2026-03-28T..."}
```

Closes #53