### PR TITLE
fix(frontend): resolve hydration mismatch risk in useFeatureFlag

### DIFF
--- a/dex_with_fiat_frontend/src/hooks/useFeatureFlag.test.ts
+++ b/dex_with_fiat_frontend/src/hooks/useFeatureFlag.test.ts
@@ -1,0 +1,38 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { renderToString } from 'react-dom/server';
+import { hydrateRoot } from 'react-dom/client';
+import { act } from 'react-dom/test-utils';
+import { useFeatureFlag } from './useFeatureFlag';
+
+function Harness(props: { flag: 'enableAdminReconciliation' | 'enableConversionReminders' }) {
+  const isEnabled = useFeatureFlag(props.flag);
+  return React.createElement('div', null, isEnabled ? 'enabled' : 'disabled');
+}
+
+describe('useFeatureFlag', () => {
+  it('hydrates without mismatch warnings and resolves to the client flag value', async () => {
+    const serverMarkup = renderToString(
+      React.createElement(Harness, { flag: 'enableAdminReconciliation' })
+    );
+    const container = document.createElement('div');
+    container.innerHTML = serverMarkup;
+
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await act(async () => {
+      hydrateRoot(container, React.createElement(Harness, { flag: 'enableAdminReconciliation' }));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(container.textContent).toBe('enabled');
+    expect(serverMarkup).toContain('disabled');
+    expect(
+      consoleErrorSpy.mock.calls.some((args) =>
+        String(args[0]).toLowerCase().includes('hydration')
+      )
+    ).toBe(false);
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/dex_with_fiat_frontend/src/hooks/useFeatureFlag.ts
+++ b/dex_with_fiat_frontend/src/hooks/useFeatureFlag.ts
@@ -1,7 +1,10 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useLayoutEffect } from 'react';
 import { FeatureFlag, getFeatureFlag, FeatureFlagNameSchema } from '@/lib/featureFlags';
+
+const useIsomorphicLayoutEffect =
+  typeof window !== 'undefined' ? useLayoutEffect : useEffect;
 
 /**
  * Hook to check if a feature flag is enabled.
@@ -11,13 +14,12 @@ import { FeatureFlag, getFeatureFlag, FeatureFlagNameSchema } from '@/lib/featur
  * @returns boolean indicating if the flag is enabled.
  */
 export function useFeatureFlag(flag: FeatureFlag) {
-  // Initialize to false for safe hydration, then update to actual value
+  // Initialize to false for safe hydration, then update to actual value.
   const [isEnabled, setIsEnabled] = useState(false);
 
-  useEffect(() => {
-    // Runtime validation using Zod
+  useIsomorphicLayoutEffect(() => {
     const validation = FeatureFlagNameSchema.safeParse(flag);
-    
+
     if (!validation.success) {
       console.error(
         `[useFeatureFlag] Invalid feature flag name: "${flag}". ` +


### PR DESCRIPTION
Summary:\n- keep a hydration-safe default false for feature flags in useFeatureFlag\n- use an isomorphic layout effect so flag state resolves immediately after hydration on the client\n- add a regression test that server-renders and hydrates the hook consumer\n\n
Closes #680 