### PR TITLE
fix(contract): correct edge case validation in initialize

### DIFF
--- a/stellar-contracts/src/lib.rs
+++ b/stellar-contracts/src/lib.rs
@@ -41,6 +41,8 @@ const DEFAULT_INACTIVITY_THRESHOLD: u32 = 1_555_200;
 /// is rejected with [`Error::UpgradeDelayTooShort`] to prevent surprise
 /// upgrades that bypass the governance timelock.
 const MIN_UPGRADE_DELAY: u32 = 1_000;
+/// Maximum number of signers allowed in the multi-signature configuration.
+const MAX_SIGNERS: u32 = 20;
 /// Version tag embedded in all contract events for indexer compatibility.
 pub const EVENT_VERSION: u32 = 1;
 /// Current escrow storage schema version used by the migration system.
@@ -128,6 +130,7 @@ pub enum Error {
     AlreadyApproved = 1105,
     ProposalAlreadyExecuted = 1106,
     ThresholdNotMet = 1107,
+    MaxSignersReached = 1108,
 }
 
 // ── Models ────────────────────────────────────────────────────────────────
@@ -676,9 +679,18 @@ impl FiatBridge {
         signers: Vec<Address>,
         threshold: u32,
     ) -> Result<(), Error> {
-        if env.storage().instance().has(&DataKey::Admin) {
+        // Boundary check (fix #214): ensure contract is not already initialized.
+        // We check SchemaVersion instead of Admin because Admin can be removed
+        // during renounce_admin, which would otherwise allow re-initialization.
+        if env.storage().instance().has(&DataKey::SchemaVersion) {
             return Err(Error::AlreadyInitialized);
         }
+
+        // Boundary check: admin cannot be the contract itself to prevent lockout.
+        if admin == env.current_contract_address() {
+            return Err(Error::Unauthorized);
+        }
+
         if limit <= 0 {
             return Err(Error::ZeroAmount);
         }
@@ -687,9 +699,16 @@ impl FiatBridge {
         }
 
         // Validate multisig config
-        if threshold == 0 || threshold > signers.len() {
+        if threshold == 0 {
             return Err(Error::InvalidThreshold);
         }
+        if signers.len() == 0 || threshold > signers.len() {
+            return Err(Error::InvalidThreshold);
+        }
+        if signers.len() > MAX_SIGNERS {
+            return Err(Error::MaxSignersReached);
+        }
+
         // Ensure no duplicate signers
         let mut seen = Vec::<Address>::new(&env);
         for s in signers.iter() {
@@ -4276,3 +4295,6 @@ mod test_new_issues;
 
 #[cfg(test)]
 mod test_issues_695_687;
+
+#[cfg(test)]
+mod test_init_validation;

--- a/stellar-contracts/src/test_init_validation.rs
+++ b/stellar-contracts/src/test_init_validation.rs
@@ -1,0 +1,116 @@
+#[cfg(test)]
+use super::*;
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    vec, Address, Env,
+};
+
+#[test]
+fn test_reinitialization_blocked_after_renounce() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(FiatBridge, ());
+    let bridge = FiatBridgeClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    let signers = vec![&env, admin.clone()];
+
+    // First initialization
+    bridge.init(&admin, &token, &1_000_000, &1, &signers, &1);
+
+    // Renounce admin
+    bridge.queue_renounce_admin();
+    
+    // Advance ledger to satisfy MIN_TIMELOCK_DELAY (34560 ledgers)
+    let current_ledger = env.ledger().sequence();
+    env.ledger().set_sequence_number(current_ledger + 34560 + 1);
+    
+    bridge.execute_renounce_admin();
+
+    // Verify admin is removed
+    let admin_res = bridge.try_get_admin();
+    assert!(admin_res.is_err());
+
+    // Attempting to re-initialize should fail with AlreadyInitialized
+    // even though the Admin key is gone, because SchemaVersion remains.
+    let new_admin = Address::generate(&env);
+    let result = bridge.try_init(&new_admin, &token, &1_000_000, &1, &signers, &1);
+    
+    assert_eq!(result, Err(Ok(Error::AlreadyInitialized)));
+}
+
+#[test]
+fn test_init_rejects_contract_as_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(FiatBridge, ());
+    let bridge = FiatBridgeClient::new(&env, &contract_id);
+
+    let token = Address::generate(&env);
+    let signers = vec![&env, token.clone()];
+
+    // Attempt to set contract itself as admin
+    let result = bridge.try_init(&contract_id, &token, &1_000_000, &1, &signers, &1);
+    
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+}
+
+#[test]
+fn test_init_rejects_too_many_signers() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(FiatBridge, ());
+    let bridge = FiatBridgeClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    
+    // Create 21 signers (MAX_SIGNERS is 20)
+    let mut signers = vec![&env];
+    for _ in 0..21 {
+        signers.push_back(Address::generate(&env));
+    }
+
+    let result = bridge.try_init(&admin, &token, &1_000_000, &1, &signers, &1);
+    
+    assert_eq!(result, Err(Ok(Error::MaxSignersReached)));
+}
+
+#[test]
+fn test_init_rejects_empty_signers() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(FiatBridge, ());
+    let bridge = FiatBridgeClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    let signers = vec![&env];
+
+    // threshold 1 but 0 signers
+    let result = bridge.try_init(&admin, &token, &1_000_000, &1, &signers, &1);
+    
+    assert_eq!(result, Err(Ok(Error::InvalidThreshold)));
+}
+
+#[test]
+fn test_init_rejects_zero_threshold() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(FiatBridge, ());
+    let bridge = FiatBridgeClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    let signers = vec![&env, admin.clone()];
+
+    let result = bridge.try_init(&admin, &token, &1_000_000, &1, &signers, &0);
+    
+    assert_eq!(result, Err(Ok(Error::InvalidThreshold)));
+}


### PR DESCRIPTION
Closes #551 

closes #518 
### Overview
This PR addresses missing boundary checks in the `FiatBridge::init` function to prevent unexpected state transitions and secure administrative configuration.

### Changes
- **Re-initialization Guard**: Replaced `has(&DataKey::Admin)` check with `has(&DataKey::SchemaVersion)` to prevent anyone from re-initializing the contract after an admin renounces.
- **Admin Lockout Protection**: Prevents setting the contract address as its own administrator.
- **Signer Cap**: Enforces a `MAX_SIGNERS` limit of 20 to safeguard against resource exhaustion.
- **Improved Errors**: Added `Error::MaxSignersReached` (1108).
- **Comprehensive Tests**: Added `test_init_validation.rs` with 5 new test cases.
