### PR TITLE
fix(frontend): resolve race condition in useChat.ts (#530)

### DIFF
--- a/dex_with_fiat_frontend/src/components/ReceiptDrawer.test.tsx
+++ b/dex_with_fiat_frontend/src/components/ReceiptDrawer.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * Unit tests for ReceiptDrawer keyboard shortcuts (issue #528).
+ */
+import React from 'react';
+import { render, fireEvent, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import ReceiptDrawer from './ReceiptDrawer';
+
+vi.mock('@/contexts/TranslationContext', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+vi.mock('@/contexts/ThemeContext', () => ({
+  useTheme: () => ({ isDarkMode: false }),
+}));
+
+vi.mock('@/hooks/useTransactionFilters', () => ({
+  useTransactionFilters: (txs: unknown[]) => ({
+    filterState: {},
+    filteredTransactions: txs,
+    filterStats: {},
+    toggleFilter: vi.fn(),
+    clearAllFilters: vi.fn(),
+  }),
+}));
+
+vi.mock('./filters/FilterChipBar', () => ({
+  FilterChipBar: () => null,
+}));
+
+vi.mock('../components/ui/skeleton/SkeletonReceipt', () => ({
+  default: () => <div data-testid="skeleton" />,
+}));
+
+const defaultProps = {
+  isOpen: true,
+  onClose: vi.fn(),
+  transactions: [],
+  onClearHistory: vi.fn(),
+};
+
+describe('ReceiptDrawer keyboard shortcuts (#528)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('Escape key calls onClose', () => {
+    render(<ReceiptDrawer {...defaultProps} />);
+    act(() => {
+      fireEvent.keyDown(document, { key: 'Escape' });
+    });
+    expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('Backspace key calls onClearHistory', () => {
+    render(<ReceiptDrawer {...defaultProps} />);
+    act(() => {
+      fireEvent.keyDown(document, { key: 'Backspace' });
+    });
+    expect(defaultProps.onClearHistory).toHaveBeenCalledTimes(1);
+  });
+
+  it('Delete key calls onClearHistory', () => {
+    render(<ReceiptDrawer {...defaultProps} />);
+    act(() => {
+      fireEvent.keyDown(document, { key: 'Delete' });
+    });
+    expect(defaultProps.onClearHistory).toHaveBeenCalledTimes(1);
+  });
+
+  it('keyboard shortcuts are ignored when drawer is closed', () => {
+    render(<ReceiptDrawer {...defaultProps} isOpen={false} />);
+    act(() => {
+      fireEvent.keyDown(document, { key: 'Escape' });
+      fireEvent.keyDown(document, { key: 'Backspace' });
+    });
+    expect(defaultProps.onClose).not.toHaveBeenCalled();
+    expect(defaultProps.onClearHistory).not.toHaveBeenCalled();
+  });
+
+  it('Backspace does nothing when onClearHistory is not provided', () => {
+    const { onClearHistory: _omit, ...propsWithoutClear } = defaultProps;
+    expect(() => {
+      render(<ReceiptDrawer {...propsWithoutClear} />);
+      act(() => {
+        fireEvent.keyDown(document, { key: 'Backspace' });
+      });
+    }).not.toThrow();
+  });
+
+  it('drawer has correct aria attributes for accessibility', () => {
+    const { getByRole } = render(<ReceiptDrawer {...defaultProps} />);
+    const dialog = getByRole('dialog');
+    expect(dialog).toBeTruthy();
+    expect(dialog.getAttribute('aria-modal')).toBe('true');
+  });
+});

--- a/dex_with_fiat_frontend/src/components/ReceiptDrawer.tsx
+++ b/dex_with_fiat_frontend/src/components/ReceiptDrawer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import {
   X,
   Receipt,
@@ -34,6 +34,24 @@ export default function ReceiptDrawer({
   const { isDarkMode } = useTheme();
 
   const [isLoading, setIsLoading] = useState(true);
+
+  // Keyboard shortcuts: Escape closes, Backspace/Delete clears history (issue #528)
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (!isOpen) return;
+      if (e.key === 'Escape') {
+        onClose();
+      } else if ((e.key === 'Backspace' || e.key === 'Delete') && onClearHistory) {
+        onClearHistory();
+      }
+    },
+    [isOpen, onClose, onClearHistory],
+  );
+
+  useEffect(() => {
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [handleKeyDown]);
 
   useEffect(() => {
     if (isOpen) {
@@ -73,6 +91,9 @@ export default function ReceiptDrawer({
           isOpen ? 'translate-x-0' : 'translate-x-full'
         }`}
         aria-busy={isLoading}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Transaction receipts — press Escape to close"
       >
         <div className="flex flex-col h-full">
           {/* Header */}
@@ -88,7 +109,7 @@ export default function ReceiptDrawer({
                 <button
                   onClick={onClearHistory}
                   className="p-2 text-gray-500 hover:text-red-500 transition-colors"
-                  title="Clear history"
+                  title="Clear history (Backspace)"
                 >
                   <Trash2 className="w-5 h-5" />
                 </button>

--- a/dex_with_fiat_frontend/src/hooks/useChat.test.ts
+++ b/dex_with_fiat_frontend/src/hooks/useChat.test.ts
@@ -812,3 +812,81 @@ describe('useChat flow state transitions', () => {
     harness.cleanup();
   });
 });
+
+// ── Issue #530 regression: race condition in useChat ─────────────────────────
+describe('useChat race condition regression (#530)', () => {
+  beforeEach(() => {
+    analyzeQueue = [];
+    createNewSessionSpy.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('concurrent sends produce unique message IDs — no ID collision', async () => {
+    // Both resolves immediately so two sends can race
+    analyzeQueue = [
+      { intent: 'query', confidence: 0.99, extractedData: {}, requiredQuestions: [], suggestedResponse: 'resp A' },
+      { intent: 'query', confidence: 0.99, extractedData: {}, requiredQuestions: [], suggestedResponse: 'resp B' },
+    ];
+
+    const harness = await setupHook();
+    await flushEffects(1);
+
+    await act(async () => { await harness.api.sendMessage('msg A'); });
+    await flushEffects(2);
+    await act(async () => { await harness.api.sendMessage('msg B'); });
+    await flushEffects(2);
+
+    const ids = harness.api.messages.map((m) => m.id);
+    const unique = new Set(ids);
+    expect(unique.size).toBe(ids.length);
+
+    harness.cleanup();
+  });
+
+  it('cancelPendingRequest works even when called before isLoading state propagates', async () => {
+    // Never-resolving promise simulates in-flight request
+    analyzeQueue = [new Promise<AnalyzeResult>(() => {})];
+
+    const harness = await setupHook();
+    await flushEffects(1);
+
+    act(() => { void harness.api.sendMessage('slow request'); });
+
+    // Cancel immediately — before React has flushed the isLoading=true state
+    act(() => { harness.api.cancelPendingRequest(); });
+
+    await flushEffects(2);
+
+    expect(harness.api.isLoading).toBe(false);
+    const last = harness.api.messages[harness.api.messages.length - 1];
+    expect(last?.metadata?.requestStatus).toBe('cancelled');
+
+    harness.cleanup();
+  });
+
+  it('stale sendMessage closure does not re-use a previous AbortController', async () => {
+    analyzeQueue = [
+      { intent: 'query', confidence: 0.99, extractedData: {}, requiredQuestions: [], suggestedResponse: 'first' },
+      { intent: 'query', confidence: 0.99, extractedData: {}, requiredQuestions: [], suggestedResponse: 'second' },
+    ];
+
+    const harness = await setupHook();
+    await flushEffects(1);
+
+    await act(async () => { await harness.api.sendMessage('first'); });
+    await flushEffects(2);
+
+    // Second send must not throw or leave isLoading stuck
+    await act(async () => { await harness.api.sendMessage('second'); });
+    await flushEffects(2);
+
+    expect(harness.api.isLoading).toBe(false);
+    const userMessages = harness.api.messages.filter((m) => m.role === 'user');
+    expect(userMessages).toHaveLength(2);
+
+    harness.cleanup();
+  });
+});

--- a/dex_with_fiat_frontend/src/hooks/useChat.ts
+++ b/dex_with_fiat_frontend/src/hooks/useChat.ts
@@ -146,7 +146,8 @@ What would you like to do today? I'm here to make your XLM-to-fiat journey smoot
   }, []);
 
   const cancelPendingRequest = useCallback(() => {
-    if (!activeRequestControllerRef.current || !isLoading) {
+    // Read the ref directly to avoid stale-closure on isLoading state.
+    if (!activeRequestControllerRef.current) {
       return;
     }
     activeRequestControllerRef.current.abort();
@@ -155,7 +156,7 @@ What would you like to do today? I'm here to make your XLM-to-fiat journey smoot
     appendCancelledMessage(
       'Request cancelled. No worries - you can send a new prompt when ready.',
     );
-  }, [appendCancelledMessage, isLoading]);
+  }, [appendCancelledMessage]);
 
   // Subscribe to state machine changes
   useEffect(() => {
@@ -515,21 +516,31 @@ What would you like to do today? I'm here to make your XLM-to-fiat journey smoot
         return;
       }
 
-      // Detect cancellation
-      if (isLoading && activeRequestControllerRef.current) {
+      // Abort any in-flight request — read the ref directly to avoid a stale
+      // closure on the isLoading state value (issue #530).
+      if (activeRequestControllerRef.current) {
         activeRequestControllerRef.current.abort();
         activeRequestControllerRef.current = null;
       }
 
+      // Use crypto.randomUUID (or a monotonic fallback) to guarantee unique IDs
+      // even when two messages are created within the same millisecond — the
+      // original Date.now() / Date.now()+1 pattern was the root cause of the
+      // race condition reported in issue #530.
+      const uid = () =>
+        typeof crypto !== 'undefined' && crypto.randomUUID
+          ? crypto.randomUUID()
+          : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
       // Add user message
       const userMessage: ChatMessage = {
-        id: Date.now().toString(),
+        id: uid(),
         role: 'user',
         content,
         timestamp: new Date(),
       };
 
-      const pendingAssistantId = (Date.now() + 1).toString();
+      const pendingAssistantId = uid();
       const pendingAssistantMessage: ChatMessage = {
         id: pendingAssistantId,
         role: 'assistant',
@@ -610,7 +621,6 @@ What would you like to do today? I'm here to make your XLM-to-fiat journey smoot
     [
       analyzeAndRespond,
       isLikelyNetworkError,
-      isLoading,
       markMessageFailed,
     ],
   );

--- a/docs/slippage-threshold.md
+++ b/docs/slippage-threshold.md
@@ -41,7 +41,22 @@ Together, these rules give **predictable boundary behaviour** at exactly `max_sl
 
 When the check fails, the contract returns `Error::SlippageTooHigh` (see `ERROR_CODES.md` / `SlippageExceeded` in product docs where applicable).
 
+## Architectural notes
+
+### Why cross-multiplication instead of division?
+
+Integer division truncates. If we simply computed `(diff * 10_000) / expected` and compared to `max_slippage_bps`, a price that is fractionally over the cap could pass because the floor rounds it down. Cross-multiplication (`diff * 10_000 > max_slippage_bps * expected`) avoids that truncation entirely for the fast-reject path.
+
+### Why the remainder guard?
+
+After the fast-reject, the floored quotient is computed. When `quotient == max_slippage_bps` the floor value is exactly at the cap, but the true rational value might be `max + ε`. The remainder guard (`remainder >= expected / 2`) catches cases where ceiling-rounding would push the value over the cap, keeping boundary behaviour deterministic for tests that construct prices at exactly `max_slippage_bps` BPS.
+
+### Where is this called?
+
+`check_slippage` is a private helper invoked inside `deposit` and `execute_withdrawal` whenever the caller supplies a non-zero `expected_price`. Passing `expected_price = 0` skips the check entirely (no oracle benchmark available).
+
 ## Further reading
 
+- Inline Rustdoc: `stellar-contracts/src/lib.rs` — `FiatBridge::check_slippage`.
 - Contract tests: `stellar-contracts/src/test.rs` — `test_slippage_*` and boundary suites.
 - Overflow / fixed-point context: `stellar-contracts/docs/OVERFLOW_PREVENTION.md`.

--- a/stellar-contracts/src/lib.rs
+++ b/stellar-contracts/src/lib.rs
@@ -1,4 +1,4 @@
-#![no_std]
+﻿#![no_std]
 #![allow(clippy::too_many_arguments)]
 use soroban_sdk::{
     contract, contracterror, contractevent, contractimpl, contracttype, token, xdr::ToXdr, Address,
@@ -2082,22 +2082,48 @@ impl FiatBridge {
 
     /// Enforces `max_slippage_bps` on **downward** price moves only.
     ///
-    /// # Model
+    /// # Parameters
     ///
-    /// - `expected_price` — benchmark (e.g. oracle) price used for the check.
-    /// - `actual_price` — effective price for the current deposit/withdraw path.
-    /// - `max_slippage_bps` — cap in **basis points** (10_000 BPS = 100%). Only
+    /// - `expected_price` - benchmark (e.g. oracle) price used for the check.
+    ///   Skipped entirely when `<= 0` (no benchmark available).
+    /// - `actual_price` - effective price for the current deposit/withdraw path.
+    /// - `max_slippage_bps` - cap in **basis points** (10_000 BPS = 100%). Only
     ///   applies when `actual_price < expected_price`.
     ///
     /// # Display vs assertion
     ///
     /// The emitted `SlippageEvent` uses **floor** BPS:
-    /// `⌊(expected - actual) * 10_000 / expected⌋` when `actual < expected`, else `0`.
+    /// `floor((expected - actual) * 10_000 / expected)` when `actual < expected`, else `0`.
     ///
     /// The revert decision uses **integer cross-multiplication** and a
     /// **remainder guard** when the floored quotient equals `max_slippage_bps`,
-    /// so boundary tests at “exactly max” vs “max + 1 bps” stay stable without
+    /// so boundary tests at "exactly max" vs "max + 1 bps" stay stable without
     /// floating point. See `docs/slippage-threshold.md` at the repo root.
+    ///
+    /// # Algorithm (step-by-step)
+    ///
+    /// 1. If `actual_price >= expected_price` - slippage is zero; return `Ok(())`.
+    /// 2. Compute `diff = expected_price - actual_price`.
+    /// 3. **Fast reject**: if `diff * 10_000 > max_slippage_bps * expected_price`
+    ///    the slippage is clearly over the cap; return `Err(SlippageTooHigh)`.
+    /// 4. Compute `quotient = (diff * 10_000) / expected_price` (integer floor).
+    /// 5. If `quotient > max_slippage_bps` - return `Err(SlippageTooHigh)`.
+    /// 6. **Boundary guard**: if `quotient == max_slippage_bps`, inspect the
+    ///    remainder `r = (diff * 10_000) % expected_price`. If `r >= expected_price / 2`
+    ///    the true (ceiling) value would exceed the cap - return `Err(SlippageTooHigh)`.
+    /// 7. Otherwise return `Ok(())`.
+    ///
+    /// # Overflow safety
+    ///
+    /// `diff * 10_000` and `max_slippage_bps * expected_price` are both `i128`
+    /// multiplications. Given that `expected_price` is bounded by the fiat limit
+    /// (see `validate_fiat_limit`) and `max_slippage_bps <= 10_000`, neither
+    /// product can overflow `i128`. See `docs/OVERFLOW_PREVENTION.md`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::SlippageTooHigh`] when the effective downward slippage
+    /// exceeds `max_slippage_bps`.
     fn check_slippage(
         env: &Env,
         expected_price: i128,

--- a/stellar-contracts/src/test.rs
+++ b/stellar-contracts/src/test.rs
@@ -4367,3 +4367,119 @@ fn test_withdrawal_quota_invariant_window_reset() {
     let daily_amount = bridge.get_user_daily_withdrawal(&user);
     assert_eq!(daily_amount, 500);
 }
+
+// ── Issue #527: pause — additional Soroban invariant tests ──────────────────
+
+#[test]
+fn test_pause_invariant_withdraw_blocked_while_paused() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_, bridge, admin, token_addr, _, token_sac) = setup_bridge(&env, 10_000);
+    let user = Address::generate(&env);
+    token_sac.mint(&user, &2_000);
+
+    bridge.deposit(&user, &1_000, &token_addr, &Bytes::new(&env), &0, &0, &None);
+    bridge.pause();
+
+    // withdraw must be blocked
+    let result = bridge.try_withdraw(&admin, &user, &100, &token_addr);
+    assert_eq!(result, Err(Ok(Error::ContractPaused)));
+
+    // unpause restores withdraw
+    bridge.unpause();
+    bridge.withdraw(&admin, &user, &100, &token_addr);
+    assert_eq!(bridge.get_total_deposited(), 900);
+}
+
+#[test]
+fn test_pause_invariant_request_withdrawal_blocked_while_paused() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_, bridge, _, token_addr, _, token_sac) = setup_bridge(&env, 10_000);
+    let user = Address::generate(&env);
+    token_sac.mint(&user, &2_000);
+
+    bridge.deposit(&user, &1_000, &token_addr, &Bytes::new(&env), &0, &0, &None);
+    bridge.pause();
+
+    let result = bridge.try_request_withdrawal(&user, &100, &token_addr, &None, &0);
+    assert_eq!(result, Err(Ok(Error::ContractPaused)));
+}
+
+#[test]
+fn test_pause_invariant_total_deposited_unchanged_across_pause_unpause_cycle() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_, bridge, _, token_addr, _, token_sac) = setup_bridge(&env, 10_000);
+    let user = Address::generate(&env);
+    token_sac.mint(&user, &5_000);
+
+    bridge.deposit(&user, &2_000, &token_addr, &Bytes::new(&env), &0, &0, &None);
+    let before = bridge.get_total_deposited();
+
+    // pause → attempt deposit → unpause: total must be unchanged
+    bridge.pause();
+    let _ = bridge.try_deposit(&user, &500, &token_addr, &Bytes::new(&env), &0, &0, &None);
+    bridge.unpause();
+
+    assert_eq!(bridge.get_total_deposited(), before);
+}
+
+#[test]
+fn test_pause_invariant_only_admin_can_pause() {
+    let env = Env::default();
+    // Do NOT mock_all_auths — require explicit auth
+    let (_, bridge, admin, token_addr, _, token_sac) = setup_bridge(&env, 10_000);
+    let non_admin = Address::generate(&env);
+    token_sac.mint(&non_admin, &1_000);
+
+    // Admin can pause
+    env.mock_auths(&[soroban_sdk::auth::MockAuth {
+        address: &admin,
+        invoke: &soroban_sdk::auth::MockAuthInvoke {
+            contract: &bridge.address,
+            fn_name: "pause",
+            args: soroban_sdk::vec![&env].into(),
+            sub_invokes: &[],
+        },
+    }]);
+    bridge.pause();
+    assert_eq!(
+        bridge.try_deposit(&non_admin, &100, &token_addr, &Bytes::new(&env), &0, &0, &None),
+        Err(Ok(Error::ContractPaused))
+    );
+}
+
+#[test]
+fn test_pause_invariant_paused_flag_persists_across_multiple_blocked_calls() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_, bridge, admin, token_addr, _, token_sac) = setup_bridge(&env, 10_000);
+    let user = Address::generate(&env);
+    token_sac.mint(&user, &5_000);
+
+    bridge.deposit(&user, &1_000, &token_addr, &Bytes::new(&env), &0, &0, &None);
+    bridge.pause();
+
+    // Multiple blocked calls must not clear the paused flag
+    for _ in 0..5 {
+        assert_eq!(
+            bridge.try_deposit(&user, &10, &token_addr, &Bytes::new(&env), &0, &0, &None),
+            Err(Ok(Error::ContractPaused))
+        );
+        assert_eq!(
+            bridge.try_withdraw(&admin, &user, &10, &token_addr),
+            Err(Ok(Error::ContractPaused))
+        );
+    }
+
+    // Still paused after all those rejections
+    assert_eq!(
+        bridge.try_deposit(&user, &1, &token_addr, &Bytes::new(&env), &0, &0, &None),
+        Err(Ok(Error::ContractPaused))
+    );
+}


### PR DESCRIPTION
- Replace Date.now()/Date.now()+1 ID generation with crypto.randomUUID() to eliminate message ID collisions when two messages are created in the same millisecond
- Remove stale isLoading closure from cancelPendingRequest and sendMessage; read activeRequestControllerRef directly so cancellation works regardless of when React flushes the isLoading state update
- Drop isLoading from sendMessage useCallback dependency array (was causing the hook to re-create on every loading toggle, contributing to stale refs)
- Add regression tests: unique IDs under concurrent sends, cancel-before- state-flush, stale-closure AbortController reuse

fix(frontend): add keyboard shortcuts to ReceiptDrawer.tsx (#528)

- Escape closes the drawer
- Backspace / Delete clears transaction history (when handler provided)
- Shortcuts are no-ops when the drawer is closed
- Added role=dialog + aria-modal=true + descriptive aria-label
- Surfaced shortcut hint in clear-history button title
- Added ReceiptDrawer.test.tsx covering all shortcut paths and aria attrs

docs: improve inline documentation for slippage threshold assertion (#529)

- Expanded check_slippage Rustdoc with Parameters, Algorithm step-by-step, Overflow safety, and Errors sections
- Updated docs/slippage-threshold.md with Architectural notes explaining why cross-multiplication and the remainder guard are used

test(contract): add Soroban invariant tests for pause (#527)

- test_pause_invariant_withdraw_blocked_while_paused
- test_pause_invariant_request_withdrawal_blocked_while_paused
- test_pause_invariant_total_deposited_unchanged_across_pause_unpause_cycle
- test_pause_invariant_only_admin_can_pause
- test_pause_invariant_paused_flag_persists_across_multiple_blocked_calls

Closes #530
Closes #529
Closes #528
Closes #527