### PR TITLE
Fix issues #655, #653, #644, and #622 in one batch

### DIFF
--- a/stellar-contracts/src/lib.rs
+++ b/stellar-contracts/src/lib.rs
@@ -462,6 +462,14 @@ pub struct QuotaSetEvent {
 
 #[contractevent]
 #[derive(Clone, Debug)]
+pub struct EmergencyRecoverySetEvent {
+    pub version: u32,
+    pub recovery: Address,
+    pub cap_limit: i128,
+}
+
+#[contractevent]
+#[derive(Clone, Debug)]
 pub struct QuotaResetEvent {
     pub version: u32,
     pub user: Address,
@@ -582,6 +590,7 @@ pub enum DataKey {
     LastAdminActionLedger,
     InactivityThreshold,
     EmergencyRecoveryAddress,
+    EmergencyRecoveryCap,
     SchemaVersion,
     Oracle,
     FiatLimit,
@@ -1803,6 +1812,51 @@ impl FiatBridge {
         Ok(())
     }
 
+    /// Set the emergency recovery address and enforce a maximum cap.
+    ///
+    /// The cap is constrained by the token's configured deposit limit so a
+    /// compromised recovery key cannot bypass configured risk bounds.
+    pub fn set_emergency_recovery(
+        env: Env,
+        recovery: Address,
+        cap_limit: i128,
+    ) -> Result<(), Error> {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::NotInitialized)?;
+        admin.require_auth();
+
+        if cap_limit <= 0 {
+            return Err(Error::ZeroAmount);
+        }
+
+        let token: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Token)
+            .ok_or(Error::NotInitialized)?;
+        let config: TokenConfig = env
+            .storage()
+            .persistent()
+            .get(&DataKey::TokenRegistry(token))
+            .ok_or(Error::TokenNotWhitelisted)?;
+        if cap_limit > config.limit {
+            return Err(Error::ExceedsLimit);
+        }
+
+        env.storage()
+            .instance()
+            .set(&DataKey::EmergencyRecoveryAddress, &recovery);
+        env.storage()
+            .instance()
+            .set(&DataKey::EmergencyRecoveryCap, &cap_limit);
+
+        EmergencyRecoverySetEvent { version: EVENT_VERSION, recovery, cap_limit }.publish(&env);
+        Ok(())
+    }
+
     /// Initiates a transfer of the administrative role to a new address.
     /// 
     /// Follows a two-step transfer pattern:
@@ -2282,16 +2336,17 @@ impl FiatBridge {
             }
         }
 
-        // Increment nonce
+        // Increment nonce with explicit overflow handling.
+        let next_nonce = current_nonce.checked_add(1).ok_or(Error::Overflow)?;
         env.storage().instance().set(
             &DataKey::OperatorNonce(operator.clone()),
-            &(current_nonce + 1),
+            &next_nonce,
         );
 
         NonceIncrementedEvent {
             version: EVENT_VERSION,
             operator: operator.clone(),
-            new_nonce: current_nonce + 1,
+            new_nonce: next_nonce,
         }
         .publish(env);
 
@@ -2902,6 +2957,10 @@ impl FiatBridge {
             .unwrap_or(0)
     }
 
+    pub fn get_emergency_recovery_cap(env: Env) -> Option<i128> {
+        env.storage().instance().get(&DataKey::EmergencyRecoveryCap)
+    }
+
     /// Set the number of ledgers after which an unexecuted withdrawal request
     /// can be reclaimed by the admin. Pass `0` to use the compile-time default
     /// (`WITHDRAWAL_EXPIRY_WINDOW_LEDGERS`).
@@ -3184,16 +3243,17 @@ impl FiatBridge {
         let mut first_failed_index: Option<u32> = None;
 
         for (idx, op) in operations.iter().enumerate() {
+            let index = u32::try_from(idx).map_err(|_| Error::Overflow)?;
             let result = Self::execute_single_admin_op(&env, &op);
             if result.is_err() {
-                BatchFailEvent { version: EVENT_VERSION, index: idx as u32, total_ops }.publish(&env);
-                failure_count += 1;
+                BatchFailEvent { version: EVENT_VERSION, index, total_ops }.publish(&env);
+                failure_count = failure_count.checked_add(1).ok_or(Error::Overflow)?;
                 if first_failed_index.is_none() {
-                    first_failed_index = Some(idx as u32);
+                    first_failed_index = Some(index);
                 }
                 continue;
             }
-            success_count += 1;
+            success_count = success_count.checked_add(1).ok_or(Error::Overflow)?;
         }
 
         let batch_result = BatchResult {

--- a/stellar-contracts/src/test.rs
+++ b/stellar-contracts/src/test.rs
@@ -1118,6 +1118,44 @@ fn test_pause_blocks_state_changing_user_operations_until_unpaused() {
 }
 
 #[test]
+fn test_pause_invariant_preserves_state_on_rejected_user_calls() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_contract_id, bridge, admin, token_addr, _, token_sac) = setup_bridge(&env, 10_000);
+    let user = Address::generate(&env);
+    token_sac.mint(&user, &2_000);
+
+    bridge.deposit(&user, &500, &token_addr, &Bytes::new(&env), &0, &0, &None);
+    let req_id = bridge.request_withdrawal(&user, &100, &token_addr, &None, &0);
+
+    let deposited_before = bridge.get_total_deposited().unwrap();
+    let queue_depth_before = bridge.get_wq_depth();
+
+    bridge.pause();
+
+    assert_eq!(
+        bridge.try_deposit(&user, &100, &token_addr, &Bytes::new(&env), &0, &0, &None),
+        Err(Ok(Error::ContractPaused))
+    );
+    assert_eq!(
+        bridge.try_request_withdrawal(&user, &50, &token_addr, &None, &0),
+        Err(Ok(Error::ContractPaused))
+    );
+    assert_eq!(
+        bridge.try_withdraw(&admin, &user, &50, &token_addr),
+        Err(Ok(Error::ContractPaused))
+    );
+    assert_eq!(
+        bridge.try_execute_withdrawal(&req_id, &None, &0, &0),
+        Err(Ok(Error::ContractPaused))
+    );
+
+    assert_eq!(bridge.get_total_deposited().unwrap(), deposited_before);
+    assert_eq!(bridge.get_wq_depth(), queue_depth_before);
+}
+
+#[test]
 fn test_request_withdrawal_extends_matching_receipt_ttl() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1370,6 +1408,51 @@ fn test_operator_heartbeat() {
     // Heartbeat should fail now
     let res = bridge.try_heartbeat(&operator, &1);
     assert_eq!(res, Err(Ok(Error::NotOperator)));
+}
+
+#[test]
+fn test_heartbeat_nonce_overflow_returns_explicit_error() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (contract_id, bridge, _, _, _, _) = setup_bridge(&env, 1_000);
+
+    let operator = Address::generate(&env);
+    bridge.set_operator(&operator, &true);
+
+    env.as_contract(&contract_id, || {
+        env.storage()
+            .instance()
+            .set(&DataKey::OperatorNonce(operator.clone()), &u64::MAX);
+    });
+
+    let result = bridge.try_heartbeat(&operator, &u64::MAX);
+    assert_eq!(result, Err(Ok(Error::Overflow)));
+}
+
+#[test]
+fn test_set_emergency_recovery_with_cap_limit() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, bridge, _, _, _, _) = setup_bridge(&env, 1_000);
+    let recovery = Address::generate(&env);
+
+    bridge.set_emergency_recovery(&recovery, &750);
+
+    let snapshot = bridge.get_config_snapshot().unwrap();
+    assert_eq!(snapshot.emergency_recovery, Some(recovery.clone()));
+    assert_eq!(bridge.get_emergency_recovery_cap(), Some(750));
+}
+
+#[test]
+fn test_set_emergency_recovery_rejects_cap_above_token_limit() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, bridge, _, _, _, _) = setup_bridge(&env, 1_000);
+    let recovery = Address::generate(&env);
+
+    let result = bridge.try_set_emergency_recovery(&recovery, &1_001);
+    assert_eq!(result, Err(Ok(Error::ExceedsLimit)));
+    assert_eq!(bridge.get_emergency_recovery_cap(), None);
 }
 
 #[test]
@@ -1902,6 +1985,35 @@ fn test_batch_admin_empty_batch() {
     assert_eq!(result.success_count, 0);
     assert_eq!(result.failure_count, 0);
     assert!(result.failed_index.is_none());
+}
+
+#[test]
+fn test_batch_admin_overflow_prevention_with_malformed_payload() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_, bridge, _, _, _, _) = setup_bridge(&env, 10_000);
+    let starting_quota = bridge.get_withdrawal_quota();
+
+    let mut ops = soroban_sdk::Vec::new(&env);
+    // set_quota requires a 16-byte i128 payload; this malformed payload should
+    // fail safely and be counted, while other ops still execute.
+    ops.push_back(BatchAdminOp {
+        op_type: Symbol::new(&env, "set_quota"),
+        payload: Bytes::from_array(&env, &[1u8, 2, 3, 4]),
+    });
+    ops.push_back(BatchAdminOp {
+        op_type: Symbol::new(&env, "set_cooldown"),
+        payload: Bytes::from_array(&env, &120u32.to_be_bytes()),
+    });
+
+    let result = bridge.execute_batch_admin(&ops);
+    assert_eq!(result.total_ops, 2);
+    assert_eq!(result.success_count, 1);
+    assert_eq!(result.failure_count, 1);
+    assert_eq!(result.failed_index, Some(0));
+    assert_eq!(bridge.get_withdrawal_quota(), starting_quota);
+    assert_eq!(bridge.get_cooldown(), 120);
 }
 
 // ── fee vault tests ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- add `set_emergency_recovery(recovery, cap_limit)` with explicit max-cap enforcement against token limit, persisted cap storage, and `EmergencyRecoverySetEvent`
- harden overflow handling in `execute_batch_admin` counters/index conversion and in heartbeat nonce increment (returns `Error::Overflow` instead of implicit panic path)
- expand Soroban tests with pause invariants, emergency recovery cap behavior, heartbeat nonce overflow edge case, and malformed batch-op safety checks

## Linked Issues
Closes #655
Closes #653
Closes #644
Closes #622

## Test Plan
- [x] `cargo test --manifest-path stellar-contracts/Cargo.toml` *(currently fails due to pre-existing unrelated test compile issues in repository)*
