### PR TITLE
feat(frontend): add accessible contrast to transaction filter chips

### DIFF
--- a/dex_with_fiat_frontend/src/components/ReceiptDrawer.tsx
+++ b/dex_with_fiat_frontend/src/components/ReceiptDrawer.tsx
@@ -52,6 +52,7 @@ export default function ReceiptDrawer({
     filterStats,
     toggleFilter,
     clearAllFilters,
+    getFilterChipTone,
   } = useTransactionFilters(transactions);
 
   // Determine which transactions to display
@@ -106,6 +107,7 @@ export default function ReceiptDrawer({
           <FilterChipBar
             filterState={filterState}
             filterStats={filterStats}
+            getFilterChipTone={getFilterChipTone}
             onFilterChange={toggleFilter}
             onClearAll={clearAllFilters}
           />

--- a/dex_with_fiat_frontend/src/components/filters/FilterChip.tsx
+++ b/dex_with_fiat_frontend/src/components/filters/FilterChip.tsx
@@ -9,6 +9,8 @@ interface FilterChipProps {
   selected: boolean;
   onToggle: (value: string) => void;
   disabled?: boolean;
+  chipClassName?: string;
+  countClassName?: string;
 }
 
 export function FilterChip({
@@ -18,6 +20,8 @@ export function FilterChip({
   selected,
   onToggle,
   disabled = false,
+  chipClassName,
+  countClassName,
 }: FilterChipProps) {
   const handleClick = () => {
     if (!disabled) {
@@ -42,13 +46,14 @@ export function FilterChip({
       onClick={handleClick}
       onKeyDown={handleKeyDown}
       className={`
-        inline-flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium
+        inline-flex items-center gap-2 px-3 py-1.5 rounded-full border text-sm font-medium
         transition-all duration-200 ease-in-out
         focus:outline-none focus:ring-2 focus:ring-offset-2
         ${
-          selected
+          chipClassName ??
+          (selected
             ? 'bg-blue-600 text-white hover:bg-blue-700 focus:ring-blue-500'
-            : 'bg-gray-100 text-gray-700 hover:bg-gray-200 focus:ring-gray-400 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700'
+            : 'border-gray-200 bg-gray-100 text-gray-700 hover:bg-gray-200 focus:ring-gray-400 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700')
         }
         ${disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}
       `}
@@ -58,9 +63,10 @@ export function FilterChip({
         className={`
           inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1.5 rounded-full text-xs font-semibold
           ${
-            selected
+            countClassName ??
+            (selected
               ? 'bg-blue-500 text-white'
-              : 'bg-gray-200 text-gray-600 dark:bg-gray-700 dark:text-gray-400'
+              : 'bg-gray-200 text-gray-600 dark:bg-gray-700 dark:text-gray-400')
           }
         `}
       >

--- a/dex_with_fiat_frontend/src/components/filters/FilterChipBar.tsx
+++ b/dex_with_fiat_frontend/src/components/filters/FilterChipBar.tsx
@@ -2,11 +2,21 @@
 
 import React from 'react';
 import { FilterChipGroup } from './FilterChipGroup';
-import type { FilterState, FilterStats, FilterCategory } from '@/types';
+import type {
+  FilterState,
+  FilterStats,
+  FilterCategory,
+  FilterChipTone,
+} from '@/types';
 
 interface FilterChipBarProps {
   filterState: FilterState;
   filterStats: FilterStats;
+  getFilterChipTone: (
+    category: FilterCategory,
+    value: string,
+    selected: boolean,
+  ) => FilterChipTone;
   onFilterChange: (category: FilterCategory, value: string) => void;
   onClearAll: () => void;
 }
@@ -14,6 +24,7 @@ interface FilterChipBarProps {
 export function FilterChipBar({
   filterState,
   filterStats,
+  getFilterChipTone,
   onFilterChange,
   onClearAll,
 }: FilterChipBarProps) {
@@ -55,6 +66,7 @@ export function FilterChipBar({
           label="Status"
           options={filterStats.statusOptions}
           selectedValues={filterState.status}
+          getFilterChipTone={getFilterChipTone}
           onToggle={(value) => onFilterChange('status', value)}
         />
 
@@ -63,6 +75,7 @@ export function FilterChipBar({
           label="Asset"
           options={filterStats.assetOptions}
           selectedValues={filterState.asset}
+          getFilterChipTone={getFilterChipTone}
           onToggle={(value) => onFilterChange('asset', value)}
         />
 
@@ -71,6 +84,7 @@ export function FilterChipBar({
           label="Network"
           options={filterStats.networkOptions}
           selectedValues={filterState.network}
+          getFilterChipTone={getFilterChipTone}
           onToggle={(value) => onFilterChange('network', value)}
         />
       </div>

--- a/dex_with_fiat_frontend/src/components/filters/FilterChipGroup.tsx
+++ b/dex_with_fiat_frontend/src/components/filters/FilterChipGroup.tsx
@@ -2,13 +2,18 @@
 
 import React from 'react';
 import { FilterChip } from './FilterChip';
-import type { FilterCategory, FilterOption } from '@/types';
+import type { FilterCategory, FilterOption, FilterChipTone } from '@/types';
 
 interface FilterChipGroupProps {
   category: FilterCategory;
   label: string;
   options: FilterOption[];
   selectedValues: string[];
+  getFilterChipTone: (
+    category: FilterCategory,
+    value: string,
+    selected: boolean,
+  ) => FilterChipTone;
   onToggle: (value: string) => void;
 }
 
@@ -17,6 +22,7 @@ export function FilterChipGroup({
   label,
   options,
   selectedValues,
+  getFilterChipTone,
   onToggle,
 }: FilterChipGroupProps) {
   if (options.length === 0) {
@@ -29,16 +35,23 @@ export function FilterChipGroup({
         {label}
       </h3>
       <div className="flex flex-wrap gap-2">
-        {options.map((option) => (
-          <FilterChip
-            key={`${category}-${option.value}`}
-            label={option.label}
-            value={option.value}
-            count={option.count}
-            selected={selectedValues.includes(option.value)}
-            onToggle={onToggle}
-          />
-        ))}
+        {options.map((option) => {
+          const selected = selectedValues.includes(option.value);
+          const tone = getFilterChipTone(category, option.value, selected);
+
+          return (
+            <FilterChip
+              key={`${category}-${option.value}`}
+              label={option.label}
+              value={option.value}
+              count={option.count}
+              selected={selected}
+              chipClassName={tone.chipClassName}
+              countClassName={tone.countClassName}
+              onToggle={onToggle}
+            />
+          );
+        })}
       </div>
     </div>
   );

--- a/dex_with_fiat_frontend/src/hooks/useTransactionFilters.test.ts
+++ b/dex_with_fiat_frontend/src/hooks/useTransactionFilters.test.ts
@@ -1,114 +1,202 @@
+import { renderHook, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { KEYBOARD_SHORTCUTS } from './useTransactionFilters';
+import type { TransactionHistoryEntry } from '@/types';
+import {
+  KEYBOARD_SHORTCUTS,
+  getAccessibleFilterChipTone,
+  useTransactionFilters,
+} from './useTransactionFilters';
 
-// ---------- Issue #711: Keyboard shortcuts ----------
+const pushMock = vi.fn();
+let mockSearchParams = new URLSearchParams();
 
-describe('useTransactionFilters keyboard shortcuts', () => {
-  describe('KEYBOARD_SHORTCUTS constant', () => {
-    it('should define a clearAll shortcut', () => {
-      expect(KEYBOARD_SHORTCUTS.clearAll).toBeDefined();
-      expect(KEYBOARD_SHORTCUTS.clearAll.key).toBe('x');
-      expect(KEYBOARD_SHORTCUTS.clearAll.modifiers).toContain('Ctrl');
-      expect(KEYBOARD_SHORTCUTS.clearAll.modifiers).toContain('Shift');
-    });
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: pushMock }),
+  usePathname: () => '/receipts',
+  useSearchParams: () => mockSearchParams,
+}));
 
-    it('should define cycleStatus shortcut with key 1', () => {
+const sampleTransactions: TransactionHistoryEntry[] = [
+  {
+    id: 'tx-1',
+    kind: 'deposit',
+    status: 'completed',
+    amount: '125',
+    asset: 'XLM',
+    message: 'Completed deposit',
+    createdAt: new Date('2026-01-01T10:00:00.000Z'),
+  },
+  {
+    id: 'tx-2',
+    kind: 'payout',
+    status: 'pending',
+    amount: '80',
+    asset: 'USDC',
+    message: 'Pending payout',
+    createdAt: new Date('2026-01-02T10:00:00.000Z'),
+  },
+  {
+    id: 'tx-3',
+    kind: 'risk_warning',
+    status: 'failed',
+    amount: '50',
+    asset: 'AQUA',
+    message: 'Failed withdrawal',
+    createdAt: new Date('2026-01-03T10:00:00.000Z'),
+  },
+];
+
+describe('useTransactionFilters', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    pushMock.mockReset();
+    mockSearchParams = new URLSearchParams();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('KEYBOARD_SHORTCUTS', () => {
+    it('defines the expected shortcut bindings', () => {
+      expect(KEYBOARD_SHORTCUTS.clearAll).toEqual({
+        key: 'x',
+        modifiers: 'Ctrl+Shift',
+        description: 'Clear all filters',
+      });
       expect(KEYBOARD_SHORTCUTS.cycleStatus.key).toBe('1');
-      expect(KEYBOARD_SHORTCUTS.cycleStatus.modifiers).toContain('Ctrl');
-    });
-
-    it('should define cycleAsset shortcut with key 2', () => {
       expect(KEYBOARD_SHORTCUTS.cycleAsset.key).toBe('2');
-      expect(KEYBOARD_SHORTCUTS.cycleAsset.modifiers).toContain('Ctrl');
-    });
-
-    it('should define cycleNetwork shortcut with key 3', () => {
       expect(KEYBOARD_SHORTCUTS.cycleNetwork.key).toBe('3');
-      expect(KEYBOARD_SHORTCUTS.cycleNetwork.modifiers).toContain('Ctrl');
-    });
-
-    it('should have descriptions for all shortcuts', () => {
-      const shortcuts = Object.values(KEYBOARD_SHORTCUTS);
-      for (const shortcut of shortcuts) {
-        expect(shortcut.description).toBeTruthy();
-        expect(typeof shortcut.description).toBe('string');
-      }
     });
   });
 
-  describe('keyboard event handler integration', () => {
-    let addSpy: ReturnType<typeof vi.spyOn>;
-    let removeSpy: ReturnType<typeof vi.spyOn>;
-
-    beforeEach(() => {
-      addSpy = vi.spyOn(window, 'addEventListener');
-      removeSpy = vi.spyOn(window, 'removeEventListener');
+  describe('accessible chip tones', () => {
+    it('uses an accessible emerald palette for completed status chips', () => {
+      expect(getAccessibleFilterChipTone('status', 'completed', true)).toEqual({
+        chipClassName:
+          'border-transparent bg-emerald-700 text-white hover:bg-emerald-800 focus:ring-emerald-600 dark:bg-emerald-300 dark:text-emerald-950 dark:hover:bg-emerald-200 dark:focus:ring-emerald-300',
+        countClassName:
+          'bg-emerald-900 text-emerald-50 dark:bg-emerald-950 dark:text-emerald-100',
+      });
     });
 
-    afterEach(() => {
-      addSpy.mockRestore();
-      removeSpy.mockRestore();
+    it('uses an accessible red palette for failed status chips', () => {
+      const tone = getAccessibleFilterChipTone('status', 'failed', false);
+
+      expect(tone.chipClassName).toContain('text-red-800');
+      expect(tone.chipClassName).toContain('dark:text-red-200');
+      expect(tone.countClassName).toContain('text-red-800');
     });
 
-    it('should not trigger shortcuts when target is an input element', () => {
-      const mockClearAll = vi.fn();
+    it('assigns deterministic accessible tones for asset chips', () => {
+      expect(getAccessibleFilterChipTone('asset', 'XLM', false)).toEqual(
+        getAccessibleFilterChipTone('asset', 'XLM', false),
+      );
+      expect(getAccessibleFilterChipTone('asset', 'XLM', false)).not.toEqual(
+        getAccessibleFilterChipTone('asset', 'USDC', false),
+      );
+    });
+
+    it('assigns deterministic accessible tones for network chips', () => {
+      expect(getAccessibleFilterChipTone('network', 'testnet', true)).toEqual(
+        getAccessibleFilterChipTone('network', 'testnet', true),
+      );
+    });
+  });
+
+  describe('hook behavior', () => {
+    it('hydrates the initial filter state from the URL', () => {
+      mockSearchParams = new URLSearchParams('status=completed&asset=XLM');
+
+      const { result } = renderHook(() =>
+        useTransactionFilters(sampleTransactions),
+      );
+
+      expect(result.current.filterState).toEqual({
+        status: ['completed'],
+        asset: ['XLM'],
+        network: [],
+      });
+      expect(result.current.filteredTransactions).toHaveLength(1);
+      expect(result.current.filteredTransactions[0].id).toBe('tx-1');
+    });
+
+    it('debounces URL updates when toggling filters', () => {
+      const { result } = renderHook(() =>
+        useTransactionFilters(sampleTransactions),
+      );
+
+      act(() => {
+        result.current.toggleFilter('status', 'completed');
+      });
+
+      expect(pushMock).not.toHaveBeenCalled();
+
+      act(() => {
+        vi.advanceTimersByTime(150);
+      });
+
+      expect(pushMock).toHaveBeenCalledWith('/receipts?status=completed', {
+        scroll: false,
+      });
+    });
+
+    it('clears all filters through the keyboard shortcut outside editable fields', () => {
+      mockSearchParams = new URLSearchParams('status=completed');
+
+      renderHook(() => useTransactionFilters(sampleTransactions));
+
+      act(() => {
+        window.dispatchEvent(
+          new KeyboardEvent('keydown', {
+            key: 'x',
+            ctrlKey: true,
+            shiftKey: true,
+            bubbles: true,
+          }),
+        );
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(150);
+      });
+
+      expect(pushMock).toHaveBeenCalledWith('/receipts', { scroll: false });
+    });
+
+    it('ignores keyboard shortcuts while typing in an input', () => {
+      mockSearchParams = new URLSearchParams('status=completed');
+
+      renderHook(() => useTransactionFilters(sampleTransactions));
+
       const input = document.createElement('input');
       document.body.appendChild(input);
 
-      // Simulate the handler logic for input check
-      const target = input as HTMLElement;
-      const shouldIgnore =
-        target.tagName === 'INPUT' ||
-        target.tagName === 'TEXTAREA' ||
-        target.isContentEditable;
+      act(() => {
+        input.dispatchEvent(
+          new KeyboardEvent('keydown', {
+            key: 'x',
+            ctrlKey: true,
+            shiftKey: true,
+            bubbles: true,
+          }),
+        );
+        vi.advanceTimersByTime(150);
+      });
 
-      expect(shouldIgnore).toBe(true);
-      expect(mockClearAll).not.toHaveBeenCalled();
+      expect(pushMock).not.toHaveBeenCalled();
 
       document.body.removeChild(input);
     });
 
-    it('should not trigger shortcuts when target is a textarea element', () => {
-      const textarea = document.createElement('textarea');
-      const target = textarea as HTMLElement;
-      const shouldIgnore =
-        target.tagName === 'INPUT' ||
-        target.tagName === 'TEXTAREA' ||
-        target.isContentEditable;
+    it('exposes the same accessible chip tone resolver through the hook', () => {
+      const { result } = renderHook(() =>
+        useTransactionFilters(sampleTransactions),
+      );
 
-      expect(shouldIgnore).toBe(true);
-    });
-
-    it('should not trigger shortcuts when target is contenteditable', () => {
-      const div = document.createElement('div');
-      div.contentEditable = 'true';
-      const shouldIgnore = div.isContentEditable;
-
-      expect(shouldIgnore).toBe(true);
-    });
-
-    it('should not trigger without modifier keys', () => {
-      const isModified = false; // Mocking behavior
-      expect(isModified).toBe(false);
-    });
-
-    it('should trigger with Ctrl+Shift', () => {
-      const isModified = true; // Mocking behavior
-      expect(isModified).toBe(true);
-    });
-
-    it('should map keys correctly to filter categories', () => {
-      const keyMap: Record<string, string> = {
-        x: 'clearAll',
-        '1': 'status',
-        '2': 'asset',
-        '3': 'network',
-      };
-
-      expect(keyMap['x']).toBe('clearAll');
-      expect(keyMap['1']).toBe('status');
-      expect(keyMap['2']).toBe('asset');
-      expect(keyMap['3']).toBe('network');
+      expect(
+        result.current.getFilterChipTone('status', 'pending', true),
+      ).toEqual(getAccessibleFilterChipTone('status', 'pending', true));
     });
   });
 });

--- a/dex_with_fiat_frontend/src/hooks/useTransactionFilters.ts
+++ b/dex_with_fiat_frontend/src/hooks/useTransactionFilters.ts
@@ -7,6 +7,8 @@ import type {
   FilterState,
   FilterStats,
   FilterCategory,
+  FilterChipTone,
+  TransactionStatus,
 } from '@/types';
 import { filterTransactions, computeFilterStats } from '@/lib/transactionFilters';
 import {
@@ -31,11 +33,200 @@ export interface UseTransactionFiltersReturn {
   toggleFilter: (category: FilterCategory, value: string) => void;
   clearAllFilters: () => void;
   hasActiveFilters: boolean;
+  getFilterChipTone: (
+    category: FilterCategory,
+    value: string,
+    selected: boolean,
+  ) => FilterChipTone;
   /** Available keyboard shortcuts for filter management. */
   keyboardShortcuts: typeof KEYBOARD_SHORTCUTS;
 }
 
 const DEBOUNCE_DELAY = 150; // ms
+
+interface FilterToneState {
+  chipClassName: string;
+  countClassName: string;
+}
+
+interface FilterTonePair {
+  selected: FilterToneState;
+  unselected: FilterToneState;
+}
+
+const FILTER_TONE_PALETTES = {
+  blue: {
+    selected: {
+      chipClassName:
+        'border-transparent bg-blue-700 text-white hover:bg-blue-800 focus:ring-blue-600 dark:bg-blue-300 dark:text-blue-950 dark:hover:bg-blue-200 dark:focus:ring-blue-300',
+      countClassName:
+        'bg-blue-900 text-blue-50 dark:bg-blue-950 dark:text-blue-100',
+    },
+    unselected: {
+      chipClassName:
+        'border-blue-200 bg-blue-50 text-blue-800 hover:bg-blue-100 focus:ring-blue-400 dark:border-blue-800 dark:bg-blue-950/40 dark:text-blue-200 dark:hover:bg-blue-950/60',
+      countClassName:
+        'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200',
+    },
+  },
+  emerald: {
+    selected: {
+      chipClassName:
+        'border-transparent bg-emerald-700 text-white hover:bg-emerald-800 focus:ring-emerald-600 dark:bg-emerald-300 dark:text-emerald-950 dark:hover:bg-emerald-200 dark:focus:ring-emerald-300',
+      countClassName:
+        'bg-emerald-900 text-emerald-50 dark:bg-emerald-950 dark:text-emerald-100',
+    },
+    unselected: {
+      chipClassName:
+        'border-emerald-200 bg-emerald-50 text-emerald-800 hover:bg-emerald-100 focus:ring-emerald-400 dark:border-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-200 dark:hover:bg-emerald-950/60',
+      countClassName:
+        'bg-emerald-100 text-emerald-800 dark:bg-emerald-900 dark:text-emerald-200',
+    },
+  },
+  amber: {
+    selected: {
+      chipClassName:
+        'border-transparent bg-amber-700 text-white hover:bg-amber-800 focus:ring-amber-600 dark:bg-amber-300 dark:text-amber-950 dark:hover:bg-amber-200 dark:focus:ring-amber-300',
+      countClassName:
+        'bg-amber-900 text-amber-50 dark:bg-amber-950 dark:text-amber-100',
+    },
+    unselected: {
+      chipClassName:
+        'border-amber-200 bg-amber-50 text-amber-800 hover:bg-amber-100 focus:ring-amber-400 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-200 dark:hover:bg-amber-950/60',
+      countClassName:
+        'bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200',
+    },
+  },
+  red: {
+    selected: {
+      chipClassName:
+        'border-transparent bg-red-700 text-white hover:bg-red-800 focus:ring-red-600 dark:bg-red-300 dark:text-red-950 dark:hover:bg-red-200 dark:focus:ring-red-300',
+      countClassName:
+        'bg-red-900 text-red-50 dark:bg-red-950 dark:text-red-100',
+    },
+    unselected: {
+      chipClassName:
+        'border-red-200 bg-red-50 text-red-800 hover:bg-red-100 focus:ring-red-400 dark:border-red-800 dark:bg-red-950/40 dark:text-red-200 dark:hover:bg-red-950/60',
+      countClassName:
+        'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
+    },
+  },
+  slate: {
+    selected: {
+      chipClassName:
+        'border-transparent bg-slate-700 text-white hover:bg-slate-800 focus:ring-slate-600 dark:bg-slate-300 dark:text-slate-950 dark:hover:bg-slate-200 dark:focus:ring-slate-300',
+      countClassName:
+        'bg-slate-900 text-slate-50 dark:bg-slate-950 dark:text-slate-100',
+    },
+    unselected: {
+      chipClassName:
+        'border-slate-200 bg-slate-50 text-slate-800 hover:bg-slate-100 focus:ring-slate-400 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-slate-800',
+      countClassName:
+        'bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-200',
+    },
+  },
+  indigo: {
+    selected: {
+      chipClassName:
+        'border-transparent bg-indigo-700 text-white hover:bg-indigo-800 focus:ring-indigo-600 dark:bg-indigo-300 dark:text-indigo-950 dark:hover:bg-indigo-200 dark:focus:ring-indigo-300',
+      countClassName:
+        'bg-indigo-900 text-indigo-50 dark:bg-indigo-950 dark:text-indigo-100',
+    },
+    unselected: {
+      chipClassName:
+        'border-indigo-200 bg-indigo-50 text-indigo-800 hover:bg-indigo-100 focus:ring-indigo-400 dark:border-indigo-800 dark:bg-indigo-950/40 dark:text-indigo-200 dark:hover:bg-indigo-950/60',
+      countClassName:
+        'bg-indigo-100 text-indigo-800 dark:bg-indigo-900 dark:text-indigo-200',
+    },
+  },
+  violet: {
+    selected: {
+      chipClassName:
+        'border-transparent bg-violet-700 text-white hover:bg-violet-800 focus:ring-violet-600 dark:bg-violet-300 dark:text-violet-950 dark:hover:bg-violet-200 dark:focus:ring-violet-300',
+      countClassName:
+        'bg-violet-900 text-violet-50 dark:bg-violet-950 dark:text-violet-100',
+    },
+    unselected: {
+      chipClassName:
+        'border-violet-200 bg-violet-50 text-violet-800 hover:bg-violet-100 focus:ring-violet-400 dark:border-violet-800 dark:bg-violet-950/40 dark:text-violet-200 dark:hover:bg-violet-950/60',
+      countClassName:
+        'bg-violet-100 text-violet-800 dark:bg-violet-900 dark:text-violet-200',
+    },
+  },
+  cyan: {
+    selected: {
+      chipClassName:
+        'border-transparent bg-cyan-700 text-white hover:bg-cyan-800 focus:ring-cyan-600 dark:bg-cyan-300 dark:text-cyan-950 dark:hover:bg-cyan-200 dark:focus:ring-cyan-300',
+      countClassName:
+        'bg-cyan-900 text-cyan-50 dark:bg-cyan-950 dark:text-cyan-100',
+    },
+    unselected: {
+      chipClassName:
+        'border-cyan-200 bg-cyan-50 text-cyan-800 hover:bg-cyan-100 focus:ring-cyan-400 dark:border-cyan-800 dark:bg-cyan-950/40 dark:text-cyan-200 dark:hover:bg-cyan-950/60',
+      countClassName:
+        'bg-cyan-100 text-cyan-800 dark:bg-cyan-900 dark:text-cyan-200',
+    },
+  },
+} as const satisfies Record<string, FilterTonePair>;
+
+const STATUS_TONE_KEYS: Record<TransactionStatus, keyof typeof FILTER_TONE_PALETTES> = {
+  pending: 'amber',
+  completed: 'emerald',
+  warning: 'blue',
+  failed: 'red',
+  cancelled: 'slate',
+};
+
+const ASSET_TONE_SEQUENCE: Array<keyof typeof FILTER_TONE_PALETTES> = [
+  'blue',
+  'indigo',
+  'violet',
+  'cyan',
+  'emerald',
+];
+
+const NETWORK_TONE_SEQUENCE: Array<keyof typeof FILTER_TONE_PALETTES> = [
+  'amber',
+  'blue',
+  'slate',
+  'cyan',
+];
+
+function hashFilterValue(value: string): number {
+  return Array.from(value).reduce(
+    (hash, character) => hash + character.charCodeAt(0),
+    0,
+  );
+}
+
+function getToneKeyForCategory(
+  category: FilterCategory,
+  value: string,
+): keyof typeof FILTER_TONE_PALETTES {
+  if (category === 'status' && value in STATUS_TONE_KEYS) {
+    return STATUS_TONE_KEYS[value as TransactionStatus];
+  }
+
+  const sequence =
+    category === 'asset' ? ASSET_TONE_SEQUENCE : NETWORK_TONE_SEQUENCE;
+
+  return sequence[hashFilterValue(value) % sequence.length];
+}
+
+export function getAccessibleFilterChipTone(
+  category: FilterCategory,
+  value: string,
+  selected: boolean,
+): FilterChipTone {
+  const toneKey = getToneKeyForCategory(category, value);
+  const palette = FILTER_TONE_PALETTES[toneKey];
+  const toneState = selected ? palette.selected : palette.unselected;
+
+  return {
+    chipClassName: toneState.chipClassName,
+    countClassName: toneState.countClassName,
+  };
+}
 
 /**
  * Hook for managing transaction filters with URL synchronization.
@@ -142,6 +333,12 @@ export function useTransactionFilters(
     updateUrl(emptyFilterState);
   }, [updateUrl]);
 
+  const getFilterChipTone = useCallback(
+    (category: FilterCategory, value: string, selected: boolean) =>
+      getAccessibleFilterChipTone(category, value, selected),
+    [],
+  );
+
   /**
    * Cycle through available values of a filter category using the
    * filter stats. Pressing the shortcut toggles the next available value,
@@ -239,7 +436,7 @@ export function useTransactionFilters(
     toggleFilter,
     clearAllFilters,
     hasActiveFilters,
+    getFilterChipTone,
     keyboardShortcuts: KEYBOARD_SHORTCUTS,
   };
 }
-

--- a/dex_with_fiat_frontend/src/lib/chatTelemetry.ts
+++ b/dex_with_fiat_frontend/src/lib/chatTelemetry.ts
@@ -223,7 +223,7 @@ function emit<P extends object>(
 
   const normalizedPayload = withAccessibleAvatarContrast(payload);
 
-  const event: ChatEvent = {
+  const event: ChatEvent<typeof normalizedPayload> = {
     name,
     version: TELEMETRY_SCHEMA_VERSION,
     timestamp: Date.now(),

--- a/dex_with_fiat_frontend/src/types/index.ts
+++ b/dex_with_fiat_frontend/src/types/index.ts
@@ -253,6 +253,11 @@ export interface FilterOption {
   count: number;
 }
 
+export interface FilterChipTone {
+  chipClassName: string;
+  countClassName: string;
+}
+
 export interface FilterStats {
   statusOptions: FilterOption[];
   assetOptions: FilterOption[];


### PR DESCRIPTION
## Summary

Adds accessible color contrast handling to transaction filter chips by moving chip tone resolution into `useTransactionFilters.ts` and applying those tones across the receipt filter UI. Status filters now use explicit accessible palettes, while asset and network filters use deterministic accessible tones so the UI stays readable and visually consistent.

Also replaces the old placeholder tests with real hook coverage for:
- accessible chip tone resolution
- URL hydration
- debounced filter updates
- keyboard shortcut behavior

A small type-only fix was included in `chatTelemetry.ts` so the frontend typecheck stays green.

## Testing

- npm run test:unit -- src/hooks/useTransactionFilters.test.ts
- npm run test:unit -- src/components/ui/skeleton/skeleton.test.ts
- npm run typecheck

Closes #649
