### PR TITLE
feat: address issues #696, #838, #839, and #840 in one release

### DIFF
--- a/dex_with_fiat_frontend/src/components/ChatInput.tsx
+++ b/dex_with_fiat_frontend/src/components/ChatInput.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from '@/contexts/TranslationContext';
 import { useStellarWallet } from '@/contexts/StellarWalletContext';
 import { saveDraft, getDraft, clearDraft } from '@/lib/draftUtils';
 import { useIdempotentAction } from '@/hooks/useIdempotentAction';
+import { useMediaQuery } from '@/hooks/useMediaQuery';
 
 interface ChatInputProps {
   onSendMessage: (message: string) => void;
@@ -45,6 +46,7 @@ export default function ChatInput({
   const [paletteIndex, setPaletteIndex] = useState(0);
   
   const bottomRef = useRef<HTMLDivElement>(null);
+  const isMobile = useMediaQuery('(max-width: 639px)');
 
   const { execute: executeSubmit, isProcessing: isSubmitting } = useIdempotentAction({
     cooldownMs: 1000,
@@ -233,10 +235,20 @@ export default function ChatInput({
   return (
     <form
       onSubmit={handleSubmit}
-      className="theme-surface p-4 sm:p-6 transition-colors duration-300 relative border-t sm:border-none"
+      data-testid="chat-input-form"
+      data-mobile-layout={isMobile ? 'stacked' : 'inline'}
+      className={`theme-surface transition-colors duration-300 relative border-t sm:border-none ${
+        isMobile
+          ? 'sticky bottom-0 z-20 p-3 pb-[max(0.75rem,env(safe-area-inset-bottom))]'
+          : 'p-4 sm:p-6'
+      }`}
     >
       {showPalette && (
-        <div className="absolute inset-x-6 bottom-full mb-3 rounded-xl border theme-surface shadow-2xl z-50">
+        <div
+          className={`absolute bottom-full mb-3 rounded-xl border theme-surface shadow-2xl z-50 ${
+            isMobile ? 'inset-x-3' : 'inset-x-6'
+          }`}
+        >
           <div className="p-3 border-b">
             <input
               value={paletteQuery}
@@ -294,7 +306,9 @@ export default function ChatInput({
             initial={{ opacity: 0, y: 10 }}
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: 10 }}
-            className="absolute bottom-full left-6 mb-2 w-64 theme-surface border rounded-xl shadow-2xl overflow-hidden z-50"
+            className={`absolute bottom-full mb-2 theme-surface border rounded-xl shadow-2xl overflow-hidden z-50 ${
+              isMobile ? 'left-3 right-3 w-auto' : 'left-6 w-64'
+            }`}
           >
             <div className="p-2 border-b bg-gray-50/50">
               <span className="text-[10px] font-bold text-gray-400 uppercase tracking-widest pl-2">
@@ -321,38 +335,47 @@ export default function ChatInput({
         )}
       </AnimatePresence>
 
-      <div className="flex items-end space-x-3">
-        <div className="flex-1 relative">
+      <div
+        data-testid="chat-input-controls"
+        className={isMobile ? 'flex flex-col gap-2' : 'flex items-end space-x-3'}
+      >
+        <div className="flex-1 relative min-w-0">
           <textarea
+            data-testid="chat-input-textarea"
             value={message}
             onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => handleInputChange(e.target.value)}
             onKeyDown={handleKeyDown}
             placeholder={activePlaceholder}
             disabled={isLoading}
             aria-describedby="chat-submit-shortcut"
-            className="theme-input w-full resize-none border rounded-lg px-4 py-3 transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+            className={`theme-input w-full resize-none border rounded-lg transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed ${
+              isMobile ? 'px-3 py-2.5 text-base' : 'px-4 py-3'
+            }`}
             rows={1}
             style={{
-              minHeight: '48px',
-              maxHeight: '120px',
+              minHeight: isMobile ? '44px' : '48px',
+              maxHeight: isMobile ? '100px' : '120px',
               height: 'auto',
             }}
             onInput={(e: React.FormEvent<HTMLTextAreaElement>) => {
               const target = e.target as HTMLTextAreaElement;
               target.style.height = 'auto';
-              target.style.height = `${Math.min(target.scrollHeight, 120)}px`;
+              target.style.height = `${Math.min(target.scrollHeight, isMobile ? 100 : 120)}px`;
             }}
           />
         </div>
 
         <button
           type="submit"
+          data-testid="chat-input-send"
           disabled={isSubmitDisabled}
           title={`Send message (${submitShortcutLabel})`}
           aria-label={`Send message (${submitShortcutLabel})`}
           aria-describedby="chat-submit-shortcut"
           aria-keyshortcuts={submitShortcutKeys}
-          className="theme-primary-button flex items-center justify-center w-12 h-12 disabled:bg-gray-300 text-white rounded-lg transition-all duration-200 disabled:cursor-not-allowed transform hover:scale-105 disabled:hover:scale-100 shadow-lg"
+          className={`theme-primary-button flex items-center justify-center disabled:bg-gray-300 text-white rounded-lg transition-all duration-200 disabled:cursor-not-allowed transform hover:scale-105 disabled:hover:scale-100 shadow-lg ${
+            isMobile ? 'w-full h-11' : 'w-12 h-12'
+          }`}
         >
           {isLoading || isSubmitting ? (
             <Loader2 className="w-5 h-5 animate-spin" />

--- a/dex_with_fiat_frontend/src/components/SplitViewComparison.tsx
+++ b/dex_with_fiat_frontend/src/components/SplitViewComparison.tsx
@@ -6,6 +6,7 @@ import { ChatSession, ChatMessage } from '@/types';
 import { UseSplitViewReturn } from '@/hooks/useSplitView';
 import { useOnlineStatus } from '@/hooks/useOnlineStatus';
 import { useToast } from '@/hooks/useToast';
+import { useEffectiveDarkMode } from '@/hooks/useEffectiveDarkMode';
 
 interface SplitViewComparisonProps {
   splitView: UseSplitViewReturn;
@@ -228,6 +229,11 @@ export default function SplitViewComparison({
 
   const { isOnline, wasOffline, resetWasOffline } = useOnlineStatus();
   const { addToast } = useToast();
+  const isDarkMode = useEffectiveDarkMode();
+  const effectiveTheme = isDarkMode ? 'dark' : 'light';
+  const themeFallback = isDarkMode
+    ? 'bg-slate-950 text-slate-50'
+    : 'bg-slate-50 text-slate-900';
   // Fix (#523): initialise the ref to `true` (assume online at mount) so the
   // first offline transition is always detected correctly, regardless of the
   // order in which React commits the initial render vs. the effect.
@@ -287,11 +293,12 @@ export default function SplitViewComparison({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex flex-col bg-[var(--background)] text-[var(--foreground)]"
+      className={`fixed inset-0 z-50 flex flex-col bg-[var(--background)] text-[var(--foreground)] ${themeFallback}`}
       role="dialog"
       aria-modal="true"
       aria-labelledby={dialogTitleId}
       data-testid="split-view-comparison"
+      data-effective-theme={effectiveTheme}
     >
       {/* Toolbar */}
       <div

--- a/dex_with_fiat_frontend/src/components/TransactionAmountDisplay.tsx
+++ b/dex_with_fiat_frontend/src/components/TransactionAmountDisplay.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { useCurrencyConversion } from '@/hooks/useCurrencyConversion';
 import { transactionAmountSchema, type TransactionAmountProps } from '@/lib/transactionSchema';
 import { motion } from 'framer-motion';
+import { useUserPreferences } from '@/contexts/UserPreferencesContext';
 
 /**
  * Component to display transaction amounts with live currency conversion.
@@ -13,9 +14,13 @@ import { motion } from 'framer-motion';
  * Auto-scroll behaviour (issue #522): whenever the displayed amount changes,
  * the component scrolls itself into view so the user always sees the latest
  * value without manual scrolling.
+ *
+ * Optimistic UI (issue #839): while a new conversion is loading, show an
+ * estimated fiat value using the last known exchange rate until the fetch settles.
  */
 export function TransactionAmountDisplay(props: TransactionAmountProps) {
   const result = transactionAmountSchema.safeParse(props);
+  const { fiatCurrency } = useUserPreferences();
 
   // Derive values for hooks unconditionally — hooks must not be called after
   // a conditional return (Rules of Hooks). Fall back to neutral values when
@@ -26,13 +31,56 @@ export function TransactionAmountDisplay(props: TransactionAmountProps) {
     : 0;
   const normalizedAsset = parsed?.asset || 'XLM';
 
-  const { displayText } = useCurrencyConversion(numericAmount, normalizedAsset);
+  const { displayText, isLoading, hasError, fiatAmount } = useCurrencyConversion(
+    numericAmount,
+    normalizedAsset,
+  );
+
+  const lastRateRef = useRef<number | null>(null);
+  const lastConfirmedTextRef = useRef<string>('');
+
+  useEffect(() => {
+    if (!isLoading && !hasError && displayText) {
+      lastConfirmedTextRef.current = displayText;
+      if (fiatAmount != null && numericAmount > 0) {
+        lastRateRef.current = fiatAmount / numericAmount;
+      }
+    }
+  }, [displayText, isLoading, hasError, fiatAmount, numericAmount]);
+
+  const currencySymbol = useMemo(() => {
+    const symbolMap: Record<string, string> = {
+      usd: '$',
+      eur: '€',
+      gbp: '£',
+      ngn: '₦',
+      cad: 'CA$',
+      aud: 'A$',
+      jpy: '¥',
+    };
+    return symbolMap[fiatCurrency.toLowerCase()] || '';
+  }, [fiatCurrency]);
+
+  const optimisticDisplayText = useMemo(() => {
+    if (!isLoading || !parsed || lastRateRef.current == null || numericAmount <= 0) {
+      return null;
+    }
+    const estimatedFiat = numericAmount * lastRateRef.current;
+    const formattedFiat = estimatedFiat.toLocaleString('en-US', {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    });
+    return `${numericAmount} ${normalizedAsset} ≈ ${currencySymbol}${formattedFiat} ${fiatCurrency.toUpperCase()}`;
+  }, [isLoading, parsed, numericAmount, normalizedAsset, currencySymbol, fiatCurrency]);
+
+  const renderedText = optimisticDisplayText ?? displayText;
+  const isOptimistic = optimisticDisplayText != null;
 
   // Auto-scroll: keep the latest amount visible whenever displayText updates.
   const containerRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     containerRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
-  }, [displayText]);
+  }, [renderedText]);
 
   if (!result.success) {
     const errorMessage = result.error.issues[0]?.message || 'Invalid Amount Data';
@@ -49,7 +97,7 @@ export function TransactionAmountDisplay(props: TransactionAmountProps) {
     );
   }
 
-  const { fiatAmount, fiatCurrency } = result.data;
+  const { fiatAmount: storedFiatAmount, fiatCurrency: storedFiatCurrency } = result.data;
 
   return (
     <motion.div
@@ -58,24 +106,27 @@ export function TransactionAmountDisplay(props: TransactionAmountProps) {
       initial={{ opacity: 0, y: -4 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.3, ease: 'easeOut' }}
+      data-testid="transaction-amount-display"
+      data-optimistic={isOptimistic ? 'true' : 'false'}
     >
       <motion.span
-        className="font-medium theme-text-primary"
-        key={displayText}
+        className={`font-medium theme-text-primary ${isOptimistic ? 'opacity-80' : ''}`}
+        key={renderedText}
         initial={{ scale: 0.95, opacity: 0.7 }}
         animate={{ scale: 1, opacity: 1 }}
         transition={{ duration: 0.2, ease: 'easeOut' }}
+        aria-busy={isOptimistic}
       >
-        {displayText}
+        {renderedText}
       </motion.span>
-      {fiatAmount && fiatCurrency && (
+      {storedFiatAmount && storedFiatCurrency && (
         <motion.span
           className="text-xs theme-text-muted"
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           transition={{ duration: 0.2, delay: 0.1 }}
         >
-          Stored fiat: {fiatAmount} {fiatCurrency}
+          Stored fiat: {storedFiatAmount} {storedFiatCurrency}
         </motion.span>
       )}
     </motion.div>

--- a/dex_with_fiat_frontend/src/components/__tests__/ChatInput.mobile-layout.test.tsx
+++ b/dex_with_fiat_frontend/src/components/__tests__/ChatInput.mobile-layout.test.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import ChatInput from '../ChatInput';
+
+const mockUseMediaQuery = vi.fn();
+
+vi.mock('@/hooks/useMediaQuery', () => ({
+  useMediaQuery: (query: string) => mockUseMediaQuery(query),
+}));
+
+vi.mock('@/contexts/TranslationContext', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('@/contexts/StellarWalletContext', () => ({
+  useStellarWallet: () => ({
+    connection: { isConnected: true },
+  }),
+}));
+
+vi.mock('@/lib/draftUtils', () => ({
+  saveDraft: vi.fn(),
+  getDraft: vi.fn(() => ''),
+  clearDraft: vi.fn(),
+}));
+
+vi.mock('@/hooks/useIdempotentAction', () => ({
+  useIdempotentAction: () => ({
+    execute: (fn: () => void) => fn(),
+    isProcessing: false,
+  }),
+}));
+
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: 'div',
+  },
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+describe('ChatInput mobile layout', () => {
+  const defaultProps = {
+    onSendMessage: vi.fn(),
+    isLoading: false,
+  };
+
+  beforeEach(() => {
+    mockUseMediaQuery.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('uses inline layout on desktop viewports', () => {
+    mockUseMediaQuery.mockReturnValue(false);
+    render(React.createElement(ChatInput, defaultProps));
+
+    expect(screen.getByTestId('chat-input-form').getAttribute('data-mobile-layout')).toBe(
+      'inline',
+    );
+    expect(screen.getByTestId('chat-input-controls').className).toContain('items-end');
+    expect(screen.getByTestId('chat-input-send').className).toContain('w-12');
+  });
+
+  it('uses stacked mobile layout below 640px', () => {
+    mockUseMediaQuery.mockReturnValue(true);
+    render(React.createElement(ChatInput, defaultProps));
+
+    expect(screen.getByTestId('chat-input-form').getAttribute('data-mobile-layout')).toBe(
+      'stacked',
+    );
+    expect(screen.getByTestId('chat-input-form').className).toContain('sticky');
+    expect(screen.getByTestId('chat-input-controls').className).toContain('flex-col');
+    expect(screen.getByTestId('chat-input-send').className).toContain('w-full');
+  });
+
+  it('queries the mobile breakpoint media query', () => {
+    render(React.createElement(ChatInput, defaultProps));
+    expect(mockUseMediaQuery).toHaveBeenCalledWith('(max-width: 639px)');
+  });
+});

--- a/dex_with_fiat_frontend/src/components/__tests__/SplitViewComparison.test.tsx
+++ b/dex_with_fiat_frontend/src/components/__tests__/SplitViewComparison.test.tsx
@@ -22,6 +22,10 @@ vi.mock('@/hooks/useToast', () => ({
   }),
 }));
 
+vi.mock('@/contexts/ThemeContext', () => ({
+  useTheme: () => ({ isDarkMode: false, toggleDarkMode: vi.fn() }),
+}));
+
 // ---------------------------------------------------------------------------
 // Fixtures
 // ---------------------------------------------------------------------------
@@ -313,5 +317,42 @@ describe('SplitViewComparison – race condition regression (#523)', () => {
     fireEvent(window, new Event('offline'));
     await waitFor(() => expect(splitViewAddToastMock).toHaveBeenCalledTimes(1));
     expect(splitViewAddToastMock.mock.calls[0][0].severity).toBe('warning');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dark mode fallback (Issue #838)
+// ---------------------------------------------------------------------------
+
+describe('SplitViewComparison – dark mode fallback (#838)', () => {
+  afterEach(() => {
+    document.documentElement.removeAttribute('data-theme');
+  });
+
+  it('exposes data-effective-theme from document data-theme when set to dark', () => {
+    document.documentElement.setAttribute('data-theme', 'dark');
+    const splitView = makeSplitView();
+    render(<SplitViewComparison splitView={splitView} sessions={allSessions} />);
+    const dialog = screen.getByTestId('split-view-comparison');
+    expect(dialog.getAttribute('data-effective-theme')).toBe('dark');
+    expect(dialog.className).toContain('bg-slate-950');
+  });
+
+  it('exposes data-effective-theme light and light fallback classes', () => {
+    document.documentElement.setAttribute('data-theme', 'light');
+    const splitView = makeSplitView();
+    render(<SplitViewComparison splitView={splitView} sessions={allSessions} />);
+    const dialog = screen.getByTestId('split-view-comparison');
+    expect(dialog.getAttribute('data-effective-theme')).toBe('light');
+    expect(dialog.className).toContain('bg-slate-50');
+  });
+
+  it('keeps CSS variable classes alongside fallback surface colours', () => {
+    document.documentElement.setAttribute('data-theme', 'dark');
+    const splitView = makeSplitView();
+    render(<SplitViewComparison splitView={splitView} sessions={allSessions} />);
+    const dialog = screen.getByTestId('split-view-comparison');
+    expect(dialog.className).toContain('var(--background)');
+    expect(dialog.className).toContain('bg-slate-950');
   });
 });

--- a/dex_with_fiat_frontend/src/components/__tests__/TransactionAmountDisplay.test.tsx
+++ b/dex_with_fiat_frontend/src/components/__tests__/TransactionAmountDisplay.test.tsx
@@ -17,6 +17,10 @@ vi.mock('@/hooks/useCurrencyConversion', () => ({
   })),
 }));
 
+vi.mock('@/contexts/UserPreferencesContext', () => ({
+  useUserPreferences: () => ({ fiatCurrency: 'usd' }),
+}));
+
 // Mock framer-motion to avoid animation issues in tests
 vi.mock('framer-motion', () => ({
   motion: {
@@ -291,5 +295,89 @@ describe('TransactionAmountDisplay - Rules of Hooks regression', () => {
     expect(hookErrors).toHaveLength(0);
 
     consoleSpy.mockRestore();
+  });
+});
+
+// ── Optimistic UI (issue #839) ─────────────────────────────────────────────
+
+describe('TransactionAmountDisplay - optimistic UI (#839)', () => {
+  afterEach(cleanup);
+
+  it('shows confirmed conversion when not loading', async () => {
+    const { useCurrencyConversion } = await import('@/hooks/useCurrencyConversion');
+    const mockHook = vi.mocked(useCurrencyConversion);
+    mockHook.mockReturnValue({
+      displayText: '100 XLM ≈ $12.40 USD',
+      isLoading: false,
+      hasError: false,
+      fiatAmount: 12.4,
+      fiatCurrency: 'USD',
+      originalAmount: 100,
+      originalCurrency: 'XLM',
+    });
+
+    render(<TransactionAmountDisplay amount={100} asset="XLM" />);
+    expect(screen.getByText('100 XLM ≈ $12.40 USD')).toBeDefined();
+    expect(screen.getByTestId('transaction-amount-display')).toHaveAttribute(
+      'data-optimistic',
+      'false',
+    );
+  });
+
+  it('shows optimistic estimate while loading after a prior conversion', async () => {
+    const { useCurrencyConversion } = await import('@/hooks/useCurrencyConversion');
+    const mockHook = vi.mocked(useCurrencyConversion);
+    mockHook.mockReturnValue({
+      displayText: '100 XLM ≈ $12.40 USD',
+      isLoading: false,
+      hasError: false,
+      fiatAmount: 12.4,
+      fiatCurrency: 'USD',
+      originalAmount: 100,
+      originalCurrency: 'XLM',
+    });
+
+    const { rerender } = render(<TransactionAmountDisplay amount={100} asset="XLM" />);
+
+    mockHook.mockReturnValue({
+      displayText: '200 XLM ≈ ...',
+      isLoading: true,
+      hasError: false,
+      fiatAmount: null,
+      fiatCurrency: 'USD',
+      originalAmount: 200,
+      originalCurrency: 'XLM',
+    });
+
+    await act(async () => {
+      rerender(<TransactionAmountDisplay amount={200} asset="XLM" />);
+    });
+
+    expect(screen.getByTestId('transaction-amount-display')).toHaveAttribute(
+      'data-optimistic',
+      'true',
+    );
+    expect(screen.getByText(/200 XLM ≈ \$24\.80 USD/i)).toBeDefined();
+  });
+
+  it('falls back to hook display text when loading without a prior rate', async () => {
+    const { useCurrencyConversion } = await import('@/hooks/useCurrencyConversion');
+    const mockHook = vi.mocked(useCurrencyConversion);
+    mockHook.mockReturnValue({
+      displayText: '50 XLM ≈ ...',
+      isLoading: true,
+      hasError: false,
+      fiatAmount: null,
+      fiatCurrency: 'USD',
+      originalAmount: 50,
+      originalCurrency: 'XLM',
+    });
+
+    render(<TransactionAmountDisplay amount={50} asset="XLM" />);
+    expect(screen.getByText('50 XLM ≈ ...')).toBeDefined();
+    expect(screen.getByTestId('transaction-amount-display')).toHaveAttribute(
+      'data-optimistic',
+      'false',
+    );
   });
 });

--- a/dex_with_fiat_frontend/src/hooks/__tests__/useEffectiveDarkMode.test.ts
+++ b/dex_with_fiat_frontend/src/hooks/__tests__/useEffectiveDarkMode.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useEffectiveDarkMode } from '../useEffectiveDarkMode';
+
+vi.mock('@/contexts/ThemeContext', () => ({
+  useTheme: vi.fn(() => ({ isDarkMode: false, toggleDarkMode: vi.fn() })),
+}));
+
+describe('useEffectiveDarkMode', () => {
+  beforeEach(() => {
+    document.documentElement.removeAttribute('data-theme');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('prefers data-theme="dark" on the document element', () => {
+    document.documentElement.setAttribute('data-theme', 'dark');
+    const { result } = renderHook(() => useEffectiveDarkMode());
+    expect(result.current).toBe(true);
+  });
+
+  it('prefers data-theme="light" on the document element', () => {
+    document.documentElement.setAttribute('data-theme', 'light');
+    const { result } = renderHook(() => useEffectiveDarkMode());
+    expect(result.current).toBe(false);
+  });
+});

--- a/dex_with_fiat_frontend/src/hooks/useEffectiveDarkMode.ts
+++ b/dex_with_fiat_frontend/src/hooks/useEffectiveDarkMode.ts
@@ -1,0 +1,36 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useTheme } from '@/contexts/ThemeContext';
+
+/**
+ * Resolves the active colour scheme for components that render outside the
+ * normal theme tree (e.g. full-screen overlays).
+ *
+ * Priority: ThemeContext → `data-theme` on `<html>` → `prefers-color-scheme`.
+ */
+export function useEffectiveDarkMode(): boolean {
+  const { isDarkMode } = useTheme();
+  const [systemPrefersDark, setSystemPrefersDark] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return;
+    }
+
+    const mql = window.matchMedia('(prefers-color-scheme: dark)');
+    setSystemPrefersDark(mql.matches);
+
+    const handler = (e: MediaQueryListEvent) => setSystemPrefersDark(e.matches);
+    mql.addEventListener('change', handler);
+    return () => mql.removeEventListener('change', handler);
+  }, []);
+
+  if (typeof document !== 'undefined') {
+    const dataTheme = document.documentElement.getAttribute('data-theme');
+    if (dataTheme === 'dark') return true;
+    if (dataTheme === 'light') return false;
+  }
+
+  return isDarkMode || systemPrefersDark;
+}

--- a/dex_with_fiat_frontend/vitest.setup.ts
+++ b/dex_with_fiat_frontend/vitest.setup.ts
@@ -1,1 +1,16 @@
 import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});

--- a/stellar-contracts/src/lib.rs
+++ b/stellar-contracts/src/lib.rs
@@ -496,6 +496,17 @@ pub struct FeeAccruedEvent {
 
 #[contractevent]
 #[derive(Clone, Debug)]
+pub struct FeeVaultReconciledEvent {
+    pub version: u32,
+    pub token: Address,
+    /// Vault balance recorded before reconciliation.
+    pub previous_balance: i128,
+    /// Vault balance after capping to on-chain token reserves.
+    pub new_balance: i128,
+}
+
+#[contractevent]
+#[derive(Clone, Debug)]
 pub struct RefundEvent {
     pub version: u32,
     pub receipt_id: BytesN<32>,
@@ -3408,6 +3419,53 @@ impl FiatBridge {
     }
 
     // ── Fee Vault ─────────────────────────────────────────────────────────
+
+    /// Returns the persisted fee-vault balance for `token`, reconciled against
+    /// the contract's on-chain token balance so the ledger never exceeds reserves.
+    fn reconcile_fee_vault(env: &Env, token: &Address) -> i128 {
+        let key = DataKey::FeeVault(token.clone());
+        let vault_balance: i128 = env.storage().persistent().get(&key).unwrap_or(0);
+        if vault_balance <= 0 {
+            return 0;
+        }
+
+        let token_client = token::Client::new(env, token);
+        let contract_balance = token_client.balance(&env.current_contract_address());
+        if vault_balance <= contract_balance {
+            return vault_balance;
+        }
+
+        env.storage()
+            .persistent()
+            .set(&key, &contract_balance);
+        FeeVaultReconciledEvent {
+            version: EVENT_VERSION,
+            token: token.clone(),
+            previous_balance: vault_balance,
+            new_balance: contract_balance,
+        }
+        .publish(env);
+        contract_balance
+    }
+
+    /// Debits `amount` from an already-reconciled fee vault and returns the remainder.
+    /// Callers must invoke [`Self::reconcile_fee_vault`] before transferring tokens.
+    fn deduct_fee_vault_ledger(
+        env: &Env,
+        token: &Address,
+        vault_balance: i128,
+        amount: i128,
+    ) -> Result<i128, Error> {
+        require!(vault_balance > 0, Error::NoFeesToWithdraw);
+        require!(amount <= vault_balance, Error::FeeWithdrawalExceedsBalance);
+        let remaining = vault_balance
+            .checked_sub(amount)
+            .ok_or(Error::Overflow)?;
+        let key = DataKey::FeeVault(token.clone());
+        env.storage().persistent().set(&key, &remaining);
+        Ok(remaining)
+    }
+
     pub fn accrue_fee(env: Env, token: Address, amount: i128) -> Result<(), Error> {
         let admin: Address = env
             .storage()
@@ -3495,22 +3553,19 @@ impl FiatBridge {
         require!(nonce >= expected_nonce, Error::StaleNonce);
         require!(nonce == expected_nonce, Error::InvalidNonce);
 
-        // ── Fee vault checks ──────────────────────────────────────────────
-        let key = DataKey::FeeVault(token.clone());
-        let current: i128 = env.storage().persistent().get(&key).unwrap_or(0);
-        require!(current > 0, Error::NoFeesToWithdraw);
-        require!(amount <= current, Error::FeeWithdrawalExceedsBalance);
-
-        // Boundary check: actual contract balance
+        // ── Fee vault checks (reconcile ledger with on-chain reserves) ───
         let token_client = token::Client::new(&env, &token);
+        let vault_balance = Self::reconcile_fee_vault(&env, &token);
         let contract_balance = token_client.balance(&env.current_contract_address());
+        require!(vault_balance > 0, Error::NoFeesToWithdraw);
+        require!(amount <= vault_balance, Error::FeeWithdrawalExceedsBalance);
         require!(amount <= contract_balance, Error::InsufficientFunds);
 
         // ── State mutation ────────────────────────────────────────────────
         token_client.transfer(&env.current_contract_address(), &to, &amount);
 
-        let remaining_fees = current.checked_sub(amount).ok_or(Error::Overflow)?;
-        env.storage().persistent().set(&key, &remaining_fees);
+        let remaining_fees =
+            Self::deduct_fee_vault_ledger(&env, &token, vault_balance, amount)?;
 
         // Increment nonce after successful withdrawal
         let next_nonce = expected_nonce.checked_add(1).ok_or(Error::Overflow)?;
@@ -3550,15 +3605,25 @@ impl FiatBridge {
 
         let contract = env.current_contract_address();
         for token in tokens.iter() {
-            let key = DataKey::FeeVault(token.clone());
-            let current: i128 = env.storage().persistent().get(&key).unwrap_or(0);
+            let current = Self::reconcile_fee_vault(&env, &token);
             if current <= 0 {
                 continue;
             }
 
             let token_client = token::Client::new(&env, &token);
-            token_client.transfer(&contract, &to, &current);
+            let contract_balance = token_client.balance(&contract);
+            let sweep_amount = if current <= contract_balance {
+                current
+            } else {
+                contract_balance
+            };
+            if sweep_amount <= 0 {
+                continue;
+            }
+
+            token_client.transfer(&contract, &to, &sweep_amount);
             // After transfer the vault for this token is fully drained.
+            let key = DataKey::FeeVault(token.clone());
             env.storage().persistent().set(&key, &0i128);
 
             // Emit full schema per token so each sweep leg is individually
@@ -3569,7 +3634,7 @@ impl FiatBridge {
                 admin: admin.clone(),
                 to: to.clone(),
                 token,
-                amount: current,
+                amount: sweep_amount,
                 nonce: 0,
                 remaining_fees: 0,
             }
@@ -5525,3 +5590,6 @@ mod test_issues_504_511_600;
 
 #[cfg(test)]
 mod test_issues_492_499;
+
+#[cfg(test)]
+mod test_issues_840;

--- a/stellar-contracts/src/test.rs
+++ b/stellar-contracts/src/test.rs
@@ -4461,6 +4461,46 @@ fn test_withdraw_fees_event_remaining_fees_reflects_vault_balance() {
     assert_eq!(result, Err(Ok(Error::NoFeesToWithdraw)));
 }
 
+// ── Issue #840: fee vault reconciliation in withdraw_fees ───────────────
+
+#[test]
+fn test_withdraw_fees_emits_vault_reconciled_event_issue_840() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, bridge, _, token_addr, _, token_sac) = setup_bridge(&env, 10_000);
+    let recipient = Address::generate(&env);
+
+    token_sac.mint(&contract_id, &200);
+    env.as_contract(&contract_id, || {
+        env.storage()
+            .persistent()
+            .set(&DataKey::FeeVault(token_addr.clone()), &400i128);
+    });
+
+    bridge.withdraw_fees(&recipient, &token_addr, &100, &0);
+
+    let events = env.events().all().filter_by_contract(&contract_id);
+    let raw = events.events();
+    let topic_symbol = soroban_sdk::xdr::ScVal::Symbol(soroban_sdk::xdr::ScSymbol(
+        soroban_sdk::xdr::StringM::try_from("fee_vault_reconciled_event").expect("topic"),
+    ));
+    let mut found = false;
+    for event in raw.iter() {
+        use soroban_sdk::xdr::ContractEventBody;
+        if let ContractEventBody::V0(body) = &event.body {
+            if body.topics.iter().any(|t| *t == topic_symbol) {
+                found = true;
+                break;
+            }
+        }
+    }
+    assert!(
+        found,
+        "FeeVaultReconciledEvent must be emitted when vault ledger exceeds on-chain reserves"
+    );
+}
+
 // ── Issue #619: Edge case validation for request_withdrawal ────────────
 
 #[test]

--- a/stellar-contracts/src/test_issues_840.rs
+++ b/stellar-contracts/src/test_issues_840.rs
@@ -1,0 +1,116 @@
+//! Integration tests for issue #840 — fee accrual vault logic in `withdraw_fees`.
+
+#![cfg(test)]
+extern crate std;
+
+use super::*;
+use soroban_sdk::{
+    testutils::{Address as _, Events},
+    token::{Client as TokenClient, StellarAssetClient},
+    vec, Address, Env,
+};
+
+fn create_token<'a>(
+    e: &Env,
+    admin: &Address,
+) -> (Address, TokenClient<'a>, StellarAssetClient<'a>) {
+    let addr = e
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+    (
+        addr.clone(),
+        TokenClient::new(e, &addr),
+        StellarAssetClient::new(e, &addr),
+    )
+}
+
+fn setup_bridge(
+    env: &Env,
+) -> (
+    Address,
+    FiatBridgeClient<'_>,
+    Address,
+    Address,
+    TokenClient<'_>,
+    StellarAssetClient<'_>,
+) {
+    let contract_id = env.register(FiatBridge, ());
+    let bridge = FiatBridgeClient::new(env, &contract_id);
+    let admin = Address::generate(env);
+    let token_admin = Address::generate(env);
+    let (token_addr, token, token_sac) = create_token(env, &token_admin);
+    let signers = vec![env, admin.clone()];
+    bridge.init(&admin, &token_addr, &1_000_000, &1, &signers, &1);
+    (contract_id, bridge, admin, token_addr, token, token_sac)
+}
+
+/// When the fee-vault ledger exceeds on-chain reserves, `withdraw_fees` must
+/// reconcile the vault before debiting and emit `FeeVaultReconciledEvent`.
+#[test]
+fn test_withdraw_fees_reconciles_vault_when_ledger_exceeds_balance() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, bridge, _, token_addr, token, token_sac) = setup_bridge(&env);
+    let recipient = Address::generate(&env);
+
+    token_sac.mint(&contract_id, &200);
+    env.as_contract(&contract_id, || {
+        env.storage()
+            .persistent()
+            .set(&DataKey::FeeVault(token_addr.clone()), &400i128);
+    });
+
+    assert_eq!(bridge.get_accrued_fees(&token_addr), 400);
+
+    bridge.withdraw_fees(&recipient, &token_addr, &100, &0);
+
+    assert_eq!(bridge.get_accrued_fees(&token_addr), 100);
+    assert_eq!(token.balance(&recipient), 100);
+}
+
+/// Partial withdrawals must debit only the reconciled vault balance.
+#[test]
+fn test_withdraw_fees_uses_fee_vault_after_reconciliation() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, bridge, _, token_addr, _, token_sac) = setup_bridge(&env);
+    let recipient = Address::generate(&env);
+
+    token_sac.mint(&contract_id, &300);
+    bridge.accrue_fee(&token_addr, &250);
+
+    bridge.withdraw_fees(&recipient, &token_addr, &100, &0);
+    assert_eq!(bridge.get_accrued_fees(&token_addr), 150);
+
+    bridge.withdraw_fees(&recipient, &token_addr, &150, &1);
+    assert_eq!(bridge.get_accrued_fees(&token_addr), 0);
+
+    let result = bridge.try_withdraw_fees(&recipient, &token_addr, &1, &2);
+    assert_eq!(result, Err(Ok(Error::NoFeesToWithdraw)));
+}
+
+/// Over-withdrawal after reconciliation must still be rejected.
+#[test]
+fn test_withdraw_fees_rejects_amount_above_reconciled_vault() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, bridge, _, token_addr, _, token_sac) = setup_bridge(&env);
+    let recipient = Address::generate(&env);
+
+    token_sac.mint(&contract_id, &100);
+    env.as_contract(&contract_id, || {
+        env.storage()
+            .persistent()
+            .set(&DataKey::FeeVault(token_addr.clone()), &250i128);
+    });
+
+    let result = bridge.try_withdraw_fees(&recipient, &token_addr, &150, &0);
+    assert!(
+        result == Err(Ok(Error::FeeWithdrawalExceedsBalance))
+            || result == Err(Ok(Error::InsufficientFunds)),
+        "expected withdrawal to fail when amount exceeds reconciled vault, got {result:?}",
+    );
+}


### PR DESCRIPTION
## Summary
- **#838**: Dark mode fallback for `SplitViewComparison` via `useEffectiveDarkMode` and `data-effective-theme`.
- **#696**: Responsive mobile layout for `ChatInput` (stacked controls, sticky bottom bar).
- **#839**: Optimistic fiat display in `TransactionAmountDisplay` while conversion reloads.
- **#840**: Fee vault reconciliation in `withdraw_fees` with `FeeVaultReconciledEvent` and integration tests.

Closes #696
Closes #838
Closes #839
Closes #840

## Test plan
- [ ] `cd dex_with_fiat_frontend && npm run test:unit`
- [ ] `cd stellar-contracts && cargo test issue_840 && cargo test test_issues_840`
- [ ] Manually verify split-view theming, chat input on a narrow viewport, and amount display while rates refresh
