### PR TITLE
feat(frontend): add clipboard copy button to admin/page.tsx (#834)

### DIFF
--- a/dex_with_fiat_frontend/src/app/admin/__tests__/page.test.tsx
+++ b/dex_with_fiat_frontend/src/app/admin/__tests__/page.test.tsx
@@ -327,6 +327,127 @@ describe('AdminDashboard - Optimistic UI Updates', () => {
   });
 });
 
+describe('AdminDashboard - Clipboard copy button (#834)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockImplementation((url) => {
+      if (typeof url === 'string' && url.includes('/api/admin/audit-log')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            entries: [
+              {
+                id: '1',
+                timestamp: '2024-01-01T00:00:00Z',
+                action: 'withdrawal_approved',
+                adminAddress: 'GTEST123',
+                parameters: { amount: 100 },
+                result: 'success',
+              },
+            ],
+            page: 1,
+            pageSize: 20,
+            total: 1,
+            totalPages: 1,
+            actions: ['withdrawal_approved'],
+          }),
+        } as Response);
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => [],
+      } as Response);
+    });
+  });
+
+  it('renders copy buttons for the address, timestamp and parameters columns', async () => {
+    render(<AdminDashboard />);
+
+    expect(
+      await screen.findByRole('button', {
+        name: /copy admin address GTEST123/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /copy timestamp/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /copy parameters/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('copies the admin address to the clipboard when clicked', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    render(<AdminDashboard />);
+
+    const copyButton = await screen.findByRole('button', {
+      name: /copy admin address GTEST123/i,
+    });
+
+    fireEvent.click(copyButton);
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith('GTEST123');
+    });
+  });
+
+  it('copies the formatted parameters when the parameters copy button is clicked', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    render(<AdminDashboard />);
+
+    const copyButton = await screen.findByRole('button', {
+      name: /copy parameters/i,
+    });
+
+    fireEvent.click(copyButton);
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith('amount: 100');
+    });
+  });
+
+  it('copies the exact ISO timestamp when the timestamp copy button is clicked', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    render(<AdminDashboard />);
+
+    const copyButton = await screen.findByRole('button', {
+      name: /copy timestamp/i,
+    });
+
+    fireEvent.click(copyButton);
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith('2024-01-01T00:00:00Z');
+    });
+  });
+
+  it('shows the success-state icon after a successful copy', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    render(<AdminDashboard />);
+
+    const copyButton = await screen.findByRole('button', {
+      name: /copy admin address GTEST123/i,
+    });
+
+    // Before clicking, the success (green check) icon is not shown.
+    expect(copyButton.querySelector('.text-green-400')).toBeNull();
+
+    fireEvent.click(copyButton);
+
+    await waitFor(() => {
+      expect(copyButton.querySelector('.text-green-400')).not.toBeNull();
+    });
+  });
+});
+
 describe('AdminDashboard - ErrorBoundary protection', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/dex_with_fiat_frontend/src/app/admin/page.tsx
+++ b/dex_with_fiat_frontend/src/app/admin/page.tsx
@@ -16,6 +16,7 @@ import ErrorBoundary from '@/components/ErrorBoundary';
 import { stroopsToDisplay } from '@/lib/stellarContract';
 import SkeletonHeader from '@/components/ui/skeleton/SkeletonHeader';
 import SkeletonPayout from '@/components/ui/skeleton/SkeletonPayout';
+import CopyButton from '@/components/ui/CopyButton';
 import {
   AreaChart,
   Area,
@@ -618,17 +619,37 @@ export default function AdminDashboard() {
                         className="theme-border border-b hover:opacity-80"
                       >
                         <td className="px-6 py-4 whitespace-nowrap text-sm theme-text-primary">
-                          {new Date(entry.timestamp).toLocaleString()}
+                          <span className="inline-flex items-center gap-1.5">
+                            <span>
+                              {new Date(entry.timestamp).toLocaleString()}
+                            </span>
+                            <CopyButton
+                              value={entry.timestamp}
+                              ariaLabel="Copy timestamp"
+                            />
+                          </span>
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap text-sm theme-text-primary font-medium">
                           {formatActionLabel(entry.action)}
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap text-sm font-mono theme-text-primary">
-                          {entry.adminAddress}
+                          <span className="inline-flex items-center gap-1.5">
+                            <span>{entry.adminAddress}</span>
+                            <CopyButton
+                              value={entry.adminAddress}
+                              ariaLabel={`Copy admin address ${entry.adminAddress}`}
+                            />
+                          </span>
                         </td>
                         <td className="px-6 py-4 text-sm theme-text-primary max-w-xl">
-                          <span className="inline-block theme-surface-muted rounded px-2 py-1 break-all">
-                            {formatParameters(entry.parameters)}
+                          <span className="inline-flex items-start gap-1.5">
+                            <span className="inline-block theme-surface-muted rounded px-2 py-1 break-all">
+                              {formatParameters(entry.parameters)}
+                            </span>
+                            <CopyButton
+                              value={formatParameters(entry.parameters)}
+                              ariaLabel="Copy parameters"
+                            />
                           </span>
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap text-sm">

--- a/dex_with_fiat_frontend/src/components/ui/CopyButton.tsx
+++ b/dex_with_fiat_frontend/src/components/ui/CopyButton.tsx
@@ -9,6 +9,8 @@ interface CopyButtonProps {
   iconClassName?: string;
   successDurationMs?: number;
   tooltipPosition?: 'top' | 'bottom';
+  /** Accessible label override; falls back to a generic "Copy to clipboard". */
+  ariaLabel?: string;
 }
 
 async function copyTextToClipboard(value: string): Promise<boolean> {
@@ -67,6 +69,7 @@ export default function CopyButton({
   iconClassName = 'w-4 h-4',
   successDurationMs = 2000,
   tooltipPosition = 'top',
+  ariaLabel = 'Copy to clipboard',
 }: CopyButtonProps) {
   const [copied, setCopied] = useState(false);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -107,8 +110,8 @@ export default function CopyButton({
     <button
       type="button"
       onClick={handleCopy}
-      aria-label="Copy to clipboard"
-      title="Copy to clipboard"
+      aria-label={ariaLabel}
+      title={ariaLabel}
       className={`relative inline-flex items-center justify-center rounded p-1 text-gray-400 transition-colors hover:text-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1 focus:ring-offset-transparent ${className}`}
     >
       <span


### PR DESCRIPTION
# Pull Request: Clipboard Copy Buttons for Admin Audit Log

## Description

Adds clipboard **copy buttons** to the Admin Dashboard audit log table so admins can quickly copy values out of each audit row, improving workflow efficiency and reducing manual selection errors.

**Closes #834**

## What's Changed

### New Features
- Copy-to-clipboard buttons on the three most useful audit-log columns:
  - **Timestamp** — copies the exact ISO timestamp (`entry.timestamp`), not the localized display string
  - **Admin Address** — copies the full wallet address
  - **Parameters** — copies the formatted parameter string
- Each button shows a transient "Copied!" success state with an accessible label.

### Files Modified
1. `src/app/admin/page.tsx` — render a `CopyButton` next to the timestamp, admin address and parameters cells
2. `src/components/ui/CopyButton.tsx` — add an optional `ariaLabel` prop (defaults to the previous generic label)
3. `src/app/admin/__tests__/page.test.tsx` — add a `Clipboard copy button (#834)` test suite

## Acceptance Criteria

### ✅ Update `admin/page.tsx` logic
- [x] Copy buttons added to the timestamp, admin address and parameters columns of the audit log table

### ✅ Add unit tests verifying behavior
- [x] Buttons render for all three columns
- [x] Clicking writes the correct value to the clipboard (address, parameters, exact ISO timestamp)
- [x] Success-state icon appears after a successful copy

### ✅ Ensure no regressions in existing frontend UI
- [x] Change is purely additive markup; no existing audit-log behaviour is modified

## Technical Details

### Architecture Decisions
- **Reuse over reinvention:** uses the existing `CopyButton` component instead of introducing a new hook. `CopyButton` already implements the `navigator.clipboard` API with a `document.execCommand` fallback for older browsers and manages its own success state.
- **Accessibility:** `CopyButton` gains an optional `ariaLabel` so each instance is individually labelled (e.g. *"Copy admin address …"*). It defaults to the original `"Copy to clipboard"`, so all existing usages are unchanged.

### Dependencies
**No new external dependencies added** ✅

## How to Test

1. Start the dev server: `npm run dev`
2. Navigate to `/admin` and locate the **Admin Audit Log** table
3. Hover a row and click the copy icon next to the timestamp, admin address or parameters
4. Confirm the value is on your clipboard and the icon briefly shows the "Copied!" success state

### Unit tests
```bash
npm run test:unit -- src/app/admin/__tests__/page.test.tsx
```

## Backward Compatibility
- ✅ No breaking changes
- ✅ No existing APIs or component contracts modified (`ariaLabel` is optional with a default)
- ✅ No new dependencies

## Checklist
- [x] All acceptance criteria met
- [x] Unit tests added and passing
- [x] TypeScript: no new type errors introduced
- [x] ESLint passes on changed files
- [x] No breaking changes
- [x] No new dependencies added
- [x] Existing UI behaviour unchanged