### PR TITLE
feat(frontend): add optimistic UI updates to ChatHistorySidebar

### DIFF
--- a/dex_with_fiat_frontend/src/app/globals.css
+++ b/dex_with_fiat_frontend/src/app/globals.css
@@ -139,6 +139,41 @@ html {
   animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
 }
 
+@keyframes bounceOnce {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+
+  40% {
+    transform: scale(1.5);
+  }
+
+  70% {
+    transform: scale(0.9);
+  }
+}
+
+.animate-bounce-once {
+  animation: bounceOnce 0.6s ease-out;
+}
+
+@keyframes slideUp {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.animate-slide-up {
+  animation: slideUp 0.25s ease-out;
+}
+
 /* Custom scrollbar for light theme */
 ::-webkit-scrollbar {
   width: 8px;

--- a/dex_with_fiat_frontend/src/components/ChatHistorySidebar.tsx
+++ b/dex_with_fiat_frontend/src/components/ChatHistorySidebar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import jsPDF from 'jspdf';
 import { useChatHistory } from '@/hooks/useChatHistory';
 import { useTxHistory } from '@/hooks/useTxHistory';
@@ -38,6 +38,7 @@ interface SessionRowProps {
   onDelete: (id: string) => void;
   onTogglePin: (id: string) => void;
   formatDate: (d: Date) => string;
+  recentlyToggledPinId?: string | null;
 }
 
 function SessionRow({
@@ -49,6 +50,7 @@ function SessionRow({
   onDelete,
   onTogglePin,
   formatDate,
+  recentlyToggledPinId,
 }: SessionRowProps) {
   const [showExportMenu, setShowExportMenu] = useState(false);
 
@@ -97,9 +99,17 @@ function SessionRow({
             title={session.pinned ? 'Unpin conversation' : 'Pin conversation'}
           >
             {session.pinned ? (
-              <PinOff className="w-3 h-3" />
+              <PinOff className={`w-3 h-3${
+                recentlyToggledPinId === session.id
+                  ? ' animate-bounce-once'
+                  : ''
+              }`} />
             ) : (
-              <Pin className="w-3 h-3" />
+              <Pin className={`w-3 h-3${
+                recentlyToggledPinId === session.id
+                  ? ' animate-bounce-once'
+                  : ''
+              }`} />
             )}
           </button>
 
@@ -162,6 +172,8 @@ interface ChatHistorySidebarProps {
   isCollapsed?: boolean;
 }
 
+const UNDO_TIMEOUT_MS = 5_000;
+
 export default function ChatHistorySidebar({
   onLoadSession,
   onClose,
@@ -178,6 +190,7 @@ export default function ChatHistorySidebar({
     searchSessions,
     togglePin,
     hasHistory,
+    sessions: allSessionsRaw,
   } = useChatHistory();
   const { entries, clearEntries, updateEntry } = useTxHistory();
   const { connection } = useStellarWallet();
@@ -189,6 +202,18 @@ export default function ChatHistorySidebar({
   const [isLoading, setIsLoading] = useState(true);
   const [contractEvents, setContractEvents] = useState<ContractEvent[]>([]);
   const [isLoadingEvents, setIsLoadingEvents] = useState(false);
+
+  // ── Optimistic UI state ──────────────────────────────────────────────────
+  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
+  const deleteTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const [recentlyToggledPinId, setRecentlyToggledPinId] = useState<string | null>(null);
+  const pinAnimTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const [pendingClearAll, setPendingClearAll] = useState(false);
+  const clearTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const stashedSessionsRef = useRef<ChatSession[]>([]);
+  // ────────────────────────────────────────────────────────────────────────
 
   useEffect(() => {
     const fetchEvents = async () => {
@@ -216,17 +241,84 @@ export default function ChatHistorySidebar({
     return () => clearTimeout(timer);
   }, []);
 
+  // Clean up timers on unmount
+  useEffect(() => {
+    return () => {
+      if (deleteTimerRef.current) clearTimeout(deleteTimerRef.current);
+      if (pinAnimTimerRef.current) clearTimeout(pinAnimTimerRef.current);
+      if (clearTimerRef.current) clearTimeout(clearTimerRef.current);
+    };
+  }, []);
+
   const allSessions = [...pinnedSessions, ...unpinnedSessions];
-  const filteredSessions = searchQuery
-    ? searchSessions(searchQuery)
+  // Filter out the session that is pending deletion so it disappears immediately
+  const visibleSessions = pendingDeleteId
+    ? allSessions.filter((s) => s.id !== pendingDeleteId)
     : allSessions;
+  const filteredSessions = searchQuery
+    ? searchSessions(searchQuery).filter((s) => s.id !== pendingDeleteId)
+    : visibleSessions;
   const filteredPinned = filteredSessions.filter((s) => s.pinned);
   const filteredUnpinned = filteredSessions.filter((s) => !s.pinned);
 
-  const handleDeleteSession = (sessionId: string) => {
-    deleteSession(sessionId);
+  // ── Optimistic delete with undo ──────────────────────────────────────────
+  const handleDeleteSession = useCallback((sessionId: string) => {
     setShowDeleteConfirm(null);
-  };
+    setPendingDeleteId(sessionId);
+
+    // Clear any previous delete timer
+    if (deleteTimerRef.current) clearTimeout(deleteTimerRef.current);
+
+    deleteTimerRef.current = setTimeout(() => {
+      deleteSession(sessionId);
+      setPendingDeleteId(null);
+    }, UNDO_TIMEOUT_MS);
+  }, [deleteSession]);
+
+  const undoDelete = useCallback(() => {
+    if (deleteTimerRef.current) clearTimeout(deleteTimerRef.current);
+    setPendingDeleteId(null);
+  }, []);
+
+  // ── Optimistic pin toggle with animation ─────────────────────────────────
+  const handleTogglePin = useCallback((sessionId: string) => {
+    togglePin(sessionId);
+    setRecentlyToggledPinId(sessionId);
+
+    if (pinAnimTimerRef.current) clearTimeout(pinAnimTimerRef.current);
+    pinAnimTimerRef.current = setTimeout(() => {
+      setRecentlyToggledPinId(null);
+    }, 600);
+  }, [togglePin]);
+
+  // ── Optimistic clear-all with undo ───────────────────────────────────────
+  const handleClearAll = useCallback(() => {
+    // Stash sessions for potential undo
+    stashedSessionsRef.current = [...allSessionsRaw];
+    clearAllHistory();
+    setPendingClearAll(true);
+
+    if (clearTimerRef.current) clearTimeout(clearTimerRef.current);
+    clearTimerRef.current = setTimeout(() => {
+      stashedSessionsRef.current = [];
+      setPendingClearAll(false);
+    }, UNDO_TIMEOUT_MS);
+  }, [allSessionsRaw, clearAllHistory]);
+
+  const undoClearAll = useCallback(() => {
+    if (clearTimerRef.current) clearTimeout(clearTimerRef.current);
+    // Restore stashed sessions by re-saving to localStorage and reloading
+    if (stashedSessionsRef.current.length > 0) {
+      const restored = {
+        currentSessionId: null,
+        sessions: stashedSessionsRef.current,
+      };
+      localStorage.setItem('defi_chat_history', JSON.stringify(restored));
+      window.location.reload();
+    }
+    stashedSessionsRef.current = [];
+    setPendingClearAll(false);
+  }, []);
 
   const handleExportSessionJSON = (sessionId: string) => {
     const exportResult = exportSessionAsJSON(sessionId);
@@ -382,7 +474,7 @@ export default function ChatHistorySidebar({
             }`}
           >
             <button
-              onClick={clearAllHistory}
+              onClick={handleClearAll}
               className="theme-text-muted hover:bg-[var(--color-danger-soft)] p-2 rounded-lg transition-all duration-200 hover:scale-110"
               title="Clear all history"
             >
@@ -511,8 +603,9 @@ export default function ChatHistorySidebar({
                           onExportJSON={handleExportSessionJSON}
                           onExportTXT={handleExportSessionTXT}
                           onDelete={(id) => setShowDeleteConfirm(id)}
-                          onTogglePin={togglePin}
+                          onTogglePin={handleTogglePin}
                           formatDate={formatDate}
+                          recentlyToggledPinId={recentlyToggledPinId}
                         />
                       ))}
                     </>
@@ -533,8 +626,9 @@ export default function ChatHistorySidebar({
                           onExportJSON={handleExportSessionJSON}
                           onExportTXT={handleExportSessionTXT}
                           onDelete={(id) => setShowDeleteConfirm(id)}
-                          onTogglePin={togglePin}
+                          onTogglePin={handleTogglePin}
                           formatDate={formatDate}
+                          recentlyToggledPinId={recentlyToggledPinId}
                         />
                       ))}
                     </>
@@ -545,6 +639,27 @@ export default function ChatHistorySidebar({
           </div>
         )}
       </div>
+
+      {/* ── Undo toast ────────────────────────────────────────────────────── */}
+      {(pendingDeleteId || pendingClearAll) && (
+        <div
+          className="flex items-center justify-between gap-2 px-4 py-2.5 text-xs font-medium border-t border-[var(--color-border)] bg-[var(--color-surface-muted)] animate-slide-up"
+          role="status"
+          aria-live="polite"
+        >
+          <span className="theme-text-secondary">
+            {pendingClearAll ? 'History cleared' : 'Conversation deleted'}
+          </span>
+          <button
+            type="button"
+            onClick={pendingClearAll ? undoClearAll : undoDelete}
+            className="px-2.5 py-1 rounded-md text-[var(--color-primary)] font-semibold hover:bg-[var(--color-primary-soft)] transition-colors"
+          >
+            Undo
+          </button>
+        </div>
+      )}
+      {/* ─────────────────────────────────────────────────────────────────── */}
 
       <div className={`theme-border border-t p-4 ${isCollapsed ? 'flex flex-col items-center' : ''}`}>
         <PriceTicker symbols={['XLM', 'ETH', 'BTC']} currency="usd" />

--- a/dex_with_fiat_frontend/src/components/__tests__/ChatHistorySidebar.test.tsx
+++ b/dex_with_fiat_frontend/src/components/__tests__/ChatHistorySidebar.test.tsx
@@ -1,20 +1,30 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, cleanup } from '@testing-library/react';
+import { render, screen, fireEvent, act, cleanup } from '@testing-library/react';
 import ChatHistorySidebar from '@/components/ChatHistorySidebar';
+import type { ChatSession } from '@/types';
+
+// ─── Shared mutable state so individual tests can override values ──────────
+let mockPinnedSessions: ChatSession[] = [];
+let mockUnpinnedSessions: ChatSession[] = [];
+let mockAllSessions: ChatSession[] = [];
+const mockDeleteSession = vi.fn();
+const mockClearAllHistory = vi.fn();
+const mockTogglePin = vi.fn();
 
 vi.mock('@/hooks/useChatHistory', () => ({
   useChatHistory: () => ({
-    pinnedSessions: [],
-    unpinnedSessions: [],
+    pinnedSessions: mockPinnedSessions,
+    unpinnedSessions: mockUnpinnedSessions,
     currentSessionId: null,
-    deleteSession: vi.fn(),
-    clearAllHistory: vi.fn(),
+    sessions: mockAllSessions,
+    deleteSession: mockDeleteSession,
+    clearAllHistory: mockClearAllHistory,
     exportSessionAsJSON: vi.fn(),
     exportSessionAsTXT: vi.fn(),
     searchSessions: vi.fn(() => []),
-    togglePin: vi.fn(),
-    hasHistory: false,
+    togglePin: mockTogglePin,
+    hasHistory: mockAllSessions.length > 0,
   }),
 }));
 
@@ -32,29 +42,164 @@ vi.mock('@/contexts/StellarWalletContext', () => ({
   }),
 }));
 
+vi.mock('@/components/PriceTicker', () => ({ default: () => null }));
+vi.mock('@/components/ui/skeleton/SkeletonSidebar', () => ({ default: () => null }));
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+function makeSession(id: string, overrides?: Partial<ChatSession>): ChatSession {
+  return {
+    id,
+    title: `Chat ${id}`,
+    messages: [],
+    createdAt: new Date(),
+    lastUpdated: new Date(),
+    pinned: false,
+    ...overrides,
+  };
+}
+
+/** Render the sidebar and advance past the 800ms loading skeleton */
+async function renderAndLoad(props?: Partial<React.ComponentProps<typeof ChatHistorySidebar>>) {
+  const result = render(
+    <ChatHistorySidebar onLoadSession={vi.fn()} isCollapsed={false} {...props} />,
+  );
+  // Advance the 800ms loading timer
+  await act(async () => { vi.advanceTimersByTime(900); });
+  return result;
+}
+
 describe('ChatHistorySidebar', () => {
   beforeEach(() => {
+    vi.useFakeTimers();
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({ events: [] }),
     } as Response);
+    mockPinnedSessions = [];
+    mockUnpinnedSessions = [];
+    mockAllSessions = [];
+    mockDeleteSession.mockReset();
+    mockClearAllHistory.mockReset();
+    mockTogglePin.mockReset();
   });
 
   afterEach(() => {
     cleanup();
     vi.restoreAllMocks();
+    vi.useRealTimers();
   });
 
   /**
    * Regression (#651): root chrome must use theme border color so the sidebar
-   * separator matches the rest of the layout (not Tailwind’s default border color).
+   * separator matches the rest of the layout (not Tailwind's default border color).
    */
-  it('applies theme border color to the root sidebar chrome', () => {
-    const { container } = render(
-      <ChatHistorySidebar onLoadSession={vi.fn()} isCollapsed={false} />,
-    );
+  it('applies theme border color to the root sidebar chrome', async () => {
+    const { container } = await renderAndLoad();
     const root = container.firstElementChild as HTMLElement;
     expect(root.className).toMatch(/\btheme-border\b/);
     expect(root.className).toMatch(/\bborder-r\b/);
+  });
+
+  it('shows undo toast after session delete and does not call deleteSession immediately', async () => {
+    const session = makeSession('s1');
+    mockUnpinnedSessions = [session];
+    mockAllSessions = [session];
+
+    await renderAndLoad();
+
+    // Click delete → confirm dialog appears → click Delete
+    fireEvent.click(screen.getByTitle('Delete conversation'));
+    fireEvent.click(screen.getByText('Delete'));
+
+    // deleteSession should NOT be called immediately (optimistic)
+    expect(mockDeleteSession).not.toHaveBeenCalled();
+
+    // Undo toast should be visible
+    expect(screen.getByText('Conversation deleted')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Undo' })).toBeTruthy();
+  });
+
+  it('calls deleteSession after the undo timeout expires', async () => {
+    const session = makeSession('s2');
+    mockUnpinnedSessions = [session];
+    mockAllSessions = [session];
+
+    await renderAndLoad();
+
+    fireEvent.click(screen.getByTitle('Delete conversation'));
+    fireEvent.click(screen.getByText('Delete'));
+
+    // Advance past the 5s undo window
+    await act(async () => { vi.advanceTimersByTime(5100); });
+
+    expect(mockDeleteSession).toHaveBeenCalledWith('s2');
+  });
+
+  it('does NOT call deleteSession when undo is clicked within the window', async () => {
+    const session = makeSession('s3');
+    mockUnpinnedSessions = [session];
+    mockAllSessions = [session];
+
+    await renderAndLoad();
+
+    fireEvent.click(screen.getByTitle('Delete conversation'));
+    fireEvent.click(screen.getByText('Delete'));
+
+    // Click Undo before the timer fires
+    fireEvent.click(screen.getByRole('button', { name: 'Undo' }));
+
+    await act(async () => { vi.advanceTimersByTime(5100); });
+
+    expect(mockDeleteSession).not.toHaveBeenCalled();
+    expect(screen.queryByText('Conversation deleted')).toBeNull();
+  });
+
+  it('calls togglePin immediately on pin button click', async () => {
+    const session = makeSession('s4');
+    mockUnpinnedSessions = [session];
+    mockAllSessions = [session];
+
+    await renderAndLoad();
+
+    fireEvent.click(screen.getByTitle('Pin conversation'));
+
+    expect(mockTogglePin).toHaveBeenCalledWith('s4');
+  });
+
+  it('applies animate-bounce-once class to pin icon and removes it after 600ms', async () => {
+    const session = makeSession('s5');
+    mockUnpinnedSessions = [session];
+    mockAllSessions = [session];
+
+    await renderAndLoad();
+
+    fireEvent.click(screen.getByTitle('Pin conversation'));
+
+    // Animation class should be applied
+    const pinBtn = screen.getByTitle('Pin conversation');
+    const svg = pinBtn.querySelector('svg');
+    expect(svg?.className).toContain('animate-bounce-once');
+
+    // After 600ms the animation class should be removed
+    await act(async () => { vi.advanceTimersByTime(700); });
+    expect(svg?.className).not.toContain('animate-bounce-once');
+  });
+
+  it('shows undo toast after clear-all and calls clearAllHistory immediately', async () => {
+    const sessions = [makeSession('c1'), makeSession('c2')];
+    mockUnpinnedSessions = sessions;
+    mockAllSessions = sessions;
+
+    await renderAndLoad();
+
+    fireEvent.click(screen.getByTitle('Clear all history'));
+
+    expect(mockClearAllHistory).toHaveBeenCalledTimes(1);
+    expect(screen.getByText('History cleared')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Undo' })).toBeTruthy();
+
+    // Toast disappears after timeout
+    await act(async () => { vi.advanceTimersByTime(5100); });
+    expect(screen.queryByText('History cleared')).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Implements optimistic UI updates in `ChatHistorySidebar.tsx` to improve user experience and align with Stellar Wave design guidelines.

## Changes

### `ChatHistorySidebar.tsx`
- **Optimistic delete with undo** — session disappears immediately from the list, a 5-second undo toast appears. Deletion only commits after the timer expires.
- **Pin toggle animation** — `togglePin` fires instantly; pin/unpin icon gets `animate-bounce-once` class for 600ms for tactile feedback.
- **Clear-all with undo** — `clearAllHistory` fires instantly, sessions stashed in a ref. Undo toast allows full restoration within 5 seconds.
- Undo toast is accessible with `role="status"` and `aria-live="polite"`.

### `globals.css`
- Added `@keyframes bounceOnce` + `.animate-bounce-once` (600ms)
- Added `@keyframes slideUp` + `.animate-slide-up` (250ms) for undo toast entrance

### `ChatHistorySidebar.test.tsx`
Updated with 7 tests verifying all three optimistic patterns using fake timers.

## Testing

- [x] 7/7 unit tests pass
- [x] `npm run lint` — no new errors (exit 0)
- [x] No regressions to existing sidebar UI

Closes #673