### PR TITLE
dx(vscode): add rust-analyzer workspace settings

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "rust-lang.rust-analyzer"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,2 +1,5 @@
 {
+  "rust-analyzer.linkedProjects": [
+    "stellar-contracts/Cargo.toml"
+  ]
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,6 +94,8 @@ cargo build --target wasm32-unknown-unknown --release
 cargo test
 ```
 
+If you use VS Code, the repository includes workspace settings that point Rust Analyzer at [stellar-contracts/Cargo.toml](./stellar-contracts/Cargo.toml). Install the recommended `rust-lang.rust-analyzer` extension when prompted so contract code navigation and diagnostics work out of the box.
+
 ---
 
 ## Branch Naming


### PR DESCRIPTION
Closes #320

## Changes
- add `.vscode/settings.json` with `rust-analyzer.linkedProjects` pointing to `stellar-contracts/Cargo.toml`
- add `.vscode/extensions.json` recommending `rust-lang.rust-analyzer`
- document the VS Code Rust Analyzer setup in `CONTRIBUTING.md`

## Testing
- not run (workspace config and documentation changes only)

