### PR TITLE
feat(contract): implement daily limit validation for validate_withdrawal_quota (#697)

### DIFF
--- a/stellar-contracts/src/lib.rs
+++ b/stellar-contracts/src/lib.rs
@@ -673,6 +673,31 @@ pub struct QuotaResetEvent {
     pub window_start: u32,
 }
 
+/// Event emitted when a withdrawal successfully consumes part of a user's
+/// daily withdrawal quota (issue #697).
+///
+/// Published on the success path of [`enforce_withdrawal_quota`] so off-chain
+/// indexers and monitoring systems can track per-user daily usage in real
+/// time without re-deriving it from raw withdrawals.
+///
+/// # Fields
+/// * `version`      – Event schema version.
+/// * `user`         – The withdrawing user.
+/// * `amount`       – The amount applied to the quota by this withdrawal.
+/// * `accumulated`  – The user's total accumulated withdrawal in the current window.
+/// * `quota`        – The configured daily quota at the time of the withdrawal.
+/// * `window_start` – Ledger sequence at which the current window started.
+#[contractevent]
+#[derive(Clone, Debug)]
+pub struct WithdrawalQuotaConsumedEvent {
+    pub version: u32,
+    pub user: Address,
+    pub amount: i128,
+    pub accumulated: i128,
+    pub quota: i128,
+    pub window_start: u32,
+}
+
 /// Event emitted during escrow storage migration to track progress.
 ///
 /// This event is published after each batch of records is migrated, allowing
@@ -4067,17 +4092,20 @@ impl FiatBridge {
     /// the configured quota.
     ///
     /// # Overflow Prevention
-    /// The running total `record.amount + amount` is computed with plain
-    /// addition after the window-reset branch.  Both values are `i128` and
-    /// bounded by the quota (itself an `i128`), so overflow is not reachable
-    /// in practice.  If the quota were ever set to `i128::MAX` the addition
-    /// could theoretically overflow; a future hardening pass could add
-    /// `checked_add` here for belt-and-suspenders safety.
+    /// The running total is computed with `checked_add` (issue #697), mirroring
+    /// the deposit-side [`enforce_daily_deposit_limit`] hardening (#499). This
+    /// prevents a crafted extremely large withdrawal from wrapping the `i128`
+    /// daily accumulator and bypassing the quota check; an overflow returns
+    /// [`Error::Overflow`].
     ///
     /// # Window Reset
     /// When the current ledger has advanced past `window_start + WINDOW_LEDGERS`
     /// the accumulated amount is reset to zero and the window start is updated.
     /// A [`QuotaResetEvent`] is emitted so off-chain indexers can track resets.
+    ///
+    /// # Usage Tracking
+    /// On the success path a [`WithdrawalQuotaConsumedEvent`] is emitted with the
+    /// newly accumulated total so indexers can track per-user daily usage.
     fn enforce_withdrawal_quota(
         env: &Env,
         user: &Address,
@@ -4114,8 +4142,12 @@ impl FiatBridge {
             .publish(env);
         }
 
-        if record.amount + amount > quota {
-            let excess = record.amount + amount - quota;
+        // #697: use checked_add so a crafted extremely large withdrawal cannot
+        // wrap the i128 daily accumulator and bypass the quota check below.
+        let projected = record.amount.checked_add(amount).ok_or(Error::Overflow)?;
+
+        if projected > quota {
+            let excess = projected - quota;
             // Accrue the excess amount as fee to the vault
             let key = DataKey::FeeVault(token.clone());
             let current: i128 = env.storage().persistent().get(&key).unwrap_or(0);
@@ -4129,10 +4161,21 @@ impl FiatBridge {
             return Err(Error::WithdrawalQuotaExceeded);
         }
 
-        record.amount += amount;
+        record.amount = projected;
         env.storage()
             .instance()
             .set(&DataKey::UserDailyWithdrawal(user.clone()), &record);
+
+        // #697: emit per-user daily usage so indexers can track quota consumption.
+        WithdrawalQuotaConsumedEvent {
+            version: EVENT_VERSION,
+            user: user.clone(),
+            amount,
+            accumulated: record.amount,
+            quota,
+            window_start: record.window_start,
+        }
+        .publish(env);
 
         Ok(())
     }
@@ -5593,3 +5636,6 @@ mod test_issues_492_499;
 
 #[cfg(test)]
 mod test_issues_840;
+
+#[cfg(test)]
+mod test_issue_697;

--- a/stellar-contracts/src/test_issue_697.rs
+++ b/stellar-contracts/src/test_issue_697.rs
@@ -1,0 +1,149 @@
+#![cfg(test)]
+//! Integration tests for issue #697 — daily limit validation in the withdrawal
+//! quota path (`enforce_withdrawal_quota`).
+//!
+//! Covers:
+//! * a withdrawal within the quota succeeding and emitting
+//!   `WithdrawalQuotaConsumedEvent`,
+//! * accumulation across multiple withdrawals up to the exact quota boundary,
+//! * a withdrawal that would exceed the quota being rejected with
+//!   `WithdrawalQuotaExceeded`,
+//! * the 24-hour rolling window resetting (emitting `QuotaResetEvent`) so a
+//!   user can withdraw again in a fresh window.
+
+extern crate std;
+
+use super::*;
+use soroban_sdk::{
+    testutils::{Address as _, Events as _, Ledger},
+    token::StellarAssetClient,
+    vec, Address, Bytes, Env,
+};
+
+fn setup(env: &Env, tx_limit: i128) -> (Address, FiatBridgeClient<'_>, Address, Address, Address) {
+    let contract_id = env.register(FiatBridge, ());
+    let bridge = FiatBridgeClient::new(env, &contract_id);
+    let admin = Address::generate(env);
+    let token_admin = Address::generate(env);
+    let token_addr = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
+    let token_sac = StellarAssetClient::new(env, &token_addr);
+    let signers = vec![env, admin.clone()];
+    bridge.init(&admin, &token_addr, &tx_limit, &1, &signers, &1);
+
+    let user = Address::generate(env);
+    token_sac.mint(&user, &1_000_000);
+
+    (contract_id, bridge, admin, token_addr, user)
+}
+
+/// Returns true if any event emitted by `contract_id` has `name` as its first
+/// topic symbol. Mirrors the topic-matching approach used elsewhere in the
+/// suite (e.g. the migration-check test).
+fn event_emitted(env: &Env, contract_id: &Address, name: &str) -> bool {
+    let events = env.events().all().filter_by_contract(contract_id);
+    events.events().iter().any(|e| {
+        // `ContractEventBody` currently has a single `V0` variant, so this
+        // destructure is irrefutable.
+        let soroban_sdk::xdr::ContractEventBody::V0(body) = &e.body;
+        !body.topics.is_empty()
+            && matches!(
+                &body.topics[0],
+                soroban_sdk::xdr::ScVal::Symbol(sym)
+                    if std::str::from_utf8(sym.0.as_slice()).unwrap() == name
+            )
+    })
+}
+
+#[test]
+fn test_withdrawal_within_quota_succeeds_and_emits_consumed_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, bridge, admin, token_addr, user) = setup(&env, 10_000);
+    bridge.set_withdrawal_quota(&2_000);
+
+    // Fund the bridge escrow so withdrawals have liquidity.
+    bridge.deposit(&user, &6_000, &token_addr, &Bytes::new(&env), &0, &0, &None);
+
+    // A withdrawal comfortably within the quota succeeds.
+    bridge.withdraw(&admin, &user, &500, &token_addr);
+
+    // Check the event before any further contract call, since the test env's
+    // event buffer reflects the most recent invocation (and the getter below
+    // is itself an invocation).
+    assert!(event_emitted(
+        &env,
+        &contract_id,
+        "withdrawal_quota_consumed_event"
+    ));
+    assert_eq!(bridge.get_user_daily_withdrawal(&user), 500);
+}
+
+#[test]
+fn test_withdrawals_accumulate_up_to_exact_quota_boundary() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_id, bridge, admin, token_addr, user) = setup(&env, 10_000);
+    bridge.set_withdrawal_quota(&2_000);
+    bridge.deposit(&user, &6_000, &token_addr, &Bytes::new(&env), &0, &0, &None);
+
+    // 1_500 + 500 == 2_000 (exactly the quota) is allowed.
+    bridge.withdraw(&admin, &user, &1_500, &token_addr);
+    bridge.withdraw(&admin, &user, &500, &token_addr);
+    assert_eq!(bridge.get_user_daily_withdrawal(&user), 2_000);
+
+    // One stroop over the quota is rejected and the accumulator is unchanged.
+    let res = bridge.try_withdraw(&admin, &user, &1, &token_addr);
+    assert_eq!(res, Err(Ok(Error::WithdrawalQuotaExceeded)));
+    assert_eq!(bridge.get_user_daily_withdrawal(&user), 2_000);
+}
+
+#[test]
+fn test_withdrawal_exceeding_quota_is_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_id, bridge, admin, token_addr, user) = setup(&env, 10_000);
+    bridge.set_withdrawal_quota(&2_000);
+    bridge.deposit(&user, &6_000, &token_addr, &Bytes::new(&env), &0, &0, &None);
+
+    let res = bridge.try_withdraw(&admin, &user, &2_001, &token_addr);
+    assert_eq!(res, Err(Ok(Error::WithdrawalQuotaExceeded)));
+    // Rejected withdrawal must not consume any quota.
+    assert_eq!(bridge.get_user_daily_withdrawal(&user), 0);
+}
+
+#[test]
+fn test_quota_window_resets_after_24h() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, bridge, admin, token_addr, user) = setup(&env, 10_000);
+    bridge.set_withdrawal_quota(&2_000);
+    bridge.deposit(
+        &user,
+        &10_000,
+        &token_addr,
+        &Bytes::new(&env),
+        &0,
+        &0,
+        &None,
+    );
+
+    // Consume most of the quota in the first window.
+    bridge.withdraw(&admin, &user, &1_800, &token_addr);
+    assert_eq!(bridge.get_user_daily_withdrawal(&user), 1_800);
+
+    // Advance just past the 24-hour rolling window (WINDOW_LEDGERS ≈ 17_280).
+    env.ledger()
+        .with_mut(|l| l.sequence_number += WINDOW_LEDGERS + 1);
+
+    // The window has lapsed, so a fresh full-quota withdrawal succeeds and a
+    // QuotaResetEvent is emitted. Check the event before the getter call.
+    bridge.withdraw(&admin, &user, &1_800, &token_addr);
+    assert!(event_emitted(&env, &contract_id, "quota_reset_event"));
+    assert_eq!(bridge.get_user_daily_withdrawal(&user), 1_800);
+}


### PR DESCRIPTION
# Pull Request: Daily Limit Validation for Withdrawal Quota

## Description

Hardens the withdrawal-quota daily-limit validation (`enforce_withdrawal_quota`, the function referenced as `validate_withdrawal_quota` in the issue and the existing migration test) and adds an on-chain usage signal for monitoring.

**Closes #697**

## What's Changed

### Smart Contract (`src/lib.rs`)
- **Overflow-safe accumulation:** the per-user daily accumulator now uses `checked_add` and returns `Error::Overflow`, mirroring the deposit-side `enforce_daily_deposit_limit` hardening (#499). This resolves the function's own documented TODO and prevents a crafted extremely large withdrawal from wrapping the `i128` accumulator and bypassing the quota check.
- **New `WithdrawalQuotaConsumedEvent`** emitted on the success path with `{ user, amount, accumulated, quota, window_start }`, so off-chain indexers and monitoring can track per-user daily usage in real time without re-deriving it from raw withdrawals.

### Tests (`src/test_issue_697.rs`)
New integration test module covering:
- withdrawal within quota → succeeds and emits `WithdrawalQuotaConsumedEvent`
- multiple withdrawals accumulating up to the **exact** quota boundary (and one stroop over being rejected)
- withdrawal exceeding the quota → `WithdrawalQuotaExceeded`, accumulator unchanged
- 24-hour rolling window lapsing → `QuotaResetEvent` emitted, fresh quota available

## Acceptance Criteria

### ✅ Modify `validate_withdrawal_quota` functionality safely
- [x] `checked_add` overflow protection added (no behaviour change for valid amounts; window reset and quota semantics preserved)

### ✅ Emit relevant updated events
- [x] `WithdrawalQuotaConsumedEvent` emitted on each successful quota consumption

### ✅ Add integration tests covering the new behavior
- [x] 4 integration tests (within-limit + event, exact-boundary accumulation, over-limit rejection, 24h window reset)

## Technical Details

### Design Notes
- Events are emitted on the **success** path only. A rejected withdrawal returns `Err(WithdrawalQuotaExceeded)`, and Soroban rolls back all state/events on error, so emitting a "limit exceeded" event there would have no observable effect.
- The pre-existing excess-fee-accrual branch is left untouched to keep this change focused; the `checked_add` result feeds its `excess` computation safely.

### Dependencies
**No new dependencies added** ✅

## How to Test
```bash
cd stellar-contracts
cargo test test_issue_697
cargo clippy --all-targets --all-features -- -D warnings   # clean for the changed code
cargo build --target wasm32-unknown-unknown --release
```

## Backward Compatibility
- ✅ No breaking changes; public API unchanged
- ✅ Quota/window semantics for valid withdrawals are identical
- ✅ Additive event only

## Checklist
- [x] All acceptance criteria met
- [x] Integration tests added and passing (4/4)
- [x] No new test regressions (full suite: same pre-existing failures before and after; +4 passing)
- [x] Changed code is clippy-clean
- [x] No new dependencies