### PR TITLE
fix: slippage docs, Zod fiat modal, feature-flag borders, audit race

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ DEX-CHAT converts crypto to fiat through an AI-guided conversation flow. The end
 
 The user connects their Freighter wallet and tells the AI assistant they want to offramp a token amount. The frontend builds a Soroban `deposit` transaction that transfers the specified token from the user's Stellar account into the `FiatBridge` contract. The contract validates the deposit against oracle-sourced prices, enforces slippage limits, checks per-token and daily deposit caps, and records a `Receipt` with a unique memo hash.
 
+For maintainers: how slippage BPS and the on-chain threshold interact is documented in [docs/slippage-threshold.md](docs/slippage-threshold.md).
+
 ### 2. Escrow (on-chain hold)
 
 Deposited funds are held in the smart contract's escrow. A withdrawal request is queued with a risk tier that determines the timelock duration — higher-value or higher-risk withdrawals wait longer before they can be executed. During this period the admin dashboard provides real-time metrics (queue depth, oldest request age, accrued fees) so operators can monitor the pipeline.

--- a/dex_with_fiat_frontend/src/components/AuditTable.test.tsx
+++ b/dex_with_fiat_frontend/src/components/AuditTable.test.tsx
@@ -1,0 +1,87 @@
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import AuditTable from './AuditTable';
+
+describe('AuditTable', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does not apply stale fetch results after a newer request (abort)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((url: string | URL, init?: RequestInit) => {
+        const u = typeof url === 'string' ? url : url.toString();
+        const signal = init?.signal;
+        const isDeposit = u.includes('actionType=deposit');
+
+        return new Promise<Response>((resolve, reject) => {
+          const delayMs = isDeposit ? 200 : 0;
+          const t = setTimeout(() => {
+            if (signal?.aborted) {
+              reject(new DOMException('Aborted', 'AbortError'));
+              return;
+            }
+            resolve({
+              ok: true,
+              status: 200,
+              json: async () => ({
+                entries: isDeposit
+                  ? [
+                      {
+                        id: 'stale',
+                        timestamp: new Date().toISOString(),
+                        adminAddress:
+                          'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
+                        actionType: 'deposit',
+                        actionDescription: 'stale-row',
+                        txHash: 'abc',
+                        status: 'success',
+                      },
+                    ]
+                  : [
+                      {
+                        id: 'fresh',
+                        timestamp: new Date().toISOString(),
+                        adminAddress:
+                          'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
+                        actionType: 'payout',
+                        actionDescription: 'fresh-row',
+                        txHash: 'def',
+                        status: 'success',
+                      },
+                    ],
+                total: 1,
+              }),
+            } as Response);
+          }, delayMs);
+
+          signal?.addEventListener('abort', () => {
+            clearTimeout(t);
+            reject(new DOMException('Aborted', 'AbortError'));
+          });
+        });
+      }),
+    );
+
+    render(<AuditTable />);
+
+    await waitFor(() => {
+      expect(screen.getByText('fresh-row')).toBeInTheDocument();
+    });
+
+    const actionSelect = screen.getAllByRole('combobox')[0];
+    fireEvent.change(actionSelect, { target: { value: 'deposit' } });
+    fireEvent.change(actionSelect, { target: { value: '' } });
+
+    await waitFor(
+      () => {
+        expect(screen.getByText('fresh-row')).toBeInTheDocument();
+      },
+      { timeout: 4000 },
+    );
+
+    expect(screen.queryByText('stale-row')).not.toBeInTheDocument();
+  });
+});

--- a/dex_with_fiat_frontend/src/components/AuditTable.tsx
+++ b/dex_with_fiat_frontend/src/components/AuditTable.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { AuditEntry } from '@/types';
 
 interface AuditTableProps {
@@ -32,8 +32,14 @@ export default function AuditTable({}: AuditTableProps) {
   });
 
   const pageSize = 20;
+  const fetchAbortRef = useRef<AbortController | null>(null);
 
   const fetchAuditEntries = useCallback(async () => {
+    fetchAbortRef.current?.abort();
+    const controller = new AbortController();
+    fetchAbortRef.current = controller;
+    const { signal } = controller;
+
     setLoading(true);
     setError(null);
 
@@ -50,7 +56,9 @@ export default function AuditTable({}: AuditTableProps) {
       params.append('limit', pageSize.toString());
       params.append('offset', (currentPage * pageSize).toString());
 
-      const response = await fetch(`/api/admin-audit?${params.toString()}`);
+      const response = await fetch(`/api/admin-audit?${params.toString()}`, {
+        signal,
+      });
 
       if (!response.ok) {
         throw new Error(`API error: ${response.statusText}`);
@@ -63,15 +71,23 @@ export default function AuditTable({}: AuditTableProps) {
       })));
       setTotalEntries(data.total);
     } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') {
+        return;
+      }
       setError(err instanceof Error ? err.message : 'Failed to fetch audit entries');
       console.error('Audit fetch error:', err);
     } finally {
-      setLoading(false);
+      if (!signal.aborted) {
+        setLoading(false);
+      }
     }
   }, [filters, currentPage]);
 
   useEffect(() => {
-    fetchAuditEntries();
+    void fetchAuditEntries();
+    return () => {
+      fetchAbortRef.current?.abort();
+    };
   }, [fetchAuditEntries]);
 
   const handleFilterChange = (key: keyof FilterState, value: string) => {

--- a/dex_with_fiat_frontend/src/components/StellarFiatModal.tsx
+++ b/dex_with_fiat_frontend/src/components/StellarFiatModal.tsx
@@ -32,6 +32,10 @@ import { downloadReceipt } from '@/lib/receipt';
 import type { ChatMessage } from '@/types';
 import { useAccessibleModal } from '@/hooks/useAccessibleModal';
 import { useIdempotentAction } from '@/hooks/useIdempotentAction';
+import {
+  STELLAR_FIAT_RISK_CONFIRMATION_PHRASE,
+  validateStellarFiatModalForm,
+} from '@/lib/stellarFiatModalSchema';
 
 interface StellarFiatModalProps {
   isOpen: boolean;
@@ -48,7 +52,6 @@ type TxStatus = 'idle' | 'loading' | 'success' | 'error';
 
 const PENDING_TX_KEY = 'stellar_pending_tx';
 const LARGE_AMOUNT_RISK_THRESHOLD = 500;
-const RISK_CONFIRMATION_PHRASE = 'CONFIRM LARGE AMOUNT';
 const SUBMIT_COOLDOWN_MS = 2000;
 
 interface PendingTxRecord {
@@ -392,7 +395,8 @@ export default function StellarFiatModal({
     (isDepositFlow &&
       (isLoadingBridgeLimit || isLimitUnavailable || isOverLimit)) ||
     (isRiskyAmount &&
-      riskConfirmation.trim().toUpperCase() !== RISK_CONFIRMATION_PHRASE) ||
+      riskConfirmation.trim().toUpperCase() !==
+        STELLAR_FIAT_RISK_CONFIRMATION_PHRASE) ||
     Date.now() - lastActionTimestamp < SUBMIT_COOLDOWN_MS;
 
   const operationType = isAdminMode ? 'Withdraw' : 'Deposit';
@@ -439,6 +443,20 @@ export default function StellarFiatModal({
   const handleAction = async () => {
     if (!connection.isConnected) return;
 
+    const zodMessage = validateStellarFiatModalForm({
+      isAdminMode,
+      amount,
+      recipient,
+      note,
+      riskConfirmation,
+      isRiskyAmount,
+    });
+    if (zodMessage) {
+      setErrorMsg(zodMessage);
+      setStatus('error');
+      return;
+    }
+
     if (
       isAmountInvalid ||
       !amount ||
@@ -460,16 +478,6 @@ export default function StellarFiatModal({
       setErrorMsg(
         bridgeLimitError ||
           'Unable to validate against the current bridge limit. Please try again.',
-      );
-      setStatus('error');
-      return;
-    }
-    if (
-      isRiskyAmount &&
-      riskConfirmation.trim().toUpperCase() !== RISK_CONFIRMATION_PHRASE
-    ) {
-      setErrorMsg(
-        `Type "${RISK_CONFIRMATION_PHRASE}" to confirm this large transfer.`,
       );
       setStatus('error');
       return;
@@ -959,7 +967,7 @@ export default function StellarFiatModal({
                   type="text"
                   value={riskConfirmation}
                   onChange={(e) => setRiskConfirmation(e.target.value)}
-                  placeholder={RISK_CONFIRMATION_PHRASE}
+                  placeholder={STELLAR_FIAT_RISK_CONFIRMATION_PHRASE}
                   className="theme-input w-full border rounded-lg px-4 py-3 text-sm focus:outline-none focus:border-blue-500"
                 />
               </div>

--- a/dex_with_fiat_frontend/src/components/UserSettings.tsx
+++ b/dex_with_fiat_frontend/src/components/UserSettings.tsx
@@ -8,7 +8,10 @@ import {
   FiatCurrencyCode,
   useUserPreferences,
 } from '@/contexts/UserPreferencesContext';
-import { useFeatureFlag } from '@/hooks/useFeatureFlag';
+import {
+  useFeatureFlag,
+  featureFlagSectionDividerBorderClass,
+} from '@/hooks/useFeatureFlag';
 import { useAccessibleModal } from '@/hooks/useAccessibleModal';
 import { useChatTelemetry } from '@/hooks/useChatTelemetry';
 import { useBeneficiaries, Beneficiary } from '@/hooks/useBeneficiaries';
@@ -365,7 +368,7 @@ export default function UserSettings({ isOpen, onClose }: UserSettingsProps) {
           </section>
           {/* Telemetry section */}
           <section
-            className={`pt-6 border-t ${isDarkMode ? 'border-gray-800' : 'border-gray-100'}`}
+            className={`pt-6 border-t ${featureFlagSectionDividerBorderClass(isDarkMode)}`}
           >
             <h3
               className={`text-xs font-semibold uppercase tracking-wider mb-3 ${
@@ -408,7 +411,7 @@ export default function UserSettings({ isOpen, onClose }: UserSettingsProps) {
 
           {enableConversionReminders && (
             <section
-              className={`pt-6 border-t ${isDarkMode ? 'border-gray-800' : 'border-gray-100'}`}
+              className={`pt-6 border-t ${featureFlagSectionDividerBorderClass(isDarkMode)}`}
             >
               <h3
                 className={`text-xs font-semibold uppercase tracking-wider mb-3 ${

--- a/dex_with_fiat_frontend/src/hooks/useFeatureFlag.test.ts
+++ b/dex_with_fiat_frontend/src/hooks/useFeatureFlag.test.ts
@@ -3,7 +3,10 @@ import { describe, it, expect, vi } from 'vitest';
 import { renderToString } from 'react-dom/server';
 import { hydrateRoot } from 'react-dom/client';
 import { act } from 'react-dom/test-utils';
-import { useFeatureFlag } from './useFeatureFlag';
+import {
+  useFeatureFlag,
+  featureFlagSectionDividerBorderClass,
+} from './useFeatureFlag';
 
 function Harness(props: { flag: 'enableAdminReconciliation' | 'enableConversionReminders' }) {
   const isEnabled = useFeatureFlag(props.flag);
@@ -34,5 +37,14 @@ describe('useFeatureFlag', () => {
     ).toBe(false);
 
     consoleErrorSpy.mockRestore();
+  });
+
+  it('uses theme-aligned divider borders for feature-flag sections', () => {
+    expect(featureFlagSectionDividerBorderClass(true)).toContain(
+      'border-gray-700',
+    );
+    expect(featureFlagSectionDividerBorderClass(false)).toContain(
+      'border-gray-200',
+    );
   });
 });

--- a/dex_with_fiat_frontend/src/hooks/useFeatureFlag.ts
+++ b/dex_with_fiat_frontend/src/hooks/useFeatureFlag.ts
@@ -34,3 +34,15 @@ export function useFeatureFlag(flag: FeatureFlag) {
 
   return isEnabled;
 }
+
+/**
+ * Tailwind classes for `border-t` dividers in settings panels that include
+ * feature-flag-gated blocks (e.g. conversion reminders). Using the same
+ * tokens as the main header divider avoids a too-faint light-mode border
+ * (`border-gray-100`) that looked inconsistent next to `border-gray-200`.
+ */
+export function featureFlagSectionDividerBorderClass(
+  isDarkMode: boolean,
+): string {
+  return isDarkMode ? 'border-gray-700' : 'border-gray-200';
+}

--- a/dex_with_fiat_frontend/src/lib/stellarFiatModalSchema.test.ts
+++ b/dex_with_fiat_frontend/src/lib/stellarFiatModalSchema.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import {
+  STELLAR_FIAT_RISK_CONFIRMATION_PHRASE,
+  validateStellarFiatModalForm,
+} from './stellarFiatModalSchema';
+
+describe('validateStellarFiatModalForm', () => {
+  it('rejects invalid amount for deposit', () => {
+    expect(
+      validateStellarFiatModalForm({
+        isAdminMode: false,
+        amount: '-1',
+        recipient: '',
+        note: '',
+        riskConfirmation: '',
+        isRiskyAmount: false,
+      }),
+    ).toBeTruthy();
+  });
+
+  it('requires exact risk phrase when amount is risky', () => {
+    expect(
+      validateStellarFiatModalForm({
+        isAdminMode: false,
+        amount: '600',
+        recipient: '',
+        note: '',
+        riskConfirmation: 'wrong',
+        isRiskyAmount: true,
+      }),
+    ).toBeTruthy();
+
+    expect(
+      validateStellarFiatModalForm({
+        isAdminMode: false,
+        amount: '600',
+        recipient: '',
+        note: '',
+        riskConfirmation: STELLAR_FIAT_RISK_CONFIRMATION_PHRASE.toLowerCase(),
+        isRiskyAmount: true,
+      }),
+    ).toBeNull();
+  });
+
+  it('rejects invalid Stellar public key in withdraw mode', () => {
+    expect(
+      validateStellarFiatModalForm({
+        isAdminMode: true,
+        amount: '10',
+        recipient: 'not-a-key',
+        note: '',
+        riskConfirmation: '',
+        isRiskyAmount: false,
+      }),
+    ).toMatch(/Recipient|Stellar|public key/i);
+  });
+
+  it('allows empty recipient in withdraw mode (self)', () => {
+    expect(
+      validateStellarFiatModalForm({
+        isAdminMode: true,
+        amount: '10',
+        recipient: '   ',
+        note: 'x',
+        riskConfirmation: '',
+        isRiskyAmount: false,
+      }),
+    ).toBeNull();
+  });
+});

--- a/dex_with_fiat_frontend/src/lib/stellarFiatModalSchema.ts
+++ b/dex_with_fiat_frontend/src/lib/stellarFiatModalSchema.ts
@@ -1,0 +1,97 @@
+import { z } from 'zod';
+
+/** Must match typed confirmation in `StellarFiatModal` for large transfers. */
+export const STELLAR_FIAT_RISK_CONFIRMATION_PHRASE = 'CONFIRM LARGE AMOUNT';
+
+/** Stellar StrKey public account (56 chars, base32 subset). */
+const STELLAR_ACCOUNT_KEY = /^G[A-Z2-7]{55}$/;
+
+const amountStringSchema = z
+  .string()
+  .trim()
+  .min(1, 'Enter an amount')
+  .refine((s) => {
+    const n = Number.parseFloat(s);
+    return Number.isFinite(n) && n > 0;
+  }, 'Amount must be a positive number');
+
+const noteSchema = z.string().max(160, 'Note must be at most 160 characters');
+
+const adminRecipientSchema = z
+  .string()
+  .trim()
+  .refine(
+    (s) => s === '' || STELLAR_ACCOUNT_KEY.test(s),
+    'Recipient must be empty (self) or a valid Stellar public key',
+  );
+
+const riskConfirmationSchema = z
+  .string()
+  .transform((s) => s.trim().toUpperCase())
+  .pipe(z.literal(STELLAR_FIAT_RISK_CONFIRMATION_PHRASE));
+
+/**
+ * Validates modal fields before building a Soroban transaction.
+ * Returns the first user-facing error message, or `null` when valid.
+ */
+export function validateStellarFiatModalForm(input: {
+  isAdminMode: boolean;
+  amount: string;
+  recipient: string;
+  note: string;
+  riskConfirmation: string;
+  isRiskyAmount: boolean;
+}): string | null {
+  if (input.isAdminMode) {
+    const r = z
+      .object({
+        amount: amountStringSchema,
+        recipient: adminRecipientSchema,
+        note: noteSchema,
+      })
+      .safeParse({
+        amount: input.amount,
+        recipient: input.recipient,
+        note: input.note,
+      });
+    if (!r.success) {
+      return r.error.issues[0]?.message ?? 'Invalid input';
+    }
+    return null;
+  }
+
+  if (!input.isRiskyAmount) {
+    const r = z
+      .object({
+        amount: amountStringSchema,
+        note: noteSchema,
+      })
+      .safeParse({
+        amount: input.amount,
+        note: input.note,
+      });
+    if (!r.success) {
+      return r.error.issues[0]?.message ?? 'Invalid input';
+    }
+    return null;
+  }
+
+  const r = z
+    .object({
+      amount: amountStringSchema,
+      note: noteSchema,
+      riskConfirmation: riskConfirmationSchema,
+    })
+    .safeParse({
+      amount: input.amount,
+      note: input.note,
+      riskConfirmation: input.riskConfirmation,
+    });
+  if (!r.success) {
+    return (
+      r.error.issues[0]?.message ??
+      `Type "${STELLAR_FIAT_RISK_CONFIRMATION_PHRASE}" to confirm this large transfer.`
+    );
+  }
+  return null;
+}

--- a/docs/slippage-threshold.md
+++ b/docs/slippage-threshold.md
@@ -1,0 +1,47 @@
+# Slippage threshold (FiatBridge)
+
+This document explains how the `FiatBridge` contract enforces **maximum slippage in basis points (BPS)** when comparing an **expected** oracle price to the **actual** execution price.
+
+## Where it lives
+
+Implementation: `stellar-contracts/src/lib.rs` — private helper `check_slippage`.
+
+Callers pass:
+
+- `expected_price` — benchmark price (e.g. from the oracle path used for validation).
+- `actual_price` — price implied by the current operation.
+- `max_slippage_bps` — maximum allowed downward slippage, in basis points (1 BPS = 0.01%, 10_000 BPS = 100%).
+
+## Semantics
+
+1. **Downward slippage only**  
+   If `actual_price >= expected_price`, slippage is treated as zero for the threshold check. Upward movement in the user’s favour does not trigger `SlippageTooHigh`.
+
+2. **Displayed slippage (events)**  
+   When `actual_price < expected_price`, the contract computes slippage in BPS with **floor division**:
+
+   \[
+   \text{slippage\_bps} = \left\lfloor \frac{(\text{expected} - \text{actual}) \times 10\,000}{\text{expected}} \right\rfloor
+   \]
+
+   That value is emitted on the `SlippageEvent` for observability.
+
+3. **Assertion vs `max_slippage_bps`**  
+   The revert path uses **integer-safe cross-multiplication** so rounding does not spuriously fail or pass:
+
+   - Let `diff = expected - actual` (only when `actual < expected`).
+   - Reject if `diff * 10_000 > max_slippage_bps * expected` (strictly over the cap).
+   - Otherwise compute `quotient = (diff * 10_000) / expected` (integer division).
+   - Reject if `quotient > max_slippage_bps`.
+   - If `quotient == max_slippage_bps`, inspect the **remainder** of `(diff * 10_000) % expected`. A remainder that would **ceil** past the cap (remainder ≥ `expected / 2`) also rejects, so boundary behaviour stays aligned with tests that use ceiling-style constructed prices.
+
+Together, these rules give **predictable boundary behaviour** at exactly `max_slippage_bps` versus one BPS over, without floating point.
+
+## Error surface
+
+When the check fails, the contract returns `Error::SlippageTooHigh` (see `ERROR_CODES.md` / `SlippageExceeded` in product docs where applicable).
+
+## Further reading
+
+- Contract tests: `stellar-contracts/src/test.rs` — `test_slippage_*` and boundary suites.
+- Overflow / fixed-point context: `stellar-contracts/docs/OVERFLOW_PREVENTION.md`.

--- a/stellar-contracts/src/lib.rs
+++ b/stellar-contracts/src/lib.rs
@@ -1921,6 +1921,24 @@ impl FiatBridge {
         Ok(())
     }
 
+    /// Enforces `max_slippage_bps` on **downward** price moves only.
+    ///
+    /// # Model
+    ///
+    /// - `expected_price` — benchmark (e.g. oracle) price used for the check.
+    /// - `actual_price` — effective price for the current deposit/withdraw path.
+    /// - `max_slippage_bps` — cap in **basis points** (10_000 BPS = 100%). Only
+    ///   applies when `actual_price < expected_price`.
+    ///
+    /// # Display vs assertion
+    ///
+    /// The emitted `SlippageEvent` uses **floor** BPS:
+    /// `⌊(expected - actual) * 10_000 / expected⌋` when `actual < expected`, else `0`.
+    ///
+    /// The revert decision uses **integer cross-multiplication** and a
+    /// **remainder guard** when the floored quotient equals `max_slippage_bps`,
+    /// so boundary tests at “exactly max” vs “max + 1 bps” stay stable without
+    /// floating point. See `docs/slippage-threshold.md` at the repo root.
     fn check_slippage(
         env: &Env,
         expected_price: i128,


### PR DESCRIPTION
## Summary
- **#634**: Expanded `check_slippage` rustdoc, added [docs/slippage-threshold.md](docs/slippage-threshold.md), and linked it from the root README.
- **#637**: Added Zod-backed validation (`stellarFiatModalSchema.ts`) and wired it into `StellarFiatModal` before submit.
- **#639**: Centralised theme-aligned `border-t` classes in `useFeatureFlag.ts`, applied them in `UserSettings`, and added a regression test.
- **#641**: Abort in-flight `fetch` in `AuditTable` when filters/page change and added a regression test for stale responses.

## Test plan
- `cd dex_with_fiat_frontend && npx vitest run src/components/AuditTable.test.tsx src/lib/stellarFiatModalSchema.test.ts src/hooks/useFeatureFlag.test.ts`

## Closes
- Closes #634
- Closes #637
- Closes #639
- Closes #641

Made with [Cursor](https://cursor.com)