### PR TITLE
feat(frontend): SplitView tokens/ARIA, Landing ARIA, PriceTicker shortcuts

### DIFF
--- a/dex_with_fiat_frontend/src/components/LandingPage.tsx
+++ b/dex_with_fiat_frontend/src/components/LandingPage.tsx
@@ -222,8 +222,12 @@ export default function LandingPage() {
         </button>
       </div>
 
+      <main id="landing-main" aria-label="DexFiat product overview">
       {/* Hero Section */}
-      <section className="relative min-h-screen flex items-center justify-center px-4 overflow-hidden">
+      <section
+        className="relative min-h-screen flex items-center justify-center px-4 overflow-hidden"
+        aria-labelledby="landing-hero-heading"
+      >
         {/* Animated Background Elements */}
         <div className="absolute inset-0 overflow-hidden">
           <div className="absolute -top-40 -right-40 w-80 h-80 bg-blue-600/10 rounded-full blur-3xl animate-pulse"></div>
@@ -233,7 +237,7 @@ export default function LandingPage() {
         <div
           className={`relative z-10 text-center max-w-5xl mx-auto transform transition-all duration-1000 ${heroVisible ? 'translate-y-0 opacity-100' : 'translate-y-12 opacity-0'}`}
         >
-          <h1 className="text-5xl md:text-7xl font-bold mb-6 leading-tight">
+          <h1 id="landing-hero-heading" className="text-5xl md:text-7xl font-bold mb-6 leading-tight">
             <span className="bg-gradient-to-r from-blue-400 to-purple-400 bg-clip-text text-transparent">
               XLM-to-Fiat
             </span>{' '}
@@ -284,8 +288,10 @@ export default function LandingPage() {
 
           <div className="flex flex-col sm:flex-row gap-4 justify-center items-center mb-8">
             <button
+              type="button"
               onClick={handleGetStarted}
               className="group flex items-center space-x-2 bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 px-8 py-4 rounded-lg text-lg font-semibold transition-all duration-300 hover:scale-105 shadow-lg hover:shadow-blue-500/25"
+              aria-label="Start bridging: open the chat app"
             >
               <Play className="w-5 h-5" />
               <span>Start Bridging</span>
@@ -297,6 +303,7 @@ export default function LandingPage() {
               target="_blank"
               rel="noopener noreferrer"
               className="text-[var(--color-text-muted)] hover:text-blue-500 transition-colors duration-300 text-sm underline"
+              aria-label="View Stellar Testnet on Stellar Expert (opens in a new tab)"
             >
               View on Stellar Expert →
             </a>
@@ -316,10 +323,10 @@ export default function LandingPage() {
       </section>
 
       {/* Features Section */}
-      <section className="py-20 px-4">
+      <section className="py-20 px-4" aria-labelledby="landing-features-heading">
         <div className="max-w-6xl mx-auto">
           <div className="text-center mb-16">
-            <h2 className="text-4xl font-bold mb-4 text-[var(--color-text-primary)]">
+            <h2 id="landing-features-heading" className="text-4xl font-bold mb-4 text-[var(--color-text-primary)]">
               Why Choose DexFiat on Stellar
             </h2>
             <p className="text-xl text-[var(--color-text-secondary)] max-w-3xl mx-auto">
@@ -337,10 +344,10 @@ export default function LandingPage() {
       </section>
 
       {/* Technology Stack */}
-      <section className="py-20 px-4 bg-[var(--color-surface-muted)]">
+      <section className="py-20 px-4 bg-[var(--color-surface-muted)]" aria-labelledby="landing-tech-heading">
         <div className="max-w-6xl mx-auto">
           <div className="text-center mb-16">
-            <h2 className="text-4xl font-bold mb-4 text-[var(--color-text-primary)]">
+            <h2 id="landing-tech-heading" className="text-4xl font-bold mb-4 text-[var(--color-text-primary)]">
               Powered by Stellar Infrastructure
             </h2>
             <p className="text-xl text-[var(--color-text-secondary)] max-w-3xl mx-auto">
@@ -387,10 +394,10 @@ export default function LandingPage() {
       </section>
 
       {/* Supported Assets */}
-      <section className="py-20 px-4">
+      <section className="py-20 px-4" aria-labelledby="landing-assets-heading">
         <div className="max-w-6xl mx-auto">
           <div className="text-center mb-16">
-            <h2 className="text-4xl font-bold mb-4 text-[var(--color-text-primary)]">
+            <h2 id="landing-assets-heading" className="text-4xl font-bold mb-4 text-[var(--color-text-primary)]">
               Stellar Assets &amp; Fiat Currencies
             </h2>
             <p className="text-xl text-[var(--color-text-secondary)] max-w-3xl mx-auto">
@@ -464,10 +471,10 @@ export default function LandingPage() {
       </section>
 
       {/* Testimonials */}
-      <section className="py-20 px-4 bg-[var(--color-surface-muted)]">
+      <section className="py-20 px-4 bg-[var(--color-surface-muted)]" aria-labelledby="landing-testimonials-heading">
         <div className="max-w-6xl mx-auto">
           <div className="text-center mb-16">
-            <h2 className="text-4xl font-bold mb-4 text-[var(--color-text-primary)]">Trusted by DeFi Leaders</h2>
+            <h2 id="landing-testimonials-heading" className="text-4xl font-bold mb-4 text-[var(--color-text-primary)]">Trusted by DeFi Leaders</h2>
             <p className="text-xl text-[var(--color-text-secondary)]">
               Join thousands of satisfied users who trust our platform
             </p>
@@ -525,10 +532,10 @@ export default function LandingPage() {
       </section>
 
       {/* Features Section */}
-      <section className="py-20 px-4">
+      <section className="py-20 px-4" aria-labelledby="landing-platform-heading">
         <div className="max-w-6xl mx-auto">
           <div className="text-center mb-16">
-            <h2 className="text-4xl font-bold mb-4 text-[var(--color-text-primary)]">Why Choose Our Platform</h2>
+            <h2 id="landing-platform-heading" className="text-4xl font-bold mb-4 text-[var(--color-text-primary)]">Why Choose Our Platform</h2>
             <p className="text-xl text-[var(--color-text-secondary)] max-w-3xl mx-auto">
               Built for the future of finance with cutting-edge blockchain
               technology and enterprise-grade security
@@ -544,10 +551,10 @@ export default function LandingPage() {
       </section>
 
       {/* How It Works */}
-      <section className="py-20 px-4 bg-gray-800/30">
+      <section className="py-20 px-4 bg-gray-800/30" aria-labelledby="landing-how-heading">
         <div className="max-w-4xl mx-auto">
           <div className="text-center mb-16">
-            <h2 className="text-4xl font-bold mb-4 text-[var(--color-text-primary)]">
+            <h2 id="landing-how-heading" className="text-4xl font-bold mb-4 text-[var(--color-text-primary)]">
               How Stellar FiatBridge Works
             </h2>
             <p className="text-xl text-[var(--color-text-secondary)]">
@@ -564,9 +571,9 @@ export default function LandingPage() {
       </section>
 
       {/* Early Access Form */}
-      <section className="py-20 px-4">
+      <section className="py-20 px-4" aria-labelledby="landing-early-access-heading">
         <div className="max-w-2xl mx-auto text-center">
-          <h2 className="text-4xl font-bold mb-4">
+          <h2 id="landing-early-access-heading" className="text-4xl font-bold mb-4">
             Join the Stellar DeFi Revolution
           </h2>
           <p className="text-xl text-[var(--color-text-secondary)] mb-8">
@@ -578,18 +585,25 @@ export default function LandingPage() {
             <form
               onSubmit={handleEmailSubmit}
               className="flex flex-col sm:flex-row gap-4 max-w-lg mx-auto"
+              aria-label="Early access email signup"
             >
+              <label htmlFor="landing-email-input" className="sr-only">
+                Email address for early access
+              </label>
               <input
+                id="landing-email-input"
                 type="email"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
                 placeholder="Enter your email address"
+                autoComplete="email"
                 className="flex-1 px-4 py-3 rounded-lg bg-[var(--color-surface)] border border-[var(--color-border)] text-[var(--color-text-primary)] placeholder-[var(--color-text-muted)] focus:outline-none focus:border-blue-500 transition-colors duration-300"
                 required
               />
               <button
                 type="submit"
                 className="bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 px-6 py-3 rounded-lg font-semibold transition-all duration-300 hover:scale-105 whitespace-nowrap"
+                aria-label="Submit email and launch app"
               >
                 Launch App
               </button>
@@ -608,6 +622,7 @@ export default function LandingPage() {
           </p>
         </div>
       </section>
+      </main>
 
       {/* Footer */}
       <footer className="bg-[var(--color-surface)] border-t border-[var(--color-border)]">
@@ -623,30 +638,34 @@ export default function LandingPage() {
                 The future of crypto-to-fiat conversion. Secure, fast, and
                 compliant with global financial standards.
               </p>
-              <div className="flex space-x-4">
+              <div className="flex space-x-4" role="list" aria-label="DexFiat social links">
                 <a
                   href="#"
                   className="text-[var(--color-text-muted)] hover:text-blue-500 transition-colors"
+                  aria-label="DexFiat on Twitter"
                 >
-                  <Twitter className="w-5 h-5" />
+                  <Twitter className="w-5 h-5" aria-hidden />
                 </a>
                 <a
                   href="#"
                   className="text-[var(--color-text-muted)] hover:text-blue-500 transition-colors"
+                  aria-label="DexFiat on GitHub"
                 >
-                  <Github className="w-5 h-5" />
+                  <Github className="w-5 h-5" aria-hidden />
                 </a>
                 <a
                   href="#"
                   className="text-[var(--color-text-muted)] hover:text-blue-500 transition-colors"
+                  aria-label="DexFiat on LinkedIn"
                 >
-                  <Linkedin className="w-5 h-5" />
+                  <Linkedin className="w-5 h-5" aria-hidden />
                 </a>
                 <a
                   href="#"
                   className="text-[var(--color-text-muted)] hover:text-blue-500 transition-colors"
+                  aria-label="DexFiat community chat"
                 >
-                  <MessageSquare className="w-5 h-5" />
+                  <MessageSquare className="w-5 h-5" aria-hidden />
                 </a>
               </div>
             </div>

--- a/dex_with_fiat_frontend/src/components/PriceTicker.tsx
+++ b/dex_with_fiat_frontend/src/components/PriceTicker.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useRef, useCallback, useId } from 'react';
 import { TrendingUp, TrendingDown } from 'lucide-react';
 import { fetchTickerData, TickerData } from '@/lib/cryptoPriceService';
 
@@ -19,6 +19,10 @@ export default function PriceTicker({
   const [error, setError] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const refreshTimeoutRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const kbHelpId = useId();
+
+  const itemsPerPage = 5;
+  const totalPages = Math.max(1, Math.ceil(symbols.length / itemsPerPage));
 
   // Format price based on currency
   const formatPrice = (price: number) => {
@@ -49,7 +53,7 @@ export default function PriceTicker({
     try {
       setError(false);
       const newPrices = await fetchTickerData(symbols, currency);
-      
+
       if (Object.keys(newPrices).length === 0) {
         setError(true);
       } else {
@@ -80,12 +84,30 @@ export default function PriceTicker({
   }, [fetchPrices, refreshInterval]);
 
   const [currentPage, setCurrentPage] = useState(0);
-  const itemsPerPage = 5;
 
-  const totalPages = Math.ceil(symbols.length / itemsPerPage);
   const paginatedSymbols = symbols.slice(
     currentPage * itemsPerPage,
     (currentPage + 1) * itemsPerPage,
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (e.key === 'ArrowLeft') {
+        e.preventDefault();
+        setCurrentPage((p) => Math.max(0, p - 1));
+        return;
+      }
+      if (e.key === 'ArrowRight') {
+        e.preventDefault();
+        setCurrentPage((p) => Math.min(totalPages - 1, p + 1));
+        return;
+      }
+      if (e.key === 'r' || e.key === 'R') {
+        e.preventDefault();
+        void fetchPrices();
+      }
+    },
+    [fetchPrices, totalPages],
   );
 
   // Show error state
@@ -112,7 +134,20 @@ export default function PriceTicker({
   }
 
   return (
-    <div className="theme-surface-muted rounded-lg border theme-border p-3">
+    <div
+      role="region"
+      tabIndex={0}
+      aria-label="Market prices ticker"
+      aria-keyshortcuts="ArrowLeft ArrowRight R"
+      aria-describedby={kbHelpId}
+      data-testid="price-ticker"
+      onKeyDown={handleKeyDown}
+      className="theme-surface-muted rounded-lg border theme-border p-3 outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background)]"
+    >
+      <span id={kbHelpId} className="sr-only">
+        Keyboard shortcuts: Left Arrow for previous page, Right Arrow for next page, R to refresh prices.
+      </span>
+
       <div className="flex items-center justify-between mb-2">
         <h3 className="theme-text-primary text-xs font-semibold uppercase tracking-wider">
           Market Prices
@@ -121,13 +156,14 @@ export default function PriceTicker({
           className={`w-2 h-2 rounded-full transition-colors duration-300 ${
             error ? 'bg-red-500' : 'bg-green-500'
           }`}
+          aria-hidden
         />
       </div>
 
       <div className="space-y-2">
         {paginatedSymbols.map((symbol) => {
           const priceData = prices[symbol];
-          
+
           if (!priceData) {
             return (
               <div key={symbol} className="flex items-center justify-between text-xs h-6 opacity-50">
@@ -164,8 +200,8 @@ export default function PriceTicker({
                       : 'theme-text-secondary'
                 }`}
               >
-                {isPositive && <TrendingUp className="w-3 h-3" />}
-                {isNegative && <TrendingDown className="w-3 h-3" />}
+                {isPositive && <TrendingUp className="w-3 h-3" aria-hidden />}
+                {isNegative && <TrendingDown className="w-3 h-3" aria-hidden />}
                 <span className="font-medium">
                   {formatChange(change)}
                 </span>
@@ -178,23 +214,27 @@ export default function PriceTicker({
       {totalPages > 1 && (
         <div className="flex items-center justify-center gap-2 mt-3 pt-2 border-t border-gray-100 dark:border-gray-800">
           <button
+            type="button"
             onClick={() => setCurrentPage((p) => Math.max(0, p - 1))}
             disabled={currentPage === 0}
+            aria-label="Previous price page"
             className="p-1 hover:bg-gray-100 dark:hover:bg-gray-800 rounded disabled:opacity-30"
           >
-            <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
             </svg>
           </button>
-          <span className="text-[10px] theme-text-secondary font-medium">
+          <span className="text-[10px] theme-text-secondary font-medium" aria-live="polite">
             {currentPage + 1} / {totalPages}
           </span>
           <button
+            type="button"
             onClick={() => setCurrentPage((p) => Math.min(totalPages - 1, p + 1))}
             disabled={currentPage === totalPages - 1}
+            aria-label="Next price page"
             className="p-1 hover:bg-gray-100 dark:hover:bg-gray-800 rounded disabled:opacity-30"
           >
-            <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
             </svg>
           </button>
@@ -203,7 +243,7 @@ export default function PriceTicker({
 
       {error && Object.keys(prices).length > 0 && (
         <p className="theme-text-secondary text-[10px] mt-2 text-center opacity-60">
-          Last updated • Tap to refresh
+          Last updated • Focus this panel and press R to refresh
         </p>
       )}
     </div>

--- a/dex_with_fiat_frontend/src/components/SplitViewComparison.tsx
+++ b/dex_with_fiat_frontend/src/components/SplitViewComparison.tsx
@@ -2,7 +2,6 @@
 
 import React, { useRef } from 'react';
 import { ArrowLeftRight, X, ChevronDown } from 'lucide-react';
-import { useTheme } from '@/contexts/ThemeContext';
 import { ChatSession, ChatMessage } from '@/types';
 import { UseSplitViewReturn } from '@/hooks/useSplitView';
 
@@ -22,7 +21,6 @@ interface ThreadPaneProps {
   allSessions: ChatSession[];
   onSelectSession: (id: string) => void;
   onSelectMessage: (id: string | null) => void;
-  isDarkMode: boolean;
 }
 
 function ThreadPane({
@@ -32,9 +30,9 @@ function ThreadPane({
   allSessions,
   onSelectSession,
   onSelectMessage,
-  isDarkMode,
 }: ThreadPaneProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
+  const paneId = `split-pane-${label.toLowerCase()}-region`;
 
   const scrollToMessage = (id: string) => {
     const el = scrollRef.current?.querySelector(`[data-message-id="${id}"]`);
@@ -51,12 +49,15 @@ function ThreadPane({
 
   return (
     <div
-      className={`flex flex-col flex-1 min-w-0 border-r last:border-r-0 ${isDarkMode ? 'border-gray-700' : 'border-gray-200'}`}
+      id={paneId}
+      role="region"
+      aria-label={`${label} thread comparison pane`}
+      className="flex flex-col flex-1 min-w-0 border-r border-[var(--color-border)] last:border-r-0"
       data-testid={`split-pane-${label.toLowerCase()}`}
     >
       {/* Pane header */}
-      <div className={`flex items-center gap-2 px-3 py-2 border-b flex-shrink-0 ${isDarkMode ? 'border-gray-700 bg-gray-800/60' : 'border-gray-200 bg-gray-50'}`}>
-        <span className={`text-xs font-semibold uppercase tracking-wider ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}>
+      <div className="flex items-center gap-2 px-3 py-2 border-b border-[var(--color-border)] bg-[var(--color-surface-muted)] flex-shrink-0">
+        <span className="text-xs font-semibold uppercase tracking-wider text-[var(--color-text-muted)]">
           {label}
         </span>
 
@@ -65,7 +66,7 @@ function ThreadPane({
           <select
             value={session?.id ?? ''}
             onChange={(e) => onSelectSession(e.target.value)}
-            className={`w-full text-xs pl-2 pr-6 py-1 rounded border appearance-none outline-none focus:ring-1 focus:ring-blue-500 truncate ${isDarkMode ? 'bg-gray-700 border-gray-600 text-gray-200' : 'bg-white border-gray-300 text-gray-800'}`}
+            className="w-full text-xs pl-2 pr-6 py-1 rounded border border-[var(--color-border)] appearance-none outline-none focus:ring-2 focus:ring-[var(--color-primary)] truncate bg-[var(--color-surface)] text-[var(--color-text-primary)]"
             aria-label={`Select ${label} thread`}
           >
             <option value="">— choose a thread —</option>
@@ -75,18 +76,27 @@ function ThreadPane({
               </option>
             ))}
           </select>
-          <ChevronDown className={`absolute right-1.5 top-1/2 -translate-y-1/2 w-3 h-3 pointer-events-none ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`} />
+          <ChevronDown
+            className="absolute right-1.5 top-1/2 -translate-y-1/2 w-3 h-3 pointer-events-none text-[var(--color-text-muted)]"
+            aria-hidden
+          />
         </div>
       </div>
 
       {/* Messages */}
-      <div ref={scrollRef} className="flex-1 overflow-y-auto px-3 py-3 space-y-2">
+      <div
+        ref={scrollRef}
+        role="log"
+        aria-relevant="additions"
+        aria-label={`${label} thread messages`}
+        className="flex-1 overflow-y-auto px-3 py-3 space-y-2"
+      >
         {!session ? (
-          <div className={`flex items-center justify-center h-full text-sm ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}>
+          <div className="flex items-center justify-center h-full text-sm text-[var(--color-text-muted)]">
             Select a thread above
           </div>
         ) : session.messages.filter((m) => m.role !== 'system').length === 0 ? (
-          <div className={`flex items-center justify-center h-full text-sm ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}>
+          <div className="flex items-center justify-center h-full text-sm text-[var(--color-text-muted)]">
             No messages in this thread
           </div>
         ) : (
@@ -102,23 +112,23 @@ function ThreadPane({
                   onClick={() => handleMessageClick(msg)}
                   className={`w-full text-left px-3 py-2 rounded-lg text-xs transition-all border ${
                     isSelected
-                      ? isDarkMode
-                        ? 'border-blue-500 bg-blue-900/30 ring-1 ring-blue-500'
-                        : 'border-blue-400 bg-blue-50 ring-1 ring-blue-400'
-                      : isDarkMode
-                        ? 'border-gray-700 hover:border-gray-600 hover:bg-gray-800'
-                        : 'border-gray-200 hover:border-gray-300 hover:bg-gray-50'
+                      ? 'border-[var(--color-primary)] bg-[var(--color-primary-soft)] ring-1 ring-[var(--color-primary)]'
+                      : 'border-[var(--color-border)] hover:border-[var(--color-text-muted)] hover:bg-[var(--color-surface-muted)]'
                   }`}
                   aria-pressed={isSelected}
                   aria-label={`${isUser ? 'User' : 'Assistant'} message`}
                 >
-                  <span className={`font-semibold ${isUser ? (isDarkMode ? 'text-blue-400' : 'text-blue-600') : (isDarkMode ? 'text-green-400' : 'text-green-700')}`}>
+                  <span
+                    className={`font-semibold ${
+                      isUser ? 'text-[var(--color-primary)]' : 'text-[var(--color-success)]'
+                    }`}
+                  >
                     {isUser ? 'You' : 'Assistant'}
                   </span>
-                  <p className={`mt-1 line-clamp-3 leading-relaxed ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}>
+                  <p className="mt-1 line-clamp-3 leading-relaxed text-[var(--color-text-secondary)]">
                     {msg.content}
                   </p>
-                  <p className={`mt-1 text-[10px] ${isDarkMode ? 'text-gray-600' : 'text-gray-400'}`}>
+                  <p className="mt-1 text-[10px] text-[var(--color-text-muted)]">
                     {new Date(msg.timestamp).toLocaleString([], {
                       month: 'short',
                       day: 'numeric',
@@ -143,28 +153,34 @@ export default function SplitViewComparison({
   splitView,
   sessions,
 }: SplitViewComparisonProps) {
-  const { isDarkMode } = useTheme();
-  const { state, close, setLeftSession, setRightSession, swapSessions, selectMessage, leftSession, rightSession } = splitView;
+  const { state, close, setLeftSession, setRightSession, swapSessions, selectMessage, leftSession, rightSession } =
+    splitView;
 
   if (!state.isOpen) return null;
 
+  const dialogTitleId = 'split-view-comparison-title';
+
   return (
     <div
-      className={`fixed inset-0 z-50 flex flex-col ${isDarkMode ? 'bg-gray-900' : 'bg-white'}`}
+      className="fixed inset-0 z-50 flex flex-col bg-[var(--background)] text-[var(--foreground)]"
       role="dialog"
       aria-modal="true"
-      aria-label="Split-view thread comparison"
+      aria-labelledby={dialogTitleId}
       data-testid="split-view-comparison"
     >
       {/* Toolbar */}
-      <div className={`flex items-center justify-between px-4 py-2 border-b flex-shrink-0 ${isDarkMode ? 'border-gray-700 bg-gray-800' : 'border-gray-200 bg-gray-50'}`}>
-        <h2 className={`text-sm font-semibold ${isDarkMode ? 'text-gray-200' : 'text-gray-800'}`}>
+      <div
+        role="toolbar"
+        aria-label="Comparison actions"
+        className="flex items-center justify-between px-4 py-2 border-b border-[var(--color-border)] bg-[var(--color-surface-muted)] flex-shrink-0"
+      >
+        <h2 id={dialogTitleId} className="text-sm font-semibold text-[var(--color-text-primary)]">
           Compare Threads
         </h2>
 
         <div className="flex items-center gap-2">
           {state.selectedMessageId && (
-            <span className={`text-xs px-2 py-0.5 rounded ${isDarkMode ? 'bg-blue-900/40 text-blue-400' : 'bg-blue-100 text-blue-700'}`}>
+            <span className="text-xs px-2 py-0.5 rounded bg-[var(--color-primary-soft)] text-[var(--color-primary)]">
               Message selected
             </span>
           )}
@@ -174,10 +190,10 @@ export default function SplitViewComparison({
             onClick={swapSessions}
             title="Swap threads"
             aria-label="Swap left and right threads"
-            className={`flex items-center gap-1 px-3 py-1.5 rounded-lg text-xs font-medium transition-all ${isDarkMode ? 'bg-gray-700 hover:bg-gray-600 text-gray-200' : 'bg-white hover:bg-gray-100 text-gray-700 border border-gray-300'}`}
+            className="flex items-center gap-1 px-3 py-1.5 rounded-lg text-xs font-medium transition-all bg-[var(--color-surface)] hover:bg-[var(--color-surface-elevated)] text-[var(--color-text-primary)] border border-[var(--color-border)]"
             data-testid="swap-threads-btn"
           >
-            <ArrowLeftRight className="w-3.5 h-3.5" />
+            <ArrowLeftRight className="w-3.5 h-3.5" aria-hidden />
             Swap
           </button>
 
@@ -186,10 +202,10 @@ export default function SplitViewComparison({
             onClick={close}
             title="Close comparison"
             aria-label="Close split-view"
-            className={`p-1.5 rounded-lg transition-colors ${isDarkMode ? 'hover:bg-gray-700 text-gray-400' : 'hover:bg-gray-200 text-gray-500'}`}
+            className="p-1.5 rounded-lg transition-colors hover:bg-[var(--color-surface-elevated)] text-[var(--color-text-muted)]"
             data-testid="close-split-view-btn"
           >
-            <X className="w-4 h-4" />
+            <X className="w-4 h-4" aria-hidden />
           </button>
         </div>
       </div>
@@ -203,7 +219,6 @@ export default function SplitViewComparison({
           allSessions={sessions}
           onSelectSession={setLeftSession}
           onSelectMessage={selectMessage}
-          isDarkMode={isDarkMode}
         />
         <ThreadPane
           session={rightSession}
@@ -212,7 +227,6 @@ export default function SplitViewComparison({
           allSessions={sessions}
           onSelectSession={setRightSession}
           onSelectMessage={selectMessage}
-          isDarkMode={isDarkMode}
         />
       </div>
     </div>

--- a/dex_with_fiat_frontend/src/components/__tests__/LandingPage.test.tsx
+++ b/dex_with_fiat_frontend/src/components/__tests__/LandingPage.test.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import LandingPage from '@/components/LandingPage';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+  }),
+}));
+
+vi.mock('../../contexts/ThemeContext', () => ({
+  useTheme: () => ({
+    isDarkMode: false,
+    toggleDarkMode: vi.fn(),
+  }),
+}));
+
+vi.mock('@/components/OfflineStatusBanner', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/components/ui/CopyButton', () => ({
+  default: () => <button type="button">Copy</button>,
+}));
+
+describe('LandingPage – accessibility', () => {
+  afterEach(cleanup);
+
+  it('wraps primary content in a labeled main landmark', () => {
+    render(<LandingPage />);
+    expect(screen.getByRole('main', { name: /DexFiat product overview/i })).toBeDefined();
+  });
+
+  it('associates the early-access email field with a label', () => {
+    render(<LandingPage />);
+    expect(screen.getByLabelText(/email address for early access/i)).toBeDefined();
+  });
+
+  it('labels the Stellar Expert external link for screen readers', () => {
+    render(<LandingPage />);
+    expect(
+      screen.getByRole('link', { name: /View Stellar Testnet on Stellar Expert/i }),
+    ).toBeDefined();
+  });
+
+  it('labels footer social links', () => {
+    render(<LandingPage />);
+    expect(screen.getByRole('link', { name: /DexFiat on Twitter/i })).toBeDefined();
+    expect(screen.getByRole('link', { name: /DexFiat on GitHub/i })).toBeDefined();
+  });
+});

--- a/dex_with_fiat_frontend/src/components/__tests__/PriceTicker.test.tsx
+++ b/dex_with_fiat_frontend/src/components/__tests__/PriceTicker.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { describe, expect, it, vi, afterEach, beforeEach } from 'vitest';
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
+import PriceTicker from '@/components/PriceTicker';
+
+const fetchTickerDataMock = vi.fn();
+
+vi.mock('@/lib/cryptoPriceService', () => ({
+  fetchTickerData: (...args: unknown[]) => fetchTickerDataMock(...args),
+}));
+
+function mockPrices(symbols: string[]) {
+  const out: Record<string, { symbol: string; price: number; change24h: number; currency: string }> = {};
+  for (const s of symbols) {
+    out[s] = { symbol: s, price: 1, change24h: 0.5, currency: 'usd' };
+  }
+  return out;
+}
+
+describe('PriceTicker – keyboard shortcuts', () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  beforeEach(() => {
+    fetchTickerDataMock.mockImplementation(async (symbols: string[]) => mockPrices(symbols));
+  });
+
+  it('moves to the next page with ArrowRight when focused', async () => {
+    const symbols = ['A', 'B', 'C', 'D', 'E', 'F'];
+    render(<PriceTicker symbols={symbols} refreshInterval={600_000} />);
+
+    await waitFor(() => {
+      expect(fetchTickerDataMock).toHaveBeenCalled();
+    });
+
+    expect(screen.getByText('A')).toBeDefined();
+    const ticker = screen.getByTestId('price-ticker');
+    ticker.focus();
+    fireEvent.keyDown(ticker, { key: 'ArrowRight' });
+    await waitFor(() => {
+      expect(screen.getByText('F')).toBeDefined();
+    });
+  });
+
+  it('refreshes prices when R is pressed while focused', async () => {
+    const symbols = ['XLM'];
+    render(<PriceTicker symbols={symbols} refreshInterval={600_000} />);
+
+    await waitFor(() => {
+      expect(fetchTickerDataMock).toHaveBeenCalledTimes(1);
+    });
+
+    const ticker = screen.getByTestId('price-ticker');
+    ticker.focus();
+    fireEvent.keyDown(ticker, { key: 'r' });
+
+    await waitFor(() => {
+      expect(fetchTickerDataMock.mock.calls.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+});

--- a/dex_with_fiat_frontend/src/components/__tests__/SplitViewComparison.test.tsx
+++ b/dex_with_fiat_frontend/src/components/__tests__/SplitViewComparison.test.tsx
@@ -9,10 +9,6 @@ import SplitViewComparison from '@/components/SplitViewComparison';
 // Mocks
 // ---------------------------------------------------------------------------
 
-vi.mock('@/contexts/ThemeContext', () => ({
-  useTheme: () => ({ isDarkMode: false }),
-}));
-
 // ---------------------------------------------------------------------------
 // Fixtures
 // ---------------------------------------------------------------------------
@@ -86,6 +82,23 @@ describe('SplitViewComparison – layout', () => {
     const dialog = screen.getByTestId('split-view-comparison');
     expect(dialog.getAttribute('role')).toBe('dialog');
     expect(dialog.getAttribute('aria-modal')).toBe('true');
+    expect(dialog.getAttribute('aria-labelledby')).toBe('split-view-comparison-title');
+  });
+
+  it('exposes labeled regions and a toolbar for assistive tech', () => {
+    const splitView = makeSplitView();
+    render(<SplitViewComparison splitView={splitView} sessions={allSessions} />);
+    expect(screen.getByRole('region', { name: /left thread comparison pane/i })).toBeDefined();
+    expect(screen.getByRole('region', { name: /right thread comparison pane/i })).toBeDefined();
+    expect(screen.getByRole('toolbar', { name: /comparison actions/i })).toBeDefined();
+  });
+
+  it('uses theme CSS variables for surfaces and borders', () => {
+    const splitView = makeSplitView();
+    const { container } = render(<SplitViewComparison splitView={splitView} sessions={allSessions} />);
+    const root = container.querySelector('[data-testid="split-view-comparison"]');
+    expect(root?.getAttribute('class')).toContain('var(--background)');
+    expect(root?.getAttribute('class')).toContain('var(--foreground)');
   });
 
   it('shows messages from the left session', () => {


### PR DESCRIPTION
## Summary
- **SplitViewComparison** (#638, #643): Uses shared theme CSS variables instead of hardcoded light/dark grays; adds labeled `region` panes, a comparison `toolbar`, message list semantics, and `aria-labelledby` on the dialog.
- **LandingPage** (#640): Adds a `<main>` landmark, `aria-labelledby` on major sections, an associated label for the early-access email field, and accessible names on CTAs, the Stellar Expert link, and footer social links.
- **PriceTicker** (#648): Keyboard shortcuts when the ticker is focused (arrow keys to change page, **R** to refresh), `aria-keyshortcuts` + screen-reader help text, and labeled pagination controls.

## Tests
```bash
cd dex_with_fiat_frontend
npx vitest run src/components/__tests__/SplitViewComparison.test.tsx \
  src/components/__tests__/LandingPage.test.tsx \
  src/components/__tests__/PriceTicker.test.tsx
```

Closes #638
Closes #640
Closes #643
Closes #648

Made with [Cursor](https://cursor.com)