### PR TITLE
feat(contract): require admin co-authentication on deposit

### DIFF
--- a/stellar-contracts/src/lib.rs
+++ b/stellar-contracts/src/lib.rs
@@ -286,6 +286,8 @@ pub struct DeployHashEvent {
 #[derive(Clone, Debug)]
 pub struct DepositEvent {
     pub version: u32,
+    /// Admin that co-authorized the deposit (recorded for off-chain audit).
+    pub admin: Address,
     pub from: Address,
     pub token: Address,
     pub amount: i128,
@@ -800,6 +802,18 @@ impl FiatBridge {
         env.storage().instance().extend_ttl(MIN_TTL, MAX_TTL);
         Self::validate_memo_hash(&env, &memo_hash)?;
         from.require_auth();
+
+        // Admin co-authentication: deposits require the admin's signature
+        // alongside the depositor's. This lets the bridge enforce off-chain
+        // KYC/AML decisions on-chain — the admin only co-signs after the
+        // operator-side checks have cleared.
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::NotInitialized)?;
+        admin.require_auth();
+
         Self::require_not_paused(&env)?;
 
         if amount <= 0 {
@@ -994,6 +1008,7 @@ impl FiatBridge {
 
         DepositEvent {
             version: EVENT_VERSION,
+            admin: admin.clone(),
             from: from.clone(),
             token: token.clone(),
             amount,
@@ -4298,3 +4313,6 @@ mod test_issues_695_687;
 
 #[cfg(test)]
 mod test_init_validation;
+
+#[cfg(test)]
+mod test_admin_auth_deposit;

--- a/stellar-contracts/src/test_admin_auth_deposit.rs
+++ b/stellar-contracts/src/test_admin_auth_deposit.rs
@@ -1,0 +1,215 @@
+//! Integration tests for admin co-authentication on `deposit`.
+//!
+//! The deposit path requires both the depositor and the admin to authorize,
+//! and the emitted [`DepositEvent`] is enriched with the admin address that
+//! co-signed.
+
+#![cfg(test)]
+extern crate std;
+
+use super::*;
+use soroban_sdk::{
+    testutils::{Address as _, Events as _, MockAuth, MockAuthInvoke},
+    token::StellarAssetClient,
+    vec,
+    xdr::{ContractEventBody, ScSymbol, ScVal, StringM},
+    Address, Bytes, Env, IntoVal, Vec,
+};
+
+fn create_token<'a>(env: &Env, admin: &Address) -> (Address, StellarAssetClient<'a>) {
+    let addr = env
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+    let sac = StellarAssetClient::new(env, &addr);
+    (addr, sac)
+}
+
+struct Fixture<'a> {
+    env: Env,
+    contract_id: Address,
+    bridge: FiatBridgeClient<'a>,
+    admin: Address,
+    token_addr: Address,
+    user: Address,
+}
+
+fn setup_fixture() -> Fixture<'static> {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let (token_addr, token_sac) = create_token(&env, &token_admin);
+
+    let contract_id = env.register(FiatBridge, ());
+    let bridge = FiatBridgeClient::new(&env, &contract_id);
+
+    let mut signers = Vec::new(&env);
+    signers.push_back(admin.clone());
+    bridge.init(&admin, &token_addr, &1_000_000, &1, &signers, &1);
+
+    let user = Address::generate(&env);
+    token_sac.mint(&user, &10_000);
+
+    Fixture {
+        env,
+        contract_id,
+        bridge,
+        admin,
+        token_addr,
+        user,
+    }
+}
+
+#[test]
+fn deposit_succeeds_when_admin_co_authorizes() {
+    let f = setup_fixture();
+
+    // mock_all_auths in setup means both `from` and `admin` are treated as
+    // having signed — the happy path under typical testing.
+    f.bridge.deposit(
+        &f.user,
+        &500,
+        &f.token_addr,
+        &Bytes::new(&f.env),
+        &0,
+        &0,
+        &None,
+    );
+
+    // Deposit landed: contract holds the funds.
+    let token = soroban_sdk::token::Client::new(&f.env, &f.token_addr);
+    assert_eq!(token.balance(&f.contract_id), 500);
+    assert_eq!(token.balance(&f.user), 9_500);
+}
+
+#[test]
+fn deposit_event_carries_admin_address() {
+    let f = setup_fixture();
+
+    f.bridge.deposit(
+        &f.user,
+        &250,
+        &f.token_addr,
+        &Bytes::new(&f.env),
+        &0,
+        &0,
+        &None,
+    );
+
+    // Inspect the raw XDR of bridge events and find the DepositEvent.
+    // The #[contractevent] macro emits a single topic equal to the
+    // snake-case struct name; the data is a Map containing the struct
+    // fields keyed by their snake_case names.
+    let bridge_events = f.env.events().all().filter_by_contract(&f.contract_id);
+    let raw = bridge_events.events();
+
+    let deposit_topic = ScVal::Symbol(ScSymbol(
+        StringM::try_from("deposit_event").expect("valid event topic"),
+    ));
+    let admin_key = ScVal::Symbol(ScSymbol(
+        StringM::try_from("admin").expect("valid field name"),
+    ));
+    let expected_admin: ScVal = (&f.admin).try_into().expect("address → ScVal");
+
+    let mut saw_admin = false;
+    for event in raw.iter() {
+        let ContractEventBody::V0(body) = &event.body;
+        if !body.topics.iter().any(|t| t == &deposit_topic) {
+            continue;
+        }
+        if let ScVal::Map(Some(map)) = &body.data {
+            let admin_entry = map
+                .iter()
+                .find(|entry| entry.key == admin_key)
+                .expect("DepositEvent map must contain `admin`");
+            assert_eq!(admin_entry.val, expected_admin);
+            saw_admin = true;
+            break;
+        }
+    }
+    assert!(
+        saw_admin,
+        "expected a DepositEvent with admin field to be emitted; got {:?}",
+        raw
+    );
+}
+
+#[test]
+fn deposit_fails_when_admin_does_not_co_authorize() {
+    // Build a fixture but DO NOT use mock_all_auths — instead, provide a
+    // narrow MockAuth list that only contains the depositor's signature.
+    // Without the admin's auth the contract's `admin.require_auth()` call
+    // must reject the invocation.
+    let env = Env::default();
+
+    // Initialise the bridge with mock_all_auths so init() succeeds, then
+    // switch to scoped auths for the deposit call we actually want to test.
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let (token_addr, token_sac) = create_token(&env, &token_admin);
+    let contract_id = env.register(FiatBridge, ());
+    let bridge = FiatBridgeClient::new(&env, &contract_id);
+    let signers = vec![&env, admin.clone()];
+    bridge.init(&admin, &token_addr, &1_000_000, &1, &signers, &1);
+    let user = Address::generate(&env);
+    token_sac.mint(&user, &5_000);
+
+    // Reduce auth scope: only the user (and the SAC transfer sub-call) are
+    // signed. Crucially, the admin is NOT in the auth list — so the
+    // bridge's admin.require_auth() inside deposit() must fail.
+    let amount: i128 = 100;
+    let reference = Bytes::new(&env);
+    let expected_price: i128 = 0;
+    let max_slippage: u32 = 0;
+    let memo: Option<soroban_sdk::BytesN<32>> = None;
+
+    let deposit_args: soroban_sdk::Vec<soroban_sdk::Val> = (
+        user.clone(),
+        amount,
+        token_addr.clone(),
+        reference.clone(),
+        expected_price,
+        max_slippage,
+        memo.clone(),
+    )
+        .into_val(&env);
+
+    let transfer_args: soroban_sdk::Vec<soroban_sdk::Val> =
+        (user.clone(), contract_id.clone(), amount).into_val(&env);
+
+    env.mock_auths(&[MockAuth {
+        address: &user,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "deposit",
+            args: deposit_args,
+            sub_invokes: &[MockAuthInvoke {
+                contract: &token_addr,
+                fn_name: "transfer",
+                args: transfer_args,
+                sub_invokes: &[],
+            }],
+        },
+    }]);
+
+    let result = bridge.try_deposit(
+        &user,
+        &amount,
+        &token_addr,
+        &reference,
+        &expected_price,
+        &max_slippage,
+        &memo,
+    );
+
+    // Without admin auth the host's auth manager rejects the call before
+    // any contract logic returns an Error code, so we just assert the
+    // invocation fails (not Ok).
+    assert!(
+        result.is_err(),
+        "deposit must fail when the admin has not co-authorized; got {:?}",
+        result
+    );
+}


### PR DESCRIPTION
The fiat bridge needs an enforcement point on-chain for the admin's KYC/AML decision before user funds enter the contract. Today `deposit` only requires the depositor's signature, so any whitelisted user can move funds in without an explicit admin sign-off recorded on chain.

Changes
* `deposit` now loads the admin from `DataKey::Admin` and calls `admin.require_auth()` immediately after `from.require_auth()`. Any deposit that isn't co-signed by the admin reverts before any state mutation or token transfer happens.
* `DepositEvent` carries a new `admin: Address` field — off-chain indexers can now attribute the on-chain co-signature to a specific admin key for audit trails.

Tests (new file: src/test_admin_auth_deposit.rs)
* deposit_succeeds_when_admin_co_authorizes — happy path under mock_all_auths; verifies funds move and balances update.
* deposit_event_carries_admin_address — inspects the raw XDR of the emitted DepositEvent and asserts the admin entry equals the configured admin.
* deposit_fails_when_admin_does_not_co_authorize — uses scoped `mock_auths` containing only the depositor's signature (and the SAC `transfer` sub-invoke); confirms the call fails when the admin has not co-signed.

Verified locally: the 3 new tests pass; the rest of the suite is unchanged (214 passed, 15 pre-existing failures inherited from origin/main, none introduced or affected by this change).


Closes #642 