### PR TITLE
feat(stellar-contracts): harden get_receipt_by_index boundaries with …

### DIFF
--- a/docs/fuzz-test-boundary.md
+++ b/docs/fuzz-test-boundary.md
@@ -27,6 +27,9 @@ For chat lifecycle logic in `dex_with_fiat_frontend/src/hooks/chatStateMachine.t
 
 - message threshold edges (`2 -> 3` messages) are critical
 - cancellation and error recovery transitions should be sampled from all non-terminal states
+- receipt-query boundaries should be fuzzed around `0`, `ReceiptCounter - 1`, `ReceiptCounter`, and `u64::MAX`
+  to ensure out-of-range queries are rejected before any storage lookups and
+  that stale/expired receipt entries return the distinct `ReceiptNotFound` error.
 - transaction-trigger guards should be fuzzed with sparse transaction payloads
   (token only, amount only, fiat only) to verify minimum-data semantics
 

--- a/stellar-contracts/FIAT_BRIDGE_README.md
+++ b/stellar-contracts/FIAT_BRIDGE_README.md
@@ -206,6 +206,11 @@ const receiptHash: string = await contract.get_receipt_by_index({ index: 0n });
 const count: bigint = await contract.get_receipt_counter();
 ```
 
+> Note: `get_receipt_by_index` distinguishes between an out-of-range index
+> (`ReceiptIndexOutOfBounds`) and a stale or expired receipt reference
+> (`ReceiptNotFound`). Queries also emit a `ReceiptQueryEvent` for
+> off-chain auditability.
+
 ---
 
 ## Migration Notes for Integrators

--- a/stellar-contracts/docs/OVERFLOW_PREVENTION.md
+++ b/stellar-contracts/docs/OVERFLOW_PREVENTION.md
@@ -162,6 +162,24 @@ fn propose_upgrade_overflow_prevention() {
 }
 ```
 
+## Receipt query boundary checks
+
+`get_receipt_by_index` is a read-side operation, but it still needs strong
+boundary checks to prevent a storage probing attack via artificially large
+index values.
+
+- `idx >= ReceiptCounter` must return `Error::ReceiptIndexOutOfBounds` before
+  touching temporary storage keys.
+- `ReceiptIndex` values are stored in temporary storage, so a previously-issued
+  index may expire. Such in-range lookups must return `Error::ReceiptNotFound`
+  instead of silently treating the query as out-of-range.
+- `u64::MAX` is a particularly important fuzz edge: it must short-circuit on the
+  bounds check to avoid constructing and probing enormous storage keys.
+
+The contract also emits a dedicated `ReceiptQueryEvent` on every lookup attempt,
+so off-chain systems can audit successful receipts and distinguish stale/missing
+entries from truly out-of-range queries.
+
 ---
 
 ## Fuzz boundary notes

--- a/stellar-contracts/src/lib.rs
+++ b/stellar-contracts/src/lib.rs
@@ -345,6 +345,15 @@ pub struct ReceiptIssuedEvent {
 
 #[contractevent]
 #[derive(Clone, Debug)]
+pub struct ReceiptQueryEvent {
+    pub version: u32,
+    pub index: u64,
+    pub receipt_hash: Option<BytesN<32>>,
+    pub error_code: Option<u32>,
+}
+
+#[contractevent]
+#[derive(Clone, Debug)]
 pub struct WithdrawEvent {
     pub version: u32,
     pub to: Address,
@@ -3244,6 +3253,11 @@ impl FiatBridge {
     ///    can become unreachable.
     /// 3. The persistent `Receipt(hash)` entry must still exist.
     ///
+    /// # Events
+    /// * [`ReceiptQueryEvent`] is emitted for every lookup attempt.
+    ///   This includes successful receipts, out-of-range queries, and stale
+    ///   or missing receipt entries.
+    ///
     /// # Errors
     /// * [`Error::ReceiptIndexOutOfBounds`] – `idx >= ReceiptCounter`.
     /// * [`Error::ReceiptNotFound`]         – index entry or receipt is gone.
@@ -3254,17 +3268,61 @@ impl FiatBridge {
             .get(&DataKey::ReceiptCounter)
             .unwrap_or(0);
         if idx >= max_receipts {
+            ReceiptQueryEvent {
+                version: EVENT_VERSION,
+                index: idx,
+                receipt_hash: None,
+                error_code: Some(Error::ReceiptIndexOutOfBounds as u32),
+            }
+            .publish(&env);
             return Err(Error::ReceiptIndexOutOfBounds);
         }
-        let receipt_hash: BytesN<32> = env
+
+        let receipt_hash: BytesN<32> = match env
             .storage()
             .temporary()
             .get(&DataKey::ReceiptIndex(idx))
-            .ok_or(Error::ReceiptNotFound)?;
-        env.storage()
+        {
+            Some(hash) => hash,
+            None => {
+                ReceiptQueryEvent {
+                    version: EVENT_VERSION,
+                    index: idx,
+                    receipt_hash: None,
+                    error_code: Some(Error::ReceiptNotFound as u32),
+                }
+                .publish(&env);
+                return Err(Error::ReceiptNotFound);
+            }
+        };
+
+        let receipt: Receipt = match env
+            .storage()
             .persistent()
-            .get(&DataKey::Receipt(receipt_hash))
-            .ok_or(Error::ReceiptNotFound)
+            .get(&DataKey::Receipt(receipt_hash.clone()))
+        {
+            Some(receipt) => receipt,
+            None => {
+                ReceiptQueryEvent {
+                    version: EVENT_VERSION,
+                    index: idx,
+                    receipt_hash: Some(receipt_hash.clone()),
+                    error_code: Some(Error::ReceiptNotFound as u32),
+                }
+                .publish(&env);
+                return Err(Error::ReceiptNotFound);
+            }
+        };
+
+        ReceiptQueryEvent {
+            version: EVENT_VERSION,
+            index: idx,
+            receipt_hash: Some(receipt_hash.clone()),
+            error_code: None,
+        }
+        .publish(&env);
+
+        Ok(receipt)
     }
 
     pub fn get_withdrawal_request(env: Env, id: u64) -> Option<WithdrawRequest> {

--- a/stellar-contracts/src/test.rs
+++ b/stellar-contracts/src/test.rs
@@ -2145,6 +2145,63 @@ fn test_get_receipt_by_index_nonexistent_index() {
 }
 
 #[test]
+fn test_get_receipt_by_index_stale_temporary_index_returns_not_found() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, bridge, _, token_addr, _, token_sac) = setup_bridge(&env, 10_000);
+    let user = Address::generate(&env);
+    token_sac.mint(&user, &5_000);
+
+    bridge.deposit(&user, &100, &token_addr, &Bytes::new(&env), &0, &0, &None);
+
+    env.as_contract(&contract_id, || {
+        env.storage().temporary().remove(&DataKey::ReceiptIndex(0));
+    });
+
+    assert_eq!(
+        bridge.try_get_receipt_by_index(&0),
+        Err(Ok(Error::ReceiptNotFound))
+    );
+}
+
+#[test]
+fn test_get_receipt_by_index_missing_persistent_receipt_returns_not_found() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, bridge, _, token_addr, _, token_sac) = setup_bridge(&env, 10_000);
+    let user = Address::generate(&env);
+    token_sac.mint(&user, &5_000);
+
+    let receipt_hash = bridge.deposit(&user, &100, &token_addr, &Bytes::new(&env), &0, &0, &None);
+
+    env.as_contract(&contract_id, || {
+        env.storage().persistent().remove(&DataKey::Receipt(receipt_hash));
+    });
+
+    assert_eq!(
+        bridge.try_get_receipt_by_index(&0),
+        Err(Ok(Error::ReceiptNotFound))
+    );
+}
+
+#[test]
+fn test_event_version_get_receipt_by_index() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_addr, bridge, _, token_addr, _, token_sac) = setup_bridge(&env, 10_000);
+    let user = Address::generate(&env);
+    token_sac.mint(&user, &5_000);
+    bridge.deposit(&user, &100, &token_addr, &Bytes::new(&env), &0, &0, &None);
+
+    assert_bridge_events_have_version(&env, &contract_addr, || {
+        bridge.get_receipt_by_index(&0);
+    });
+}
+
+#[test]
 fn test_memo_hash_zero_rejected() {
     let env = Env::default();
     env.mock_all_auths();


### PR DESCRIPTION
Closes #592 
Closes #542 

## Summary 

- Tightened `get_receipt_by_index` so it checks the requested index before reading storage.
- Added a new `ReceiptQueryEvent` so every lookup is recorded, including success, out-of-range, and missing receipt cases.
- Made the contract return a clear `ReceiptNotFound` error when an index is still in range but the receipt data has expired or disappeared.
- Added tests for stale temporary index entries, missing persisted receipts, and event version coverage.
- Updated overflow/fuzz documentation and user-facing docs to explain the new lookup behavior and boundary expectations.