### PR TITLE
docs: add .env.example and update setup instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,18 @@
+# Stellar Network Configuration
+NEXT_PUBLIC_STELLAR_NETWORK=TESTNET # Target Stellar network: TESTNET or PUBLIC
+NEXT_PUBLIC_STELLAR_RPC_URL=https://soroban-testnet.stellar.org # Soroban RPC endpoint for contract interaction
+
+# Smart Contract Configuration
+NEXT_PUBLIC_STELLAR_CONTRACT_ID= # The deployed Soroban FiatBridge contract ID (starts with 'C')
+NEXT_PUBLIC_XLM_SAC_ID=CAS3J7GYCCXG7WS6Y7G2HGDV6X6YHS2753T55E4YDLM5D35W6N6YJLYE # XLM Stellar Asset Contract ID (Native asset)
+
+# AI Assistant Configuration
+GEMINI_API_KEY= # Google Gemini API key for AI-powered bridge assistance
+
+# Payout Provider Configuration
+PAYOUT_PROVIDER=paystack # Payout provider name (e.g., paystack)
+PAYSTACK_SECRET_KEY= # Paystack secret key for initiating bank transfers and verifying webhooks
+
+# Optional: Monitoring & Security
+# SENTRY_DSN= # Optional: Sentry DSN for error tracking
+# ADMIN_IP_ALLOWLIST= # Optional: Comma-separated list of IPs allowed for admin routes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,13 +20,13 @@ Thank you for taking the time to contribute. This document covers everything you
 
 Install the following tools before you begin.
 
-| Tool | Minimum version | Notes |
-|---|---|---|
-| Node.js | 20.x | Use [nvm](https://github.com/nvm-sh/nvm) or [fnm](https://github.com/Schniz/fnm) to manage versions |
-| Rust toolchain | stable | Install via [rustup](https://rustup.rs/) |
-| wasm32 target | — | `rustup target add wasm32-unknown-unknown` |
-| Stellar CLI | latest | Install via `cargo install --locked stellar-cli` |
-| Freighter extension | latest | Browser wallet available at the [Freighter website](https://www.freighter.app/) |
+| Tool                | Minimum version | Notes                                                                                               |
+| ------------------- | --------------- | --------------------------------------------------------------------------------------------------- |
+| Node.js             | 20.x            | Use [nvm](https://github.com/nvm-sh/nvm) or [fnm](https://github.com/Schniz/fnm) to manage versions |
+| Rust toolchain      | stable          | Install via [rustup](https://rustup.rs/)                                                            |
+| wasm32 target       | —               | `rustup target add wasm32-unknown-unknown`                                                          |
+| Stellar CLI         | latest          | Install via `cargo install --locked stellar-cli`                                                    |
+| Freighter extension | latest          | Browser wallet available at the [Freighter website](https://www.freighter.app/)                     |
 
 Verify your setup:
 
@@ -52,7 +52,7 @@ cd Stellar-Dex-Chat
 The frontend requires a `.env.local` file. Copy the example and fill in the values:
 
 ```bash
-cp dex_with_fiat_frontend/.env.example dex_with_fiat_frontend/.env.local
+cp .env.example dex_with_fiat_frontend/.env.local
 ```
 
 The required variables are:
@@ -102,11 +102,11 @@ If you use VS Code, the repository includes workspace settings that point Rust A
 
 Use one of the following prefixes followed by a short, hyphen-separated description:
 
-| Prefix | When to use |
-|---|---|
-| `feature/` | New functionality |
-| `fix/` | Bug fixes |
-| `docs/` | Documentation-only changes |
+| Prefix     | When to use                |
+| ---------- | -------------------------- |
+| `feature/` | New functionality          |
+| `fix/`     | Bug fixes                  |
+| `docs/`    | Documentation-only changes |
 
 Examples:
 
@@ -132,12 +132,12 @@ This project follows [Conventional Commits](https://www.conventionalcommits.org/
 
 Allowed types:
 
-| Type | When to use |
-|---|---|
-| `feat` | A new feature |
-| `fix` | A bug fix |
-| `docs` | Documentation changes only |
-| `test` | Adding or updating tests |
+| Type    | When to use                             |
+| ------- | --------------------------------------- |
+| `feat`  | A new feature                           |
+| `fix`   | A bug fix                               |
+| `docs`  | Documentation changes only              |
+| `test`  | Adding or updating tests                |
 | `chore` | Tooling, dependency updates, CI changes |
 
 Examples:


### PR DESCRIPTION
- Create .env.example at the repository root with all required and optional environment variables.
- Add inline comments for each variable explaining its purpose and expected format.
- Update CONTRIBUTING.md to reference the root-level .env.example instead of the subdirectory path.
- Verified that .env.local is correctly ignored in .gitignore.

Closes #372