### PR TITLE
fix(frontend): use theme border on chat history sidebar

### DIFF
--- a/dex_with_fiat_frontend/src/components/ChatHistorySidebar.tsx
+++ b/dex_with_fiat_frontend/src/components/ChatHistorySidebar.tsx
@@ -357,7 +357,7 @@ export default function ChatHistorySidebar({
 
   return (
     <div
-      className={`theme-surface h-full flex flex-col transition-all duration-300 border-r ${
+      className={`theme-surface theme-border h-full flex flex-col transition-all duration-300 border-r ${
         isCollapsed ? 'w-20' : 'w-full'
       } transition-colors duration-300`}
     >

--- a/dex_with_fiat_frontend/src/components/__tests__/ChatHistorySidebar.test.tsx
+++ b/dex_with_fiat_frontend/src/components/__tests__/ChatHistorySidebar.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import ChatHistorySidebar from '@/components/ChatHistorySidebar';
+
+vi.mock('@/hooks/useChatHistory', () => ({
+  useChatHistory: () => ({
+    pinnedSessions: [],
+    unpinnedSessions: [],
+    currentSessionId: null,
+    deleteSession: vi.fn(),
+    clearAllHistory: vi.fn(),
+    exportSessionAsJSON: vi.fn(),
+    exportSessionAsTXT: vi.fn(),
+    searchSessions: vi.fn(() => []),
+    togglePin: vi.fn(),
+    hasHistory: false,
+  }),
+}));
+
+vi.mock('@/hooks/useTxHistory', () => ({
+  useTxHistory: () => ({
+    entries: [],
+    clearEntries: vi.fn(),
+    updateEntry: vi.fn(),
+  }),
+}));
+
+vi.mock('@/contexts/StellarWalletContext', () => ({
+  useStellarWallet: () => ({
+    connection: { address: null as string | null },
+  }),
+}));
+
+describe('ChatHistorySidebar', () => {
+  beforeEach(() => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ events: [] }),
+    } as Response);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  /**
+   * Regression (#651): root chrome must use theme border color so the sidebar
+   * separator matches the rest of the layout (not Tailwind’s default border color).
+   */
+  it('applies theme border color to the root sidebar chrome', () => {
+    const { container } = render(
+      <ChatHistorySidebar onLoadSession={vi.fn()} isCollapsed={false} />,
+    );
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.className).toMatch(/\btheme-border\b/);
+    expect(root.className).toMatch(/\bborder-r\b/);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `theme-border` to the `ChatHistorySidebar` root (with `border-r`) so the vertical separator uses `var(--color-border)` instead of the default border color.
- Add a small unit test that locks this behavior.

Closes leojay-net/Stellar-Dex-Chat#651
