### PR TITLE
fix: resolve AdminGuard leak and improve replay-protection docs

### DIFF
--- a/NONCE_REPLAY_PROTECTION.md
+++ b/NONCE_REPLAY_PROTECTION.md
@@ -4,6 +4,21 @@
 
 This implementation adds nonce-based replay protection to operator-authorized actions in the Stellar smart contract, preventing replay attacks and ensuring that operator actions can only be executed once.
 
+## Developer Quick Reference
+
+### Nonce lifecycle
+
+1. Read the next expected nonce with `get_operator_nonce(operator)`
+2. Submit the signed operator action with that exact nonce
+3. Contract accepts once, increments stored nonce, and emits `NonceIncrementedEvent`
+4. Reusing old nonce returns `StaleNonce`; skipping ahead returns `InvalidNonce`
+
+### Recommended client flow
+
+- Treat nonce as on-chain state (not local-only state)
+- Re-fetch nonce right before signing every operator action
+- After a nonce error, re-read nonce before retrying
+
 ## Changes Made
 
 ### 1. Storage Key Addition (`stellar-contracts/src/lib.rs`)

--- a/dex_with_fiat_frontend/src/components/AdminGuard.test.tsx
+++ b/dex_with_fiat_frontend/src/components/AdminGuard.test.tsx
@@ -1,0 +1,78 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let mockAddress = '';
+const getAdminMock = vi.fn<() => Promise<string>>();
+
+vi.mock('@/contexts/StellarWalletContext', () => ({
+  useStellarWallet: () => ({
+    connection: { address: mockAddress },
+  }),
+}));
+
+vi.mock('@/lib/stellarContract', () => ({
+  getAdmin: () => getAdminMock(),
+}));
+
+vi.mock('@/components/LandingPage', () => ({
+  default: () => <div data-testid="landing-page">Landing Page</div>,
+}));
+
+const { default: AdminGuard } = await import('@/components/AdminGuard');
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+describe('AdminGuard', () => {
+  beforeEach(() => {
+    mockAddress = '';
+    getAdminMock.mockReset();
+  });
+
+  it('ignores stale async admin checks when wallet address changes', async () => {
+    const firstCheck = createDeferred<string>();
+    const secondCheck = createDeferred<string>();
+    getAdminMock
+      .mockImplementationOnce(() => firstCheck.promise)
+      .mockImplementationOnce(() => secondCheck.promise);
+
+    mockAddress = 'GADMIN_OLD';
+    const { rerender } = render(
+      <AdminGuard>
+        <div data-testid="admin-content">Admin Content</div>
+      </AdminGuard>,
+    );
+
+    mockAddress = 'GUSER_NEW';
+    rerender(
+      <AdminGuard>
+        <div data-testid="admin-content">Admin Content</div>
+      </AdminGuard>,
+    );
+
+    await act(async () => {
+      secondCheck.resolve('GADMIN_OLD');
+      await secondCheck.promise;
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('landing-page')).not.toBeNull();
+    });
+
+    await act(async () => {
+      firstCheck.resolve('GADMIN_OLD');
+      await firstCheck.promise;
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('landing-page')).not.toBeNull();
+      expect(screen.queryByTestId('admin-content')).toBeNull();
+    });
+    expect(getAdminMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/dex_with_fiat_frontend/src/components/AdminGuard.tsx
+++ b/dex_with_fiat_frontend/src/components/AdminGuard.tsx
@@ -20,8 +20,14 @@ export default function AdminGuard({ children }: AdminGuardProps) {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    let isCancelled = false;
+
     async function checkAdmin() {
+      setLoading(true);
+      setError(null);
+
       if (!connection.address) {
+        if (isCancelled) return;
         setIsAdmin(false);
         setLoading(false);
         return;
@@ -29,17 +35,24 @@ export default function AdminGuard({ children }: AdminGuardProps) {
 
       try {
         const adminAddress = await getAdmin();
+        if (isCancelled) return;
         setIsAdmin(connection.address === adminAddress);
       } catch (err) {
+        if (isCancelled) return;
         console.error('Failed to verify admin status:', err);
         setError('Failed to verify admin status. Please try again.');
         setIsAdmin(false);
       } finally {
+        if (isCancelled) return;
         setLoading(false);
       }
     }
 
     checkAdmin();
+
+    return () => {
+      isCancelled = true;
+    };
   }, [connection.address]);
 
   if (loading) {

--- a/docs/typescript-sdk-examples.md
+++ b/docs/typescript-sdk-examples.md
@@ -97,6 +97,17 @@ The `heartbeat` function is called by operators to maintain their active status 
 pub fn heartbeat(env: Env, operator: Address, nonce: u64) -> Result<(), Error>
 ```
 
+### Replay Protection Architecture
+
+For each operator, the contract keeps an independent nonce counter:
+
+1. Client reads `get_operator_nonce(operator)` to get the **next expected nonce**
+2. Client submits `heartbeat(operator, nonce)`
+3. Contract accepts only exact matches, then increments the stored nonce
+4. Reusing an old nonce fails with `StaleNonce`; skipping ahead fails with `InvalidNonce`
+
+This design guarantees each signed operator action can be accepted only once.
+
 ### TypeScript Implementation
 
 ```typescript
@@ -105,6 +116,20 @@ interface HeartbeatParams {
   nonce: number;
   adminPublicKey: string;
   signTx: (xdr: string) => Promise<string>;
+}
+
+export async function getOperatorNonce(operatorAddress: string): Promise<number> {
+  const contract = new Contract(CONTRACT_ID);
+  const op = contract.call('get_operator_nonce', new Address(operatorAddress).toScVal());
+  const { assembledXdr } = await buildAndSimulate(DUMMY_SOURCE, op);
+  const tx = TransactionBuilder.fromXDR(assembledXdr, NETWORK_PASSPHRASE);
+  const sim = await server.simulateTransaction(tx);
+  if (rpc.Api.isSimulationError(sim)) {
+    throw new Error(`Failed to fetch operator nonce: ${sim.error}`);
+  }
+  const retval = (sim as rpc.Api.SimulateTransactionSuccessResponse).result?.retval;
+  if (!retval) throw new Error('No nonce value returned');
+  return Number(scValToNative(retval));
 }
 
 export async function submitHeartbeat(params: HeartbeatParams): Promise<string> {
@@ -148,9 +173,12 @@ export async function submitHeartbeat(params: HeartbeatParams): Promise<string> 
 
 // Usage example
 try {
+  // Recommended: fetch the current on-chain nonce first.
+  const nextNonce = await getOperatorNonce('GB...operator-address');
+
   const hash = await submitHeartbeat({
     operatorAddress: 'GB...operator-address',
-    nonce: 1,
+    nonce: nextNonce,
     adminPublicKey: 'GB...admin-public-key',
     signTx: async (xdr) => {
       // Implement your signing logic here
@@ -663,7 +691,7 @@ adminOperations();
 2. **Use proper error handling** to provide meaningful feedback to users
 3. **Implement retry logic** for network-related failures
 4. **Cache view-only results** to improve performance
-5. **Use nonces** for replay protection in operator functions
+5. **Always read nonce from chain right before signing** operator actions
 6. **Monitor transaction status** and provide feedback to users
 7. **Handle edge cases** like network timeouts and insufficient funds
 8. **Validate admin permissions** before executing sensitive operations

--- a/stellar-contracts/src/lib.rs
+++ b/stellar-contracts/src/lib.rs
@@ -2054,6 +2054,12 @@ impl FiatBridge {
         Ok(())
     }
 
+    /// Records an operator heartbeat with strict nonce validation.
+    ///
+    /// Replay protection rule:
+    /// - `nonce` must be exactly the current stored nonce for `operator`
+    /// - on success, nonce is incremented by 1 atomically with the heartbeat update
+    /// - stale values return `Error::StaleNonce`, skipped/future values return `Error::InvalidNonce`
     pub fn heartbeat(env: Env, operator: Address, nonce: u64) -> Result<(), Error> {
         operator.require_auth();
         if !env
@@ -2091,6 +2097,9 @@ impl FiatBridge {
             .get(&DataKey::OperatorHeartbeat(operator))
     }
 
+    /// Returns the next expected nonce for an operator.
+    ///
+    /// Starts at `0` for operators that have never submitted a heartbeat.
     pub fn get_operator_nonce(env: Env, operator: Address) -> u64 {
         env.storage()
             .instance()
@@ -2109,6 +2118,10 @@ impl FiatBridge {
         Ok(())
     }
 
+    /// Validates nonce monotonicity and persists the next nonce value.
+    ///
+    /// This helper is intentionally strict to block replay attacks:
+    /// each operator action must provide exactly the next expected nonce.
     fn validate_and_increment_nonce(
         env: &Env,
         operator: &Address,


### PR DESCRIPTION
Closes leojay-net/Stellar-Dex-Chat#677, Closes leojay-net/Stellar-Dex-Chat#701.

Details worked on:

fix(frontend): resolve memory leak in AdminGuard.tsx leojay-net/Stellar-Dex-Chat#677: Prevent stale async admin checks from mutating state after unmount/address changes by adding effect cancellation guards, and add a regression test that reproduces the race.

docs: improve inline documentation for replay protection leojay-net/Stellar-Dex-Chat#701: Expand replay-protection architecture guidance in markdown and add clearer inline Rust docs for heartbeat nonce validation, expected nonce semantics, and stale/future nonce behavior.