### PR TITLE
feat/fix/docs: resolve issues #519 #520 #521 #522

### DIFF
--- a/dex_with_fiat_frontend/src/components/CCIPBridgeModal.tsx
+++ b/dex_with_fiat_frontend/src/components/CCIPBridgeModal.tsx
@@ -38,16 +38,26 @@ export default function CCIPBridgeModal({
 }: CCIPBridgeModalProps) {
   const modalRef = useRef<HTMLDivElement>(null);
   const pollingStartedAtRef = useRef<number | null>(null);
+  // Fix #520: keep a ref in sync with transactionHash state so the polling
+  // callback always reads the latest value without being re-created on every
+  // hash change (avoids stale-closure race condition).
+  const transactionHashRef = useRef('');
   const [bridgeState, setBridgeState] = useState<BridgeState>('idle');
   const [transactionHash, setTransactionHash] = useState('');
   const [explorerUrl, setExplorerUrl] = useState('');
   const [latestStatus, setLatestStatus] = useState<string>('');
   const [errorMessage, setErrorMessage] = useState('');
 
+  // Keep ref in sync with state.
+  useEffect(() => {
+    transactionHashRef.current = transactionHash;
+  }, [transactionHash]);
+
   useAccessibleModal(isOpen, modalRef, onClose);
 
   const resetState = useCallback(() => {
     pollingStartedAtRef.current = null;
+    transactionHashRef.current = '';
     setBridgeState('idle');
     setTransactionHash('');
     setExplorerUrl('');
@@ -98,16 +108,19 @@ export default function CCIPBridgeModal({
     }
   }, [onStartTransfer]);
 
-  const pollTransferStatus = useCallback(async () => {
-    if (!transactionHash) {
-      return;
-    }
+  // Fix #520: pollTransferStatus reads the hash from a ref instead of closing
+  // over the state value.  This means the callback identity is stable and the
+  // polling interval never fires with a stale hash.
+  const pollTransferStatus = useCallback(async (signal: { aborted: boolean }) => {
+    const hash = transactionHashRef.current;
+    if (!hash) return;
 
     const pollingStartedAt = pollingStartedAtRef.current;
     if (
       pollingStartedAt !== null &&
       Date.now() - pollingStartedAt >= timeoutMs
     ) {
+      if (signal.aborted) return;
       setBridgeState('error');
       setErrorMessage(
         'CCIP confirmation timed out after 10 minutes. Please verify the transaction in the explorer and try again.',
@@ -116,8 +129,9 @@ export default function CCIPBridgeModal({
     }
 
     try {
-      const result = await fetchTransferStatus(transactionHash);
-      
+      const result = await fetchTransferStatus(hash);
+      if (signal.aborted) return;
+
       // Optimistic UI: update status immediately
       setLatestStatus(result.status);
       if (result.explorerUrl) {
@@ -125,13 +139,11 @@ export default function CCIPBridgeModal({
       }
 
       if (result.status === 'SUCCESS') {
-        // Optimistic UI: transition to success state immediately
         setBridgeState('success');
         return;
       }
 
       if (result.status === 'FAILED' || result.status === 'ERROR') {
-        // Optimistic UI: transition to error state immediately
         setBridgeState('error');
         setErrorMessage(
           result.errorMessage ??
@@ -140,10 +152,10 @@ export default function CCIPBridgeModal({
         return;
       }
 
-      // Optimistic UI: keep polling state for intermediate statuses
       setBridgeState('polling');
     } catch (error) {
-      // Optimistic UI: maintain PENDING status during transient errors
+      if (signal.aborted) return;
+      // Maintain PENDING status during transient errors
       setLatestStatus('PENDING');
       setBridgeState('polling');
       if (
@@ -158,7 +170,7 @@ export default function CCIPBridgeModal({
         );
       }
     }
-  }, [fetchTransferStatus, timeoutMs, transactionHash]);
+  }, [fetchTransferStatus, timeoutMs]);
 
   useEffect(() => {
     if (
@@ -172,12 +184,18 @@ export default function CCIPBridgeModal({
       return;
     }
 
-    void pollTransferStatus();
+    // Fix #520: each effect invocation gets its own abort signal so that
+    // in-flight async calls from a previous render cycle cannot mutate state
+    // after the effect has been cleaned up.
+    const signal = { aborted: false };
+
+    void pollTransferStatus(signal);
     const intervalId = window.setInterval(() => {
-      void pollTransferStatus();
+      void pollTransferStatus(signal);
     }, pollIntervalMs);
 
     return () => {
+      signal.aborted = true;
       window.clearInterval(intervalId);
     };
   }, [

--- a/dex_with_fiat_frontend/src/components/TransactionAmountDisplay.tsx
+++ b/dex_with_fiat_frontend/src/components/TransactionAmountDisplay.tsx
@@ -1,16 +1,21 @@
 'use client';
 
+import { useEffect, useRef } from 'react';
 import { useCurrencyConversion } from '@/hooks/useCurrencyConversion';
 import { transactionAmountSchema, type TransactionAmountProps } from '@/lib/transactionSchema';
 
 /**
- * Component to display transaction amounts with live currency conversion
+ * Component to display transaction amounts with live currency conversion.
  * Shows format: "100 XLM ≈ $12.40 USD"
- * Falls back to just amount if price is unavailable
+ * Falls back to just amount if price is unavailable.
+ *
+ * Auto-scroll behaviour (issue #522): whenever the displayed amount changes,
+ * the component scrolls itself into view so the user always sees the latest
+ * value without manual scrolling.
  */
 export function TransactionAmountDisplay(props: TransactionAmountProps) {
   const result = transactionAmountSchema.safeParse(props);
-  
+
   if (!result.success) {
     const errorMessage = result.error.issues[0]?.message || 'Invalid Amount Data';
     console.error('TransactionAmountDisplay: Invalid props', result.error.format());
@@ -18,13 +23,19 @@ export function TransactionAmountDisplay(props: TransactionAmountProps) {
   }
 
   const { amount, asset, fiatAmount, fiatCurrency } = result.data;
-  
+
   const numericAmount = typeof amount === 'string' ? parseFloat(amount) : amount;
   const normalizedAsset = asset || 'XLM';
   const { displayText } = useCurrencyConversion(numericAmount, normalizedAsset);
 
+  // Auto-scroll: keep the latest amount visible whenever displayText updates.
+  const containerRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    containerRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+  }, [displayText]);
+
   return (
-    <div className="flex flex-col gap-1">
+    <div ref={containerRef} className="flex flex-col gap-1">
       <span className="font-medium dark:text-gray-300">
         {displayText}
       </span>

--- a/dex_with_fiat_frontend/src/components/__tests__/CCIPBridgeModal.test.tsx
+++ b/dex_with_fiat_frontend/src/components/__tests__/CCIPBridgeModal.test.tsx
@@ -112,6 +112,80 @@ describe('CCIPBridgeModal', () => {
     ).toBeInTheDocument();
   });
 
+  // ── Race condition regression tests (issue #520) ─────────────────────
+
+  describe('Race condition fix (issue #520)', () => {
+    it('does not call fetchTransferStatus after modal is closed mid-poll', async () => {
+      let resolveStatus!: (v: { status: string }) => void;
+      const fetchTransferStatus = vi.fn().mockImplementationOnce(
+        () => new Promise((resolve) => { resolveStatus = resolve; }),
+      );
+
+      const { rerender } = render(
+        <CCIPBridgeModal
+          {...defaultProps}
+          fetchTransferStatus={fetchTransferStatus}
+        />,
+      );
+
+      fireEvent.click(screen.getByText('Start CCIP Transfer'));
+      await screen.findByText('Waiting for CCIP confirmation…');
+
+      // Close the modal while the first poll is still in-flight
+      rerender(
+        <CCIPBridgeModal
+          {...defaultProps}
+          isOpen={false}
+          fetchTransferStatus={fetchTransferStatus}
+        />,
+      );
+
+      // Resolve the in-flight request after the modal closed
+      await act(async () => {
+        resolveStatus({ status: 'SUCCESS' });
+      });
+
+      // The modal is closed — success state must NOT be rendered
+      expect(screen.queryByText('CCIP transfer confirmed')).not.toBeInTheDocument();
+    });
+
+    it('does not apply stale status from a previous hash after hash changes', async () => {
+      // First call returns slowly; second call returns quickly with SUCCESS
+      let resolveFirst!: (v: { status: string }) => void;
+      const fetchTransferStatus = vi
+        .fn()
+        .mockImplementationOnce(() => new Promise((resolve) => { resolveFirst = resolve; }))
+        .mockResolvedValue({ status: 'SUCCESS' });
+
+      render(
+        <CCIPBridgeModal
+          {...defaultProps}
+          fetchTransferStatus={fetchTransferStatus}
+        />,
+      );
+
+      fireEvent.click(screen.getByText('Start CCIP Transfer'));
+      await screen.findByText('Waiting for CCIP confirmation…');
+
+      // Advance timer to trigger a second poll (which resolves to SUCCESS)
+      await act(async () => {
+        vi.advanceTimersByTime(15_000);
+      });
+
+      // Confirm success from the fast second poll
+      await screen.findByText('CCIP transfer confirmed');
+
+      // Now resolve the stale first poll — it should be a no-op
+      await act(async () => {
+        resolveFirst({ status: 'FAILED' });
+      });
+
+      // Should still show success, not error
+      expect(screen.getByText('CCIP transfer confirmed')).toBeInTheDocument();
+      expect(screen.queryByText('CCIP transfer error')).not.toBeInTheDocument();
+    });
+  });
+
   // ── Optimistic UI tests for issue #536 ────────────────────────────────
 
   describe('Optimistic UI updates (issue #536)', () => {

--- a/dex_with_fiat_frontend/src/components/__tests__/TransactionAmountDisplay.test.tsx
+++ b/dex_with_fiat_frontend/src/components/__tests__/TransactionAmountDisplay.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { describe, expect, it, vi, afterEach } from 'vitest';
-import { render, screen, cleanup } from '@testing-library/react';
+import { render, screen, cleanup, act } from '@testing-library/react';
 import { TransactionAmountDisplay } from '../TransactionAmountDisplay';
 
 // Mock the hook
@@ -70,5 +70,53 @@ describe('TransactionAmountDisplay', () => {
     render(<TransactionAmountDisplay amount={-50} />);
     expect(screen.getByText(/Amount must be positive/i)).toBeDefined();
     consoleSpy.mockRestore();
+  });
+
+  // ── Auto-scroll behaviour (issue #522) ────────────────────────────────
+
+  it('calls scrollIntoView on mount', () => {
+    const scrollIntoView = vi.fn();
+    window.HTMLElement.prototype.scrollIntoView = scrollIntoView;
+
+    render(<TransactionAmountDisplay amount={100} asset="XLM" />);
+
+    expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth', block: 'nearest' });
+  });
+
+  it('calls scrollIntoView again when displayText changes', async () => {
+    const scrollIntoView = vi.fn();
+    window.HTMLElement.prototype.scrollIntoView = scrollIntoView;
+
+    const { useCurrencyConversion } = await import('@/hooks/useCurrencyConversion');
+    const mockHook = vi.mocked(useCurrencyConversion);
+
+    mockHook.mockReturnValueOnce({
+      displayText: '100 XLM ≈ $12.40 USD',
+      originalAmount: 100,
+      originalCurrency: 'XLM',
+      fiatAmount: 12.4,
+      fiatCurrency: 'USD',
+      isLoading: false,
+      hasError: false,
+    });
+
+    const { rerender } = render(<TransactionAmountDisplay amount={100} asset="XLM" />);
+    const callsBefore = scrollIntoView.mock.calls.length;
+
+    mockHook.mockReturnValueOnce({
+      displayText: '200 XLM ≈ $24.80 USD',
+      originalAmount: 200,
+      originalCurrency: 'XLM',
+      fiatAmount: 24.8,
+      fiatCurrency: 'USD',
+      isLoading: false,
+      hasError: false,
+    });
+
+    await act(async () => {
+      rerender(<TransactionAmountDisplay amount={200} asset="XLM" />);
+    });
+
+    expect(scrollIntoView.mock.calls.length).toBeGreaterThan(callsBefore);
   });
 });

--- a/dex_with_fiat_frontend/src/lib/chatTelemetry.test.ts
+++ b/dex_with_fiat_frontend/src/lib/chatTelemetry.test.ts
@@ -273,4 +273,45 @@ describe('Rendering overflow fix (issue #539)', () => {
     
     window.removeEventListener('chat:telemetry', handler);
   });
+
+  // ── avatar_color_check event (issue #521) ─────────────────────────────
+
+  it('avatarColorCheck emits avatar_color_check event with enriched payload', async () => {
+    const promise = captureNextEvent<AccessibleAvatarColorTelemetryPayload>();
+    chatTelemetry.avatarColorCheck({ avatarBackgroundColor: '#1a1a2e' });
+    const event = await promise;
+
+    expect(event.name).toBe('avatar_color_check');
+    expect(event.payload).toHaveProperty('avatarBackgroundColor');
+    expect(event.payload).toHaveProperty('avatarTextColor');
+    expect(event.payload).toHaveProperty('avatarContrastRatio');
+    expect(event.payload).toHaveProperty('avatarContrastCompliant');
+  });
+
+  it('avatarColorCheck marks dark background as contrast-compliant with white text', async () => {
+    const promise = captureNextEvent<AccessibleAvatarColorTelemetryPayload>();
+    chatTelemetry.avatarColorCheck({ avatarBackgroundColor: '#000000' });
+    const event = await promise;
+
+    expect(event.payload.avatarContrastCompliant).toBe(true);
+    expect(event.payload.avatarContrastRatio).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it('avatarColorCheck marks light background as contrast-compliant with dark text', async () => {
+    const promise = captureNextEvent<AccessibleAvatarColorTelemetryPayload>();
+    chatTelemetry.avatarColorCheck({ avatarBackgroundColor: '#FFFFFF' });
+    const event = await promise;
+
+    expect(event.payload.avatarContrastCompliant).toBe(true);
+    expect(event.payload.avatarContrastRatio).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it('avatarColorCheck does not emit when consent is not given', () => {
+    setTelemetryConsent(false);
+    const handler = vi.fn();
+    window.addEventListener('chat:telemetry', handler);
+    chatTelemetry.avatarColorCheck({ avatarBackgroundColor: '#FF0000' });
+    window.removeEventListener('chat:telemetry', handler);
+    expect(handler).not.toHaveBeenCalled();
+  });
 });

--- a/dex_with_fiat_frontend/src/lib/chatTelemetry.ts
+++ b/dex_with_fiat_frontend/src/lib/chatTelemetry.ts
@@ -12,7 +12,8 @@ export type ChatEventName =
   | 'wallet_connect'
   | 'bridge_open'
   | 'tx_confirm'
-  | 'fiat_payout_step';
+  | 'fiat_payout_step'
+  | 'avatar_color_check';
 
 export interface ChatEvent<P extends object = Record<string, unknown>> {
   /** Normalized event name. */
@@ -317,5 +318,20 @@ export const chatTelemetry = {
 
   fiatPayoutStep(payload: FiatPayoutStepPayload): void {
     emit('fiat_payout_step', payload);
+  },
+
+  /**
+   * Emit an `avatar_color_check` event that records whether the avatar
+   * foreground/background colour pair meets WCAG AA contrast (4.5:1).
+   *
+   * The payload is automatically enriched with the accessible text colour,
+   * the computed contrast ratio, and a compliance flag via
+   * `withAccessibleAvatarContrast` before dispatch.
+   *
+   * Issue #521: surfaces colour-contrast telemetry so design tooling can
+   * detect non-compliant avatar palettes in production.
+   */
+  avatarColorCheck(payload: AvatarColorTelemetryPayload): void {
+    emit('avatar_color_check', payload);
   },
 };

--- a/stellar-contracts/src/lib.rs
+++ b/stellar-contracts/src/lib.rs
@@ -2247,6 +2247,40 @@ impl FiatBridge {
     }
 
     // ── Timelock ──────────────────────────────────────────────────────────
+    /// Queue an admin action to be executed after the mandatory timelock delay.
+    ///
+    /// All privileged governance operations (parameter changes, operator
+    /// management, etc.) must be queued here first and can only be executed
+    /// once the timelock has elapsed.  This prevents surprise changes and
+    /// gives observers time to react.
+    ///
+    /// # Role check
+    /// Only the contract admin may call this function.  The admin address is
+    /// read from instance storage and `require_auth()` is called against it,
+    /// so the transaction must be signed by the admin key.  Operators and
+    /// other addresses are explicitly excluded — they hold a narrower role
+    /// that does not include governance authority.
+    ///
+    /// # Timelock enforcement
+    /// `delay` must be at least [`MIN_TIMELOCK_DELAY`] (34 560 ledgers ≈ 48 h).
+    /// Shorter delays are rejected with [`Error::ActionNotReady`] to prevent
+    /// governance actions from bypassing the mandatory waiting period.
+    ///
+    /// # Arguments
+    /// * `env`         – The contract environment.
+    /// * `action_type` – A [`Symbol`] identifying the action kind (used for
+    ///                   event emission and off-chain indexing).
+    /// * `payload`     – Arbitrary bytes encoding the action parameters.
+    /// * `delay`       – Number of ledgers to wait before the action becomes
+    ///                   executable.  Must be ≥ `MIN_TIMELOCK_DELAY`.
+    ///
+    /// # Returns
+    /// The numeric ID assigned to the queued action.  Pass this ID to
+    /// [`execute_admin_action`] once the timelock has elapsed.
+    ///
+    /// # Errors
+    /// * [`Error::NotInitialized`] – Contract has not been initialised.
+    /// * [`Error::ActionNotReady`] – `delay` is below `MIN_TIMELOCK_DELAY`.
     pub fn queue_admin_action(
         env: Env,
         action_type: Symbol,
@@ -2289,6 +2323,30 @@ impl FiatBridge {
         Ok(id)
     }
 
+    /// Execute a previously queued admin action once its timelock has elapsed.
+    ///
+    /// # Role check
+    /// Only the contract admin may execute queued actions.  The same
+    /// `require_auth()` guard used in [`queue_admin_action`] applies here,
+    /// ensuring that the entity that queued the action is also the one that
+    /// executes it.  This prevents a scenario where an attacker who gains
+    /// temporary access to the queue could trigger execution without the
+    /// admin's continued authorisation.
+    ///
+    /// # Timelock enforcement
+    /// The action is only executable once `env.ledger().sequence()` is
+    /// strictly greater than `action.target_ledger` (i.e. `>`, not `>=`).
+    /// This adds one extra ledger of safety margin and is consistent with
+    /// the off-by-one fix documented in [`execute_upgrade`].
+    ///
+    /// # Arguments
+    /// * `env` – The contract environment.
+    /// * `id`  – The action ID returned by [`queue_admin_action`].
+    ///
+    /// # Errors
+    /// * [`Error::NotInitialized`]  – Contract has not been initialised.
+    /// * [`Error::ActionNotQueued`] – No action exists for the given `id`.
+    /// * [`Error::ActionNotReady`]  – The timelock has not yet elapsed.
     pub fn execute_admin_action(env: Env, id: u64) -> Result<(), Error> {
         let admin: Address = env
             .storage()
@@ -2324,6 +2382,37 @@ impl FiatBridge {
     /// Operators are restricted roles that can perform low-stakes actions like
     /// heartbeats but cannot change core contract parameters.
     /// Admin-only function.
+    ///
+    /// # Role separation (timelock role check)
+    /// The admin and operator roles are intentionally kept separate:
+    ///
+    /// * **Admin** – governance role; can queue/execute timelock actions,
+    ///   pause/unpause the contract, and manage operators.
+    /// * **Operator** – operational role; limited to heartbeat and similar
+    ///   low-stakes actions that do not require a timelock.
+    ///
+    /// Conflating both roles on a single address would allow an operator key
+    /// compromise to bypass the governance timelock entirely.  Therefore:
+    ///
+    /// 1. The admin address **must not** be granted the operator role
+    ///    (`operator != admin` is enforced; violation → [`Error::NotAllowed`]).
+    /// 2. The contract itself **must not** be an operator
+    ///    (`operator != current_contract_address()`; violation →
+    ///    [`Error::InvalidRecipient`]).
+    ///
+    /// These checks are the canonical *timelock role check* referenced
+    /// throughout the codebase and test suite (fix #525).
+    ///
+    /// # Arguments
+    /// * `env`      – The contract environment.
+    /// * `operator` – The address to grant or revoke the operator role for.
+    /// * `active`   – `true` to grant, `false` to revoke.
+    ///
+    /// # Errors
+    /// * [`Error::NotInitialized`]    – Contract has not been initialised.
+    /// * [`Error::NotAllowed`]        – `operator` is the admin address.
+    /// * [`Error::InvalidRecipient`]  – `operator` is the contract address.
+    /// * [`Error::OperatorCapReached`] – Maximum operator count already reached.
     pub fn set_operator(env: Env, operator: Address, active: bool) -> Result<(), Error> {
         let admin: Address = env
             .storage()


### PR DESCRIPTION
## Summary

Resolves four open issues in a single atomic PR.

---

### feat(frontend): auto-scroll in TransactionAmountDisplay (#522)

Attaches a `containerRef` to the wrapper div and calls `scrollIntoView({ behavior: 'smooth', block: 'nearest' })` inside a `useEffect` that fires whenever `displayText` changes. This keeps the latest amount visible without manual scrolling.

Tests added: scroll on mount, scroll on displayText change.

---

### feat(frontend): accessible color contrast telemetry in chatTelemetry (#521)

Adds `avatar_color_check` to the `ChatEventName` union and exposes `chatTelemetry.avatarColorCheck()`. The payload is automatically enriched by the existing `withAccessibleAvatarContrast` helper (contrast ratio, WCAG AA compliance flag, accessible text color) before dispatch.

Tests added: enriched payload shape, compliant dark/light backgrounds, consent guard.

---

### fix(frontend): race condition in CCIPBridgeModal (#520)

Two root causes fixed:
1. `pollTransferStatus` closed over the `transactionHash` state value, so a stale hash could be used if the state updated between renders. Fixed by keeping a `transactionHashRef` in sync and reading from the ref inside the callback.
2. In-flight async poll calls could mutate state after the modal closed or the effect re-ran. Fixed by passing an `{ aborted: boolean }` signal into each invocation and checking it before any `setState` call; the effect cleanup sets `signal.aborted = true`.

Regression tests added: no state update after modal closes mid-poll; stale slow response does not overwrite a faster terminal response.

---

### docs: inline documentation for timelock role check (#519)

- Full JSDoc on `queue_admin_action`: admin role check, timelock enforcement, args, return, errors.
- Full JSDoc on `execute_admin_action`: role check rationale, off-by-one boundary semantics, args, errors.
- Expanded `set_operator` docs with a dedicated **Role separation (timelock role check)** section explaining why admin/operator must stay separate, the two boundary checks (fix #525), and all error variants.

---

Closes #519
Closes #520
Closes #521
Closes #522
