### PR TITLE
test(312): add proptest property-based tests for deposit amount invariants

### DIFF
--- a/stellar-contracts/Cargo.toml
+++ b/stellar-contracts/Cargo.toml
@@ -11,6 +11,7 @@ soroban-sdk = "25.3.0"
 
 [dev-dependencies]
 soroban-sdk = { version = "25.3.0", features = ["testutils"] }
+proptest = "1"
 
 [features]
 testutils = ["soroban-sdk/testutils"]

--- a/stellar-contracts/src/test.rs
+++ b/stellar-contracts/src/test.rs
@@ -2060,3 +2060,51 @@ fn test_get_receipt_by_index_nonexistent_index() {
     assert_eq!(bridge.get_receipt_by_index(&50), None);
     assert_eq!(bridge.get_receipt_by_index(&u64::MAX), None);
 }
+
+// ── Property-based tests (proptest) ──────────────────────────────────────────
+
+#[cfg(test)]
+mod proptest_deposit {
+    use super::*;
+    use proptest::prelude::*;
+
+    /// Deposit invariants that must hold for every positive amount ≤ limit:
+    ///   1. deposit() succeeds
+    ///   2. contract balance increases by exactly `amount`
+    ///   3. user balance decreases by exactly `amount`
+    ///   4. get_user_deposited() returns `amount`
+    proptest! {
+        #[test]
+        fn deposit_invariants_hold_for_all_valid_amounts(amount in 1i128..=500i128) {
+            let env = Env::default();
+            env.mock_all_auths();
+
+            let (contract_id, bridge, _, token_addr, token, token_sac) = setup_bridge(&env, 500);
+            let user = Address::generate(&env);
+            token_sac.mint(&user, &1_000);
+
+            let user_before = token.balance(&user);
+            let contract_before = token.balance(&contract_id);
+
+            bridge.deposit(&user, &amount, &token_addr, &Bytes::new(&env), &0, &0, &None);
+
+            prop_assert_eq!(token.balance(&user), user_before - amount);
+            prop_assert_eq!(token.balance(&contract_id), contract_before + amount);
+            prop_assert_eq!(bridge.get_user_deposited(&user), amount);
+        }
+
+        /// Amounts above the configured limit must be rejected with ExceedsLimit.
+        #[test]
+        fn deposit_above_limit_is_rejected(amount in 501i128..=10_000i128) {
+            let env = Env::default();
+            env.mock_all_auths();
+
+            let (_, bridge, _, token_addr, _, token_sac) = setup_bridge(&env, 500);
+            let user = Address::generate(&env);
+            token_sac.mint(&user, &amount);
+
+            let result = bridge.try_deposit(&user, &amount, &token_addr, &Bytes::new(&env), &0, &0, &None);
+            prop_assert_eq!(result, Err(Ok(Error::ExceedsLimit)));
+        }
+    }
+}


### PR DESCRIPTION
Closes #312

## Summary

Added property-based tests using `proptest` to verify deposit amount invariants across the full valid range and the rejection boundary.

## Changes

- `stellar-contracts/Cargo.toml` — added `proptest = "1"` to `[dev-dependencies]`
- `stellar-contracts/src/test.rs` — added `proptest_deposit` module with two suites

## Test Suites

### `deposit_invariants_hold_for_all_valid_amounts` (1..=500)
For every amount in the valid range:
- `deposit()` succeeds
- contract balance increases by exactly `amount`
- user balance decreases by exactly `amount`
- `get_user_deposited()` returns `amount`

### `deposit_above_limit_is_rejected` (501..=10_000)
For every amount above the limit, verifies `ExceedsLimit` error is returned. proptest shrinks to the minimal failing case on failure.

## Test Plan

- [x] `cargo test` — 101 tests pass (99 existing + 2 new proptest suites)
- [x] proptest runs 256 cases per suite by default
- [x] Shrinking verified: proptest produces minimal failing example on failure
