### PR TITLE
feat(frontend): add accessible avatar contrast normalization to chat …

### DIFF
--- a/dex_with_fiat_frontend/src/lib/chatTelemetry.test.ts
+++ b/dex_with_fiat_frontend/src/lib/chatTelemetry.test.ts
@@ -1,24 +1,28 @@
 import { describe, expect, it, beforeEach, vi } from 'vitest';
 import {
+  calculateContrastRatio,
   chatTelemetry,
+  getAccessibleAvatarTextColor,
   getTelemetryConsent,
   setTelemetryConsent,
   TELEMETRY_SCHEMA_VERSION,
   type ChatEvent,
+  type AccessibleAvatarColorTelemetryPayload,
   type MessageSendPayload,
   type MessageRetryPayload,
   type WalletConnectPayload,
   type BridgeOpenPayload,
   type TxConfirmPayload,
+  withAccessibleAvatarContrast,
 } from './chatTelemetry';
 
 // ── helpers ────────────────────────────────────────────────────────────────
 
-function captureNextEvent(): Promise<ChatEvent> {
+function captureNextEvent<P extends object>(): Promise<ChatEvent<P>> {
   return new Promise((resolve) => {
     window.addEventListener(
       'chat:telemetry',
-      (e) => resolve((e as CustomEvent<ChatEvent>).detail),
+      (e) => resolve((e as CustomEvent<ChatEvent<P>>).detail),
       { once: true },
     );
   });
@@ -72,7 +76,7 @@ describe('Event payload shapes', () => {
   });
 
   it('message_send has correct schema', async () => {
-    const promise = captureNextEvent();
+    const promise = captureNextEvent<MessageSendPayload>();
     chatTelemetry.messageSend({ messageLength: 42, hasWallet: true });
     const event = await promise;
 
@@ -80,59 +84,105 @@ describe('Event payload shapes', () => {
     expect(event.version).toBe(TELEMETRY_SCHEMA_VERSION);
     expect(typeof event.timestamp).toBe('number');
 
-    const payload = event.payload as MessageSendPayload;
+    const payload = event.payload;
     expect(payload.messageLength).toBe(42);
     expect(payload.hasWallet).toBe(true);
   });
 
   it('message_retry has correct schema', async () => {
-    const promise = captureNextEvent();
+    const promise = captureNextEvent<MessageRetryPayload>();
     chatTelemetry.messageRetry({ retryAttempts: 2, errorMessage: 'timeout' });
     const event = await promise;
 
     expect(event.name).toBe('message_retry');
-    const payload = event.payload as MessageRetryPayload;
+    const payload = event.payload;
     expect(payload.retryAttempts).toBe(2);
     expect(payload.errorMessage).toBe('timeout');
   });
 
   it('wallet_connect has correct schema', async () => {
-    const promise = captureNextEvent();
+    const promise = captureNextEvent<WalletConnectPayload>();
     chatTelemetry.walletConnect({ walletType: 'freighter', success: true });
     const event = await promise;
 
     expect(event.name).toBe('wallet_connect');
-    const payload = event.payload as WalletConnectPayload;
+    const payload = event.payload;
     expect(payload.walletType).toBe('freighter');
     expect(payload.success).toBe(true);
   });
 
   it('bridge_open has correct schema', async () => {
-    const promise = captureNextEvent();
+    const promise = captureNextEvent<BridgeOpenPayload>();
     chatTelemetry.bridgeOpen({ flow: 'deposit' });
     const event = await promise;
 
     expect(event.name).toBe('bridge_open');
-    const payload = event.payload as BridgeOpenPayload;
+    const payload = event.payload;
     expect(payload.flow).toBe('deposit');
   });
 
   it('tx_confirm has correct schema', async () => {
-    const promise = captureNextEvent();
+    const promise = captureNextEvent<TxConfirmPayload>();
     chatTelemetry.txConfirm({ assetCode: 'XLM', amountXlm: 10, network: 'TESTNET' });
     const event = await promise;
 
     expect(event.name).toBe('tx_confirm');
-    const payload = event.payload as TxConfirmPayload;
+    const payload = event.payload;
     expect(payload.assetCode).toBe('XLM');
     expect(payload.network).toBe('TESTNET');
   });
 
   it('every event includes the schema version', async () => {
-    const promise = captureNextEvent();
+    const promise = captureNextEvent<MessageSendPayload>();
     chatTelemetry.messageSend({ messageLength: 1, hasWallet: false });
     const event = await promise;
 
     expect(event.version).toBe(TELEMETRY_SCHEMA_VERSION);
+  });
+
+  it('normalizes avatar colors to an accessible text color when needed', async () => {
+    const promise = captureNextEvent<
+      MessageSendPayload & AccessibleAvatarColorTelemetryPayload
+    >();
+
+    chatTelemetry.messageSend({
+      messageLength: 12,
+      hasWallet: true,
+      avatarBackgroundColor: '#F3F4F6',
+      avatarTextColor: '#FFFFFF',
+    } as MessageSendPayload & {
+      avatarBackgroundColor: string;
+      avatarTextColor: string;
+    });
+
+    const event = await promise;
+    const payload = event.payload;
+
+    expect(payload.avatarBackgroundColor).toBe('#F3F4F6');
+    expect(payload.avatarTextColor).toBe('#111827');
+    expect(payload.avatarContrastCompliant).toBe(true);
+    expect(payload.avatarContrastRatio).toBeGreaterThanOrEqual(4.5);
+  });
+});
+
+describe('Avatar contrast helpers', () => {
+  it('calculates the expected contrast ratio for a compliant avatar pair', () => {
+    expect(calculateContrastRatio('#FFFFFF', '#2563EB')).toBeGreaterThanOrEqual(
+      4.5,
+    );
+  });
+
+  it('keeps the preferred avatar text color when it is already accessible', () => {
+    expect(getAccessibleAvatarTextColor('#2563EB', '#FFFFFF')).toBe('#FFFFFF');
+  });
+
+  it('switches to a darker avatar text color when light text is not accessible', () => {
+    expect(getAccessibleAvatarTextColor('#F3F4F6', '#FFFFFF')).toBe('#111827');
+  });
+
+  it('leaves payloads without avatar colors unchanged', () => {
+    const payload = { messageLength: 10, hasWallet: true };
+
+    expect(withAccessibleAvatarContrast(payload)).toEqual(payload);
   });
 });

--- a/dex_with_fiat_frontend/src/lib/chatTelemetry.ts
+++ b/dex_with_fiat_frontend/src/lib/chatTelemetry.ts
@@ -12,7 +12,7 @@ export type ChatEventName =
   | 'bridge_open'
   | 'tx_confirm';
 
-export interface ChatEvent<P extends Record<string, unknown> = Record<string, unknown>> {
+export interface ChatEvent<P extends object = Record<string, unknown>> {
   /** Normalized event name. */
   name: ChatEventName;
   /** Schema version for this payload shape. */
@@ -50,9 +50,141 @@ export interface TxConfirmPayload {
   network: string;
 }
 
+export interface AvatarColorTelemetryPayload {
+  avatarBackgroundColor: string;
+  avatarTextColor?: string;
+}
+
+export interface AccessibleAvatarColorTelemetryPayload
+  extends AvatarColorTelemetryPayload {
+  avatarTextColor: string;
+  avatarContrastRatio: number;
+  avatarContrastCompliant: boolean;
+}
+
 // ── Consent key ───────────────────────────────────────────────────────────
 
 const CONSENT_KEY = 'nova_telemetry_consent';
+const MIN_CONTRAST_RATIO = 4.5;
+const FALLBACK_LIGHT_TEXT = '#FFFFFF';
+const FALLBACK_DARK_TEXT = '#111827';
+
+function normalizeHexColor(color: string): string | null {
+  const trimmed = color.trim();
+
+  if (/^#[\da-f]{3}$/i.test(trimmed)) {
+    const [, r, g, b] = trimmed;
+    return `#${r}${r}${g}${g}${b}${b}`.toUpperCase();
+  }
+
+  if (/^#[\da-f]{6}$/i.test(trimmed)) {
+    return trimmed.toUpperCase();
+  }
+
+  return null;
+}
+
+function getRelativeLuminance(color: string): number | null {
+  const normalizedColor = normalizeHexColor(color);
+  if (!normalizedColor) return null;
+
+  const hex = normalizedColor.slice(1);
+  const channels = [0, 2, 4].map((offset) => {
+    const sRGB = Number.parseInt(hex.slice(offset, offset + 2), 16) / 255;
+    return sRGB <= 0.03928
+      ? sRGB / 12.92
+      : ((sRGB + 0.055) / 1.055) ** 2.4;
+  });
+
+  return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
+}
+
+export function calculateContrastRatio(
+  foregroundColor: string,
+  backgroundColor: string,
+): number | null {
+  const foregroundLuminance = getRelativeLuminance(foregroundColor);
+  const backgroundLuminance = getRelativeLuminance(backgroundColor);
+
+  if (
+    foregroundLuminance === null ||
+    backgroundLuminance === null
+  ) {
+    return null;
+  }
+
+  const lighter = Math.max(foregroundLuminance, backgroundLuminance);
+  const darker = Math.min(foregroundLuminance, backgroundLuminance);
+  const ratio = (lighter + 0.05) / (darker + 0.05);
+
+  return Number(ratio.toFixed(2));
+}
+
+export function getAccessibleAvatarTextColor(
+  backgroundColor: string,
+  preferredTextColor = FALLBACK_LIGHT_TEXT,
+): string {
+  const normalizedBackgroundColor = normalizeHexColor(backgroundColor);
+  const normalizedPreferredTextColor =
+    normalizeHexColor(preferredTextColor) ?? FALLBACK_LIGHT_TEXT;
+
+  if (!normalizedBackgroundColor) {
+    return normalizedPreferredTextColor;
+  }
+
+  const candidateColors = [
+    normalizedPreferredTextColor,
+    FALLBACK_LIGHT_TEXT,
+    FALLBACK_DARK_TEXT,
+  ].filter((color, index, allColors) => allColors.indexOf(color) === index);
+
+  let bestColor = candidateColors[0];
+  let bestRatio =
+    calculateContrastRatio(bestColor, normalizedBackgroundColor) ?? 0;
+
+  for (const candidateColor of candidateColors.slice(1)) {
+    const candidateRatio =
+      calculateContrastRatio(candidateColor, normalizedBackgroundColor) ?? 0;
+
+    if (candidateRatio > bestRatio) {
+      bestColor = candidateColor;
+      bestRatio = candidateRatio;
+    }
+  }
+
+  return bestRatio >= MIN_CONTRAST_RATIO ? bestColor : normalizedPreferredTextColor;
+}
+
+export function withAccessibleAvatarContrast<
+  P extends object,
+>(payload: P): P | (P & AccessibleAvatarColorTelemetryPayload) {
+  const avatarPayload = payload as Partial<AvatarColorTelemetryPayload>;
+  const backgroundColor =
+    typeof avatarPayload.avatarBackgroundColor === 'string'
+      ? normalizeHexColor(avatarPayload.avatarBackgroundColor)
+      : null;
+
+  if (!backgroundColor) {
+    return payload;
+  }
+
+  const accessibleTextColor = getAccessibleAvatarTextColor(
+    backgroundColor,
+    typeof avatarPayload.avatarTextColor === 'string'
+      ? avatarPayload.avatarTextColor
+      : FALLBACK_LIGHT_TEXT,
+  );
+  const contrastRatio =
+    calculateContrastRatio(accessibleTextColor, backgroundColor) ?? 0;
+
+  return {
+    ...payload,
+    avatarBackgroundColor: backgroundColor,
+    avatarTextColor: accessibleTextColor,
+    avatarContrastRatio: contrastRatio,
+    avatarContrastCompliant: contrastRatio >= MIN_CONTRAST_RATIO,
+  };
+}
 
 export function getTelemetryConsent(): boolean {
   if (typeof window === 'undefined') return false;
@@ -89,11 +221,13 @@ function emit<P extends object>(
 ): void {
   if (!getTelemetryConsent()) return;
 
+  const normalizedPayload = withAccessibleAvatarContrast(payload);
+
   const event: ChatEvent = {
     name,
     version: TELEMETRY_SCHEMA_VERSION,
     timestamp: Date.now(),
-    payload: payload as Record<string, unknown>,
+    payload: normalizedPayload,
   };
 
   if (typeof window !== 'undefined') {
@@ -101,7 +235,7 @@ function emit<P extends object>(
       new CustomEvent('chat:telemetry', { detail: event }),
     );
   }
-}
+}   
 
 // ── Public API ────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Closes #601

This PR adds accessible avatar color handling to chatTelemetry.ts by normalizing optional avatar color payload fields, calculating contrast ratio, and automatically choosing a more readable text color when needed. It also expands chatTelemetry.test.ts with coverage for contrast calculation, accessible color selection, unchanged payload behavior, and emitted telemetry payload normalization.


