### PR TITLE
ci(311): cache Next.js build artifacts in GitHub Actions

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -38,6 +38,14 @@ jobs:
         working-directory: dex_with_fiat_frontend
         run: npm ci
 
+      - name: Cache Next.js build artifacts
+        uses: actions/cache@v4
+        with:
+          path: dex_with_fiat_frontend/.next/cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('dex_with_fiat_frontend/package-lock.json') }}-${{ hashFiles('dex_with_fiat_frontend/src/**/*.{ts,tsx,js,jsx}') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-${{ hashFiles('dex_with_fiat_frontend/package-lock.json') }}-
+
       - name: Build
         run: npm run build
         env:


### PR DESCRIPTION
Closes #311

## Summary

Added an `actions/cache@v4` step to persist `.next/cache` between CI runs. The existing workflow already ran `npm run build` and produced build artifacts, but they were discarded after each run, making every CI run a cold build.

## Changes

- `.github/workflows/frontend.yml` — cache step inserted between `npm ci` and `npm run build`

## Cache Strategy

- **Key**: OS + `package-lock.json` hash + source file hash → exact cache hit when nothing changed
- **Restore key**: OS + `package-lock.json` hash → partial hit after code-only changes (deps unchanged)
- Stale cache is never used after dependency changes

## Test Plan

- [x] Workflow YAML is valid
- [x] First run populates `.next/cache`; subsequent runs restore and build faster
- [x] Build failure still blocks merge
