### PR TITLE
feat(frontend): theme tokens, themed error border, skeleton gate, rapid-click guard

### DIFF
--- a/dex_with_fiat_frontend/src/components/StellarChatInterface.tsx
+++ b/dex_with_fiat_frontend/src/components/StellarChatInterface.tsx
@@ -107,6 +107,9 @@ function StellarChatInterfaceContent() {
   >(null);
   const [isReceiptDrawerOpen, setIsReceiptDrawerOpen] = useState(false);
   const [showSearch, setShowSearch] = useState(false);
+  // Show the chat skeleton until the client has hydrated so the first paint
+  // isn't an empty conversation pane before messages are restored.
+  const [isHydrated, setIsHydrated] = useState(false);
   const { entries: txHistory, clearEntries: clearTxHistory } = useTxHistory();
   const accountDropdownRef = useRef<HTMLDivElement>(null);
   const reconnectNoticeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
@@ -149,6 +152,10 @@ function StellarChatInterfaceContent() {
     checkMobile();
     window.addEventListener('resize', checkMobile);
     return () => window.removeEventListener('resize', checkMobile);
+  }, []);
+
+  useEffect(() => {
+    setIsHydrated(true);
   }, []);
 
   useEffect(() => {
@@ -853,7 +860,7 @@ function StellarChatInterfaceContent() {
 
           {/* Messages */}
           <div className="flex-1 min-h-0 flex flex-col">
-            {isLoading && messages.length === 0 ? (
+            {!isHydrated || (isLoading && messages.length === 0) ? (
               <SkeletonChat />
             ) : (
               <ErrorBoundary

--- a/dex_with_fiat_frontend/src/components/StellarFiatModal.tsx
+++ b/dex_with_fiat_frontend/src/components/StellarFiatModal.tsx
@@ -73,6 +73,10 @@ export default function StellarFiatModal({
   messages = [],
 }: StellarFiatModalProps) {
   const modalRef = useRef<HTMLDivElement>(null);
+  // Synchronous guard against rapid double-submits: state updates are batched,
+  // so the submit button stays enabled across same-tick clicks. A ref closes
+  // that window before React re-renders.
+  const lastSubmitAtRef = useRef(0);
   const { connection, signTx } = useStellarWallet();
   const { addNotification } = useNotifications();
   const { addEntry } = useTxHistory();
@@ -201,6 +205,7 @@ export default function StellarFiatModal({
     setRiskConfirmation('');
     setLastLoggedRiskAmount('');
     setLastActionTimestamp(0);
+    lastSubmitAtRef.current = 0;
 
     if (isAdminMode) {
       return;
@@ -506,6 +511,13 @@ export default function StellarFiatModal({
     if (status === 'loading' || isTxProcessing) {
       return;
     }
+
+    const now = Date.now();
+    if (now - lastSubmitAtRef.current < SUBMIT_COOLDOWN_MS) {
+      return;
+    }
+    lastSubmitAtRef.current = now;
+    setLastActionTimestamp(now);
 
     setStatus('pending');
     setErrorMsg('');

--- a/dex_with_fiat_frontend/src/components/TransactionAmountDisplay.tsx
+++ b/dex_with_fiat_frontend/src/components/TransactionAmountDisplay.tsx
@@ -22,7 +22,7 @@ export function TransactionAmountDisplay(props: TransactionAmountProps) {
     console.error('TransactionAmountDisplay: Invalid props', result.error.format());
     return (
       <motion.span
-        className="text-red-500 text-xs italic"
+        className="theme-soft-danger inline-flex items-center rounded-md border px-2 py-1 text-xs italic"
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         transition={{ duration: 0.2 }}
@@ -52,7 +52,7 @@ export function TransactionAmountDisplay(props: TransactionAmountProps) {
       transition={{ duration: 0.3, ease: 'easeOut' }}
     >
       <motion.span
-        className="font-medium dark:text-gray-300"
+        className="font-medium theme-text-primary"
         key={displayText}
         initial={{ scale: 0.95, opacity: 0.7 }}
         animate={{ scale: 1, opacity: 1 }}
@@ -62,7 +62,7 @@ export function TransactionAmountDisplay(props: TransactionAmountProps) {
       </motion.span>
       {fiatAmount && fiatCurrency && (
         <motion.span
-          className="text-xs text-gray-500 dark:text-gray-400"
+          className="text-xs theme-text-muted"
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           transition={{ duration: 0.2, delay: 0.1 }}

--- a/dex_with_fiat_frontend/src/components/__tests__/StellarChatInterface.skeleton.test.tsx
+++ b/dex_with_fiat_frontend/src/components/__tests__/StellarChatInterface.skeleton.test.tsx
@@ -1,0 +1,196 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import StellarChatInterface from '@/components/StellarChatInterface';
+
+type ChatMessage = {
+  id: string;
+  role: string;
+  content: string;
+  timestamp: Date;
+};
+
+const mockChatState: {
+  messages: ChatMessage[];
+  isLoading: boolean;
+  sendMessage: ReturnType<typeof vi.fn>;
+  cancelPendingRequest: ReturnType<typeof vi.fn>;
+  clearChat: ReturnType<typeof vi.fn>;
+  loadChatSession: ReturnType<typeof vi.fn>;
+  currentSessionId: string | null;
+  setTransactionReadyCallback: ReturnType<typeof vi.fn>;
+  setIsAdmin: ReturnType<typeof vi.fn>;
+} = {
+  messages: [],
+  isLoading: false,
+  sendMessage: vi.fn(),
+  cancelPendingRequest: vi.fn(),
+  clearChat: vi.fn(),
+  loadChatSession: vi.fn(),
+  currentSessionId: null,
+  setTransactionReadyCallback: vi.fn(),
+  setIsAdmin: vi.fn(),
+};
+
+vi.mock('@/contexts/ThemeContext', () => ({
+  useTheme: () => ({ isDarkMode: false, toggleDarkMode: vi.fn() }),
+}));
+
+vi.mock('@/contexts/TranslationContext', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/contexts/UserPreferencesContext', () => ({
+  useUserPreferences: () => ({ fiatCurrency: 'NGN' }),
+}));
+
+vi.mock('@/contexts/StellarWalletContext', () => ({
+  EXPECTED_NETWORK: 'Test',
+  useStellarWallet: () => ({
+    connection: {
+      address: '',
+      publicKey: '',
+      isConnected: false,
+      network: 'TEST',
+    },
+    accounts: [] as { address: string; name?: string }[],
+    selectedAccountIndex: 0,
+    selectAccount: vi.fn(),
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    signTx: vi.fn(),
+    isFreighterInstalled: true,
+    isLoading: false,
+    error: null,
+    sessionExpired: false,
+    clearSessionExpired: vi.fn(),
+    mockConnect: vi.fn(),
+    isNetworkMismatch: false,
+  }),
+}));
+
+vi.mock('@/hooks/useChat', () => ({
+  default: () => mockChatState,
+}));
+
+vi.mock('@/hooks/useBridgeStats', () => ({
+  default: () => ({
+    balance: null,
+    limit: null,
+    totalDeposited: null,
+    loading: false,
+    error: null,
+    refetchStats: vi.fn(),
+    refresh: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/useTxHistory', () => ({
+  useTxHistory: () => ({
+    entries: [],
+    clearEntries: vi.fn(),
+    updateEntry: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/useChatHistory', () => ({
+  useChatHistory: () => ({ sessions: [] }),
+}));
+
+vi.mock('@/hooks/useSplitView', () => ({
+  useSplitView: () => ({
+    state: {
+      isOpen: false,
+      leftSessionId: null,
+      rightSessionId: null,
+      selectedMessageId: null,
+    },
+    open: vi.fn(),
+    close: vi.fn(),
+    setLeftSession: vi.fn(),
+    setRightSession: vi.fn(),
+    swapSessions: vi.fn(),
+    selectMessage: vi.fn(),
+    leftSession: null,
+    rightSession: null,
+  }),
+}));
+
+vi.mock('@/hooks/usePaystackWebhookStatus', () => ({
+  usePaystackWebhookStatus: () => undefined,
+}));
+
+vi.mock('@/lib/networkQueue', () => ({
+  getQueuedReadRequestsCount: () => 0,
+  subscribeToQueue: () => () => undefined,
+  processQueue: vi.fn(),
+}));
+
+vi.mock('@/lib/stellarContract', () => ({
+  getAdmin: vi.fn().mockResolvedValue(null),
+  getWithdrawalQueueDepth: vi.fn().mockResolvedValue(0),
+  stroopsToDisplay: (n: string | number) => String(n),
+}));
+
+vi.mock('@/components/ChatHistorySidebar', () => ({ default: () => null }));
+vi.mock('@/components/ChatInput', () => ({ default: () => null }));
+vi.mock('@/components/ChatMessages', () => ({
+  default: () => <div data-testid="chat-messages" />,
+}));
+vi.mock('@/components/StellarFiatModal', () => ({ default: () => null }));
+vi.mock('@/components/BankDetailsModal', () => ({ default: () => null }));
+vi.mock('@/components/UserSettings', () => ({ default: () => null }));
+vi.mock('@/components/WalletConnectionTimeline', () => ({
+  default: () => null,
+}));
+vi.mock('@/components/ReceiptDrawerWrapper', () => ({ default: () => null }));
+vi.mock('@/components/SplitViewComparison', () => ({ default: () => null }));
+vi.mock('@/components/ChatSearchPanel', () => ({ default: () => null }));
+vi.mock('@/components/ui/skeleton/SkeletonChat', () => ({
+  default: () => <div data-testid="skeleton-chat" />,
+}));
+vi.mock('@/components/ui/skeleton/SkeletonSidebar', () => ({
+  default: () => null,
+}));
+vi.mock('@/components/NotificationsCenter', () => ({ default: () => null }));
+
+describe('StellarChatInterface - skeleton loading state', () => {
+  beforeEach(() => {
+    mockChatState.messages = [];
+    mockChatState.isLoading = false;
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => ({}) } as Response);
+    Object.defineProperty(window, 'innerWidth', {
+      writable: true,
+      configurable: true,
+      value: 1200,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('renders the chat skeleton while loading with no messages yet', () => {
+    mockChatState.isLoading = true;
+    mockChatState.messages = [];
+
+    render(<StellarChatInterface />);
+
+    expect(screen.getByTestId('skeleton-chat')).toBeTruthy();
+    expect(screen.queryByTestId('chat-messages')).toBeNull();
+  });
+
+  it('renders the conversation (not the skeleton) once messages have loaded', () => {
+    mockChatState.isLoading = false;
+    mockChatState.messages = [
+      { id: '1', role: 'assistant', content: 'hello', timestamp: new Date() },
+    ];
+
+    render(<StellarChatInterface />);
+
+    expect(screen.getByTestId('chat-messages')).toBeTruthy();
+    expect(screen.queryByTestId('skeleton-chat')).toBeNull();
+  });
+});

--- a/dex_with_fiat_frontend/src/components/__tests__/StellarFiatModal.rapid-click.test.tsx
+++ b/dex_with_fiat_frontend/src/components/__tests__/StellarFiatModal.rapid-click.test.tsx
@@ -1,0 +1,139 @@
+import React from 'react';
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  cleanup,
+  act,
+} from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import StellarFiatModal from '../StellarFiatModal';
+
+const depositToContract = vi.fn().mockResolvedValue('HASHDEPOSIT123');
+const withdrawFromContract = vi.fn().mockResolvedValue('HASHWITHDRAW123');
+
+vi.mock('@/lib/stellarContract', () => ({
+  pollTransaction: vi.fn().mockResolvedValue('HASHPOLL'),
+  BRIDGE_LIMIT_WARNING_PERCENT: 80,
+  CONTRACT_ID: 'CTEST_CONTRACT_ID',
+  depositToContract: (...args: unknown[]) => depositToContract(...args),
+  withdrawFromContract: (...args: unknown[]) => withdrawFromContract(...args),
+  clearCache: vi.fn(),
+  simulateDeposit: vi.fn().mockResolvedValue(null),
+  simulateWithdraw: vi.fn().mockResolvedValue(null),
+}));
+
+const TEST_KEY = 'GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUV';
+
+vi.mock('@/contexts/StellarWalletContext', () => ({
+  useStellarWallet: () => ({
+    connection: {
+      isConnected: true,
+      publicKey: TEST_KEY,
+      address: TEST_KEY,
+      network: 'TESTNET',
+    },
+    signTx: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/useBridgeStats', () => ({
+  default: () => ({
+    limit: 100_000_000_000n, // 10,000 XLM in stroops — well above the test amount
+    loading: false,
+    error: null,
+    refetchStats: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+vi.mock('@/lib/cryptoPriceService', () => ({
+  getTokenPrice: vi.fn().mockResolvedValue(0.12),
+  formatFiatAmount: vi.fn().mockReturnValue('$1.20'),
+}));
+
+vi.mock('@/hooks/useNotifications', () => ({
+  useNotifications: () => ({ addNotification: vi.fn() }),
+}));
+
+vi.mock('@/hooks/useTxHistory', () => ({
+  useTxHistory: () => ({
+    addEntry: vi.fn(),
+    entries: [],
+    clearEntries: vi.fn(),
+    updateEntry: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/useAccessibleModal', () => ({
+  useAccessibleModal: () => undefined,
+}));
+
+vi.mock('@/lib/receipt', () => ({
+  downloadReceipt: vi.fn(),
+}));
+
+// Pass-through: strip the hook's own idempotency guard so the test exercises
+// the component's rapid-click protection directly.
+vi.mock('@/hooks/useIdempotentAction', () => ({
+  useIdempotentAction: () => ({
+    execute: async (fn: (key: string) => Promise<void>) => {
+      await fn('test-key');
+    },
+    isProcessing: false,
+  }),
+}));
+
+const defaultProps = {
+  isOpen: true,
+  onClose: vi.fn(),
+  defaultAmount: '10',
+};
+
+async function getSubmitButton() {
+  return waitFor(
+    () => screen.getByRole('button', { name: /review transaction/i }),
+    { timeout: 2000 },
+  );
+}
+
+describe('StellarFiatModal - rapid click protection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue({ ok: false }) as unknown as typeof fetch;
+  });
+
+  afterEach(cleanup);
+
+  it('submits only once when the deposit button is clicked rapidly', async () => {
+    render(<StellarFiatModal {...defaultProps} />);
+    const submit = await getSubmitButton();
+
+    // Batch the clicks in a single act() so React does not flush the
+    // disabling re-render between them — this reproduces a true double-click.
+    await act(async () => {
+      fireEvent.click(submit);
+      fireEvent.click(submit);
+      fireEvent.click(submit);
+    });
+
+    await waitFor(() => {
+      expect(depositToContract).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('still allows a single legitimate deposit to go through', async () => {
+    render(<StellarFiatModal {...defaultProps} />);
+    const submit = await getSubmitButton();
+
+    await act(async () => {
+      fireEvent.click(submit);
+    });
+
+    await waitFor(() => {
+      expect(depositToContract).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/dex_with_fiat_frontend/src/components/__tests__/TransactionAmountDisplay.test.tsx
+++ b/dex_with_fiat_frontend/src/components/__tests__/TransactionAmountDisplay.test.tsx
@@ -130,6 +130,47 @@ describe('TransactionAmountDisplay', () => {
   });
 });
 
+// ── Dynamic theme tokens (issue #593) ──────────────────────────────────
+describe('TransactionAmountDisplay - dynamic theme tokens', () => {
+  afterEach(cleanup);
+
+  it('renders the amount with the primary theme token instead of hardcoded colours', () => {
+    render(<TransactionAmountDisplay amount={100} asset="XLM" />);
+    const amountText = screen.getByText(/100 XLM ≈ \$12\.40 USD/i);
+    expect(amountText).toHaveClass('theme-text-primary');
+    expect(amountText.className).not.toMatch(/text-gray-300/);
+  });
+
+  it('renders the stored fiat line with the muted theme token', () => {
+    render(
+      <TransactionAmountDisplay
+        amount={100}
+        asset="XLM"
+        fiatAmount="12.40"
+        fiatCurrency="USD"
+      />
+    );
+    const storedFiat = screen.getByText(/Stored fiat: 12.40 USD/i);
+    expect(storedFiat).toHaveClass('theme-text-muted');
+    expect(storedFiat.className).not.toMatch(/text-gray-(400|500)/);
+  });
+});
+
+// ── Themed error border colour (issue #596) ─────────────────────────────
+describe('TransactionAmountDisplay - error border colour', () => {
+  afterEach(cleanup);
+
+  it('renders the error state with a themed danger border', () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    render(<TransactionAmountDisplay amount={0} />);
+    const errorMessage = screen.getByText(/Amount must be positive/i);
+    expect(errorMessage).toHaveClass('theme-soft-danger');
+    expect(errorMessage).toHaveClass('border');
+    expect(errorMessage.className).not.toMatch(/text-red-500/);
+    consoleSpy.mockRestore();
+  });
+});
+
 describe('TransactionAmountDisplay - Framer Motion Animations', () => {
   afterEach(cleanup);
 


### PR DESCRIPTION
## Summary

Four small frontend issues, batched into one PR.

- **#624 — skeleton loading state (`StellarChatInterface.tsx`)**: the chat skeleton only showed for `isLoading && messages.length === 0`. Added an `isHydrated` gate so the skeleton also renders on the initial client paint, before messages are restored, instead of a momentarily-empty conversation pane.
- **#596 — incorrect border colour (`TransactionAmountDisplay.tsx`)**: the invalid-props error used a hardcoded `text-red-500` with no border. It now uses the existing `theme-soft-danger` callout style with a themed `border`, so the border colour follows the active theme (matching the error-callout pattern already used elsewhere, e.g. `StellarFiatModal`).
- **#593 — dynamic theme tokens (`TransactionAmountDisplay.tsx`)**: replaced hardcoded `dark:text-gray-300` / `text-gray-500 dark:text-gray-400` on the amount and stored-fiat lines with the dynamic `theme-text-primary` / `theme-text-muted` tokens.
- **#585 — race condition (`StellarFiatModal.tsx`)**: the submit flow had a `lastActionTimestamp` cooldown guard wired into `isSubmitDisabled`, but it was only ever reset to `0` and never set — so it was inert, and React state wouldn't close a same-tick double-click anyway. Added a synchronous `useRef` guard that drops repeat submits within the existing `SUBMIT_COOLDOWN_MS` window before any contract call is issued.

## Tests

- `TransactionAmountDisplay.test.tsx`: asserts theme-token classes on the amount/fiat text and a themed danger border on the error state.
- `StellarFiatModal.rapid-click.test.tsx` (new): three rapid clicks result in exactly one `depositToContract` call; a single click still submits. Verified failing (3 calls) without the guard.
- `StellarChatInterface.skeleton.test.tsx` (new): skeleton renders while loading with no messages; the conversation renders once messages load.

## Test plan

- [ ] `npm run test:unit` — new/changed tests pass
- [ ] `npm run typecheck` — no new type errors
- [ ] Manually verify the amount display and error state in light/dark themes
- [ ] Manually verify rapid-clicking the deposit submit button submits once

## Out of scope (pre-existing, unrelated to this PR)

These already fail on a clean `main` in this environment and are not touched here:
- `TransactionAmountDisplay.test.tsx` — two `scrollIntoView` (#522) tests
- `StellarFiatModal.test.tsx` — two optimistic-UI tests
- `AdminGuard.tsx` — a `tsc` arity error, plus various timer/animation-based suites

Closes #624
Closes #596
Closes #593
Closes #585