### PR TITLE
feat: add minimum deposit floor (#113)

### DIFF
--- a/stellar-contracts/src/lib.rs
+++ b/stellar-contracts/src/lib.rs
@@ -81,6 +81,9 @@ pub enum Error {
     // --- 900 series: Replay Protection ---
     InvalidNonce = 901,
     StaleNonce = 902,
+
+    // --- 1000 series: Deposit Floor ---
+    BelowMinimum = 1001,
 }
 
 // ── Models ────────────────────────────────────────────────────────────────
@@ -212,6 +215,7 @@ pub enum DataKey {
     LastDeposit(Address),
     ReceiptCounter,
     Receipt(BytesN<32>),
+    MinDeposit,
     LockPeriod,
     NextRequestID,
     WithdrawQueueLen,
@@ -270,13 +274,17 @@ pub struct FiatBridge;
 
 #[contractimpl]
 impl FiatBridge {
-    pub fn init(env: Env, admin: Address, token: Address, limit: i128) -> Result<(), Error> {
+    pub fn init(env: Env, admin: Address, token: Address, limit: i128, min_deposit: i128) -> Result<(), Error> {
         if env.storage().instance().has(&DataKey::Admin) {
             return Err(Error::AlreadyInitialized);
         }
         if limit <= 0 {
             return Err(Error::ZeroAmount);
         }
+        if min_deposit < 1 || min_deposit >= limit {
+            return Err(Error::BelowMinimum);
+        }
+        env.storage().instance().set(&DataKey::MinDeposit, &min_deposit);
         env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage().instance().set(&DataKey::Token, &token);
 
@@ -402,6 +410,15 @@ impl FiatBridge {
             .persistent()
             .get(&DataKey::TokenRegistry(token.clone()))
             .ok_or(Error::TokenNotWhitelisted)?;
+        // ── Issue #113: minimum deposit floor ────────────────────────────
+        let min_deposit: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::MinDeposit)
+            .unwrap_or(1);
+        if amount < min_deposit {
+            return Err(Error::BelowMinimum);
+        }
         if amount > config.limit {
             return Err(Error::ExceedsLimit);
         }
@@ -975,6 +992,31 @@ impl FiatBridge {
             .persistent()
             .set(&DataKey::TokenRegistry(token), &config);
         Ok(())
+    }
+
+    // ── Issue #113: minimum deposit floor ────────────────────────────
+    pub fn set_min_deposit(env: Env, min: i128) -> Result<(), Error> {
+        env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::NotInitialized)?;
+        admin.require_auth();
+        if min < 1 {
+            return Err(Error::BelowMinimum);
+        }
+        env.storage().instance().set(&DataKey::MinDeposit, &min);
+        env.events()
+            .publish((EVENT_VERSION, Symbol::new(&env, "set_min_dep")), min);
+        Ok(())
+    }
+
+    pub fn get_min_deposit(env: Env) -> i128 {
+        env.storage()
+            .instance()
+            .get(&DataKey::MinDeposit)
+            .unwrap_or(1)
     }
 
     pub fn set_daily_deposit_limit(
@@ -2194,7 +2236,6 @@ impl FiatBridge {
         };
 
         env.events().publish(
-            (Symbol::new(&env, "batch_ok"), Symbol::new(&env, "v1")),
             (EVENT_VERSION, Symbol::new(&env, "batch_ok")),
             (success_count, failure_count, total_ops),
         );

--- a/stellar-contracts/src/test.rs
+++ b/stellar-contracts/src/test.rs
@@ -41,9 +41,31 @@ fn setup_bridge(
     let admin = Address::generate(env);
     let token_admin = Address::generate(env);
     let (token_addr, token, token_sac) = create_token(env, &token_admin);
-    bridge.init(&admin, &token_addr, &limit);
+    bridge.init(&admin, &token_addr, &limit, &1);
     (contract_id, bridge, admin, token_addr, token, token_sac)
 }
+
+fn setup_bridge_with_min(
+    env: &Env,
+    limit: i128,
+    min_deposit: i128,
+) -> (
+    Address,
+    FiatBridgeClient<'_>,
+    Address,
+    Address,
+    TokenClient<'_>,
+    StellarAssetClient<'_>,
+) {
+    let contract_id = env.register(FiatBridge, ());
+    let bridge = FiatBridgeClient::new(env, &contract_id);
+    let admin = Address::generate(env);
+    let token_admin = Address::generate(env);
+    let (token_addr, token, token_sac) = create_token(env, &token_admin);
+    bridge.init(&admin, &token_addr, &limit, &min_deposit);
+    (contract_id, bridge, admin, token_addr, token, token_sac)
+}
+
 
 // ── happy-path tests ──────────────────────────────────────────────────
 
@@ -418,7 +440,7 @@ fn test_double_init() {
     env.mock_all_auths();
 
     let (_, bridge, admin, token_addr, _, _) = setup_bridge(&env, 500);
-    let result = bridge.try_init(&admin, &token_addr, &500);
+    let result = bridge.try_init(&admin, &token_addr, &500, &1);
     assert_eq!(result, Err(Ok(Error::AlreadyInitialized)));
 }
 
@@ -2877,4 +2899,82 @@ fn test_escrow_partial_migration_preserves_count() {
         escrow_total += record.amount;
     }
     assert_eq!(escrow_total, expected_total);
+}
+
+// ── Issue #113: minimum deposit floor tests ───────────────────────────────
+
+#[test]
+fn test_init_rejects_invalid_min_deposit() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(FiatBridge, ());
+    let bridge = FiatBridgeClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let (token_addr, _, _) = create_token(&env, &token_admin);
+
+    // Reject 0
+    let result = bridge.try_init(&admin, &token_addr, &1000, &0);
+    assert_eq!(result, Err(Ok(Error::BelowMinimum)));
+
+    // Reject negative
+    let result = bridge.try_init(&admin, &token_addr, &1000, &-5);
+    assert_eq!(result, Err(Ok(Error::BelowMinimum)));
+
+    // Reject min_deposit >= limit
+    let result = bridge.try_init(&admin, &token_addr, &1000, &1000);
+    assert_eq!(result, Err(Ok(Error::BelowMinimum)));
+
+    let result = bridge.try_init(&admin, &token_addr, &1000, &2000);
+    assert_eq!(result, Err(Ok(Error::BelowMinimum)));
+}
+
+#[test]
+fn test_deposit_below_minimum_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    // Limit = 10_000, MinDeposit = 500
+    let (_, bridge, _, token_addr, _, token_sac) = setup_bridge_with_min(&env, 10_000, 500);
+    let user = Address::generate(&env);
+    token_sac.mint(&user, &1_000);
+
+    // 499 < 500 should be rejected
+    let result = bridge.try_deposit(&user, &499, &token_addr, &Bytes::new(&env), &0, &0, &None);
+    assert_eq!(result, Err(Ok(Error::BelowMinimum)));
+    
+    // Default config minimum is 1, so 0 should already fail due to ZeroAmount,
+    // let's verify custom min_deposit blocks 1 through min_deposit - 1.
+}
+
+#[test]
+fn test_deposit_exactly_minimum_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_, bridge, _, token_addr, _, token_sac) = setup_bridge_with_min(&env, 10_000, 500);
+    let user = Address::generate(&env);
+    token_sac.mint(&user, &1_000);
+
+    // Exactly 500 should succeed
+    bridge.deposit(&user, &500, &token_addr, &Bytes::new(&env), &0, &0, &None);
+    assert_eq!(bridge.get_total_deposited(), 500);
+}
+
+#[test]
+fn test_set_min_deposit_admin_only() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_, bridge, _, _, _, _) = setup_bridge(&env, 10_000);
+    assert_eq!(bridge.get_min_deposit(), 1);
+
+    // Should succeed because admin is mocked
+    bridge.set_min_deposit(&500);
+    assert_eq!(bridge.get_min_deposit(), 500);
+    
+    // Try to set below minimum
+    let result = bridge.try_set_min_deposit(&0);
+    assert_eq!(result, Err(Ok(Error::BelowMinimum)));
 }


### PR DESCRIPTION
## Summary

Closes #113 — the contract had an upper limit for deposits but lacked a lower bound, allowing users to deposit as little as 1 stroop. Dust deposits waste compute and bloat analytics. This PR adds a configurable minimum deposit floor.

## Changes

**`stellar-contracts/src/lib.rs`**
- Added `BelowMinimum = 1001` to the `Error` enum for the 1000 series (Deposit Floor).
- Added `MinDeposit` to the `DataKey` enum for instance storage.
- Updated `init` signature to accept `min_deposit: i128` alongside `limit`, enforcing that `min_deposit >= 1` and `min_deposit < limit`.
- Updated `deposit` to read `MinDeposit` ( defaulting to 1 ) and enforce `amount >= min_deposit` before the standard limit bounds.
- Added admin-only `set_min_deposit(env, min: i128)` and view function `get_min_deposit(env)`.

**`stellar-contracts/src/test.rs`**
- Updated the testing helper `setup_bridge` to pass `1` as the minimum deposit to cleanly support all existing tests.
- Added `setup_bridge_with_min` helper for the new custom minimum deposit tests.
- Added unit tests:
  - `test_init_rejects_invalid_min_deposit` (rejects 0, negative, and >= limit)
  - `test_deposit_below_minimum_rejected` (dust rejected)
  - `test_deposit_exactly_minimum_succeeds` (boundary condition succeeds)
  - `test_set_min_deposit_admin_only` (validates admin setter correctly updates the minimum)

## Test results

```
test result: ok. 126 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 17.28s    
```

Clippy: ✅ clean (no warnings)

## Acceptance criteria

- [x] Depositing below the minimum returns `BelowMinimum`
- [x] Depositing exactly the minimum succeeds
- [x] Admin can update the minimum at any time
- [x] Setting minimum to 1 (the smallest valid amount) is accepted
