### PR TITLE
fix(frontend): suppress hydration warning on html element for theme data-attribute

### DIFF
--- a/dex_with_fiat_frontend/src/app/layout.tsx
+++ b/dex_with_fiat_frontend/src/app/layout.tsx
@@ -24,7 +24,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >


### PR DESCRIPTION
Closes #306

## Summary

`ThemeProvider` sets `data-theme` on `document.documentElement` after mount via `useEffect`, which means the server-rendered `<html>` element has no `data-theme` attribute while the client applies it on first paint. React flags this as a hydration mismatch.

Adding `suppressHydrationWarning` to the `<html>` element in `layout.tsx` tells React to ignore attribute differences on that element, eliminating the warning without changing any theme behaviour.

## Changes

- `dex_with_fiat_frontend/src/app/layout.tsx` — added `suppressHydrationWarning` to `<html>`

## Test Plan

- [x] `npm run build` passes with no errors
- [x] No hydration warnings in browser console on page load (dark or light theme)
- [x] Theme toggle continues to work correctly
