### PR TITLE
feat(frontend): add network status toast to AuditTable

### DIFF
--- a/dex_with_fiat_frontend/src/components/AuditTable.test.tsx
+++ b/dex_with_fiat_frontend/src/components/AuditTable.test.tsx
@@ -1,71 +1,68 @@
 import '@testing-library/jest-dom/vitest';
+import React from 'react';
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { cleanup, render, screen, waitFor, fireEvent } from '@testing-library/react';
 import AuditTable from './AuditTable';
+import { toastStore } from '@/lib/toastStore';
 
 describe('AuditTable', () => {
   afterEach(() => {
+    cleanup();
+    toastStore.clearToasts();
     vi.restoreAllMocks();
   });
 
   it('does not apply stale fetch results after a newer request (abort)', async () => {
     vi.stubGlobal(
       'fetch',
-      vi.fn((url: string | URL, init?: RequestInit) => {
+      vi.fn(async (url: string | URL, init?: RequestInit) => {
         const u = typeof url === 'string' ? url : url.toString();
         const signal = init?.signal;
         const isDeposit = u.includes('actionType=deposit');
 
-        return new Promise<Response>((resolve, reject) => {
-          const delayMs = isDeposit ? 200 : 0;
-          const t = setTimeout(() => {
-            if (signal?.aborted) {
-              reject(new DOMException('Aborted', 'AbortError'));
-              return;
-            }
-            resolve({
-              ok: true,
-              status: 200,
-              json: async () => ({
-                entries: isDeposit
-                  ? [
-                      {
-                        id: 'stale',
-                        timestamp: new Date().toISOString(),
-                        adminAddress:
-                          'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
-                        actionType: 'deposit',
-                        actionDescription: 'stale-row',
-                        txHash: 'abc',
-                        status: 'success',
-                      },
-                    ]
-                  : [
-                      {
-                        id: 'fresh',
-                        timestamp: new Date().toISOString(),
-                        adminAddress:
-                          'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
-                        actionType: 'payout',
-                        actionDescription: 'fresh-row',
-                        txHash: 'def',
-                        status: 'success',
-                      },
-                    ],
-                total: 1,
-              }),
-            } as Response);
-          }, delayMs);
+        if (isDeposit) {
+          await new Promise((resolve) => setTimeout(resolve, 200));
+          if (signal?.aborted) {
+            throw new DOMException('Aborted', 'AbortError');
+          }
+        }
 
-          signal?.addEventListener('abort', () => {
-            clearTimeout(t);
-            reject(new DOMException('Aborted', 'AbortError'));
-          }, { once: true });
-        });
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            entries: isDeposit
+              ? [
+                  {
+                    id: 'stale',
+                    timestamp: new Date().toISOString(),
+                    adminAddress:
+                      'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
+                    actionType: 'deposit',
+                    actionDescription: 'stale-row',
+                    txHash: 'abc',
+                    status: 'success',
+                  },
+                ]
+              : [
+                  {
+                    id: 'fresh',
+                    timestamp: new Date().toISOString(),
+                    adminAddress:
+                      'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
+                    actionType: 'payout',
+                    actionDescription: 'fresh-row',
+                    txHash: 'def',
+                    status: 'success',
+                  },
+                ],
+            total: 1,
+          }),
+        } as Response;
       }),
     );
 
-    render(<AuditTable />);
+    render(React.createElement(AuditTable));
 
     await waitFor(() => {
       expect(screen.getByText('fresh-row')).toBeInTheDocument();
@@ -83,5 +80,41 @@ describe('AuditTable', () => {
     );
 
     expect(screen.queryByText('stale-row')).not.toBeInTheDocument();
+  });
+
+  it('shows a warning toast when the browser goes offline while open', async () => {
+    const addToastSpy = vi.spyOn(toastStore, 'addToast');
+    render(React.createElement(AuditTable));
+
+    fireEvent(window, new Event('offline'));
+
+    await waitFor(() => {
+      expect(addToastSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          severity: 'warning',
+          message: expect.stringMatching(/offline/i),
+        }),
+      );
+    });
+  });
+
+  it('shows a success toast when coming back online after offline', async () => {
+    const addToastSpy = vi.spyOn(toastStore, 'addToast');
+    render(React.createElement(AuditTable));
+
+    fireEvent(window, new Event('offline'));
+    await waitFor(() => expect(addToastSpy).toHaveBeenCalled());
+
+    addToastSpy.mockClear();
+    fireEvent(window, new Event('online'));
+
+    await waitFor(() => {
+      expect(addToastSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          severity: 'success',
+          message: expect.stringMatching(/online|refresh/i),
+        }),
+      );
+    });
   });
 });

--- a/dex_with_fiat_frontend/src/components/AuditTable.tsx
+++ b/dex_with_fiat_frontend/src/components/AuditTable.tsx
@@ -2,6 +2,8 @@
 
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { AuditEntry } from '@/types';
+import { useOnlineStatus } from '@/hooks/useOnlineStatus';
+import { useToast } from '@/hooks/useToast';
 
 interface AuditTableProps {
   onRefresh?: () => void;
@@ -89,6 +91,33 @@ export default function AuditTable({}: AuditTableProps) {
       fetchAbortRef.current?.abort();
     };
   }, [fetchAuditEntries]);
+
+  const { isOnline, wasOffline, resetWasOffline } = useOnlineStatus();
+  const { addToast } = useToast();
+  const wasOnlineRef = useRef(true);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const prevOnline = wasOnlineRef.current;
+
+    if (prevOnline && !isOnline) {
+      addToast({
+        message: "You're offline. Audit entries may not update until you reconnect.",
+        severity: 'warning',
+        durationMs: 4500,
+      });
+    } else if (!prevOnline && isOnline && wasOffline) {
+      addToast({
+        message: 'Back online. Audit table will refresh with the latest data.',
+        severity: 'success',
+        durationMs: 3000,
+      });
+      resetWasOffline();
+    }
+
+    wasOnlineRef.current = isOnline;
+  }, [isOnline, wasOffline, addToast, resetWasOffline]);
 
   const handleFilterChange = (key: keyof FilterState, value: string) => {
     setFilters((prev) => ({ ...prev, [key]: value }));

--- a/dex_with_fiat_frontend/src/hooks/useToast.ts
+++ b/dex_with_fiat_frontend/src/hooks/useToast.ts
@@ -1,12 +1,13 @@
-import { useSyncExternalStore } from 'react';
+import { useSyncExternalStore, useCallback } from 'react';
 import { AppToast, toastStore } from '@/lib/toastStore';
 
 const EMPTY_ARRAY: AppToast[] = [];
 
 export function useToast() {
+  const getSnapshot = useCallback(() => toastStore.getSnapshot(), []);
   const toasts = useSyncExternalStore(
     (listener) => toastStore.subscribe(listener),
-    () => toastStore.getSnapshot(),
+    getSnapshot,
     () => EMPTY_ARRAY,
   );
 

--- a/dex_with_fiat_frontend/src/lib/toastStore.ts
+++ b/dex_with_fiat_frontend/src/lib/toastStore.ts
@@ -107,7 +107,7 @@ export class ToastStore {
       durationMs: duration,
     };
 
-    this.toasts.push(toast);
+    this.toasts = [...this.toasts, toast];
     
     if (duration > 0) {
       const timer = setTimeout(() => {
@@ -126,7 +126,7 @@ export class ToastStore {
   removeToast(id: string): void {
     const index = this.toasts.findIndex((t) => t.id === id);
     if (index > -1) {
-      this.toasts.splice(index, 1);
+      this.toasts = [...this.toasts.slice(0, index), ...this.toasts.slice(index + 1)];
       
       const timer = this.timers.get(id);
       if (timer) {
@@ -154,18 +154,18 @@ export class ToastStore {
    * Get current toasts snapshot
    */
   getToasts(): AppToast[] {
-    return [...this.toasts];
+    return this.toasts;
   }
 
   getSnapshot(): AppToast[] {
-    return this.getToasts();
+    return this.toasts;
   }
 
   /**
    * Clear all toasts
    */
   clearToasts(): void {
-    this.toasts.length = 0;
+    this.toasts = [];
     this.timers.forEach((timer) => clearTimeout(timer));
     this.timers.clear();
     this.notifyListeners();

--- a/dex_with_fiat_frontend/tsconfig.json
+++ b/dex_with_fiat_frontend/tsconfig.json
@@ -20,7 +20,7 @@
     ],
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {


### PR DESCRIPTION
This PR adds offline/online network status toast notifications to the AuditTable component and includes unit tests covering the behavior.\n\nChanges include:\n- network status toast logic in \n- unit tests in \n- stable toast snapshot handling in  and \n- updated frontend  for React JSX support in Vitest \n\nCloses #553.