### PR TITLE
fix(frontend): resolve hydration mismatch in ChatInput.tsx (#607)

### DIFF
--- a/dex_with_fiat_frontend/src/components/ChatInput.tsx
+++ b/dex_with_fiat_frontend/src/components/ChatInput.tsx
@@ -32,9 +32,19 @@ export default function ChatInput({
   const { t } = useTranslation();
   const { connection } = useStellarWallet();
   const activePlaceholder = placeholder || t('chat.placeholder');
-  const isApplePlatform =
-    typeof navigator !== 'undefined' &&
-    /(Mac|iPhone|iPad|iPod)/i.test(navigator.platform);
+  // Detect the platform after mount rather than during render. Reading
+  // `navigator` during render makes the server (no navigator → false) and an
+  // Apple client (true) disagree, which produces a hydration mismatch on the
+  // shortcut label/aria attributes. Defaulting to the SSR-safe value and
+  // updating in an effect keeps the first client render identical to the
+  // server markup. (#607)
+  const [isApplePlatform, setIsApplePlatform] = useState(false);
+  useEffect(() => {
+    setIsApplePlatform(
+      typeof navigator !== 'undefined' &&
+        /(Mac|iPhone|iPad|iPod)/i.test(navigator.platform),
+    );
+  }, []);
   const submitShortcutLabel = isApplePlatform ? 'Cmd+Enter' : 'Ctrl+Enter';
   const submitShortcutKeys = isApplePlatform ? 'Meta+Enter' : 'Control+Enter';
   const [message, setMessage] = useState('');

--- a/dex_with_fiat_frontend/src/components/__tests__/ChatInput.hydration.test.tsx
+++ b/dex_with_fiat_frontend/src/components/__tests__/ChatInput.hydration.test.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import '@testing-library/jest-dom';
+import ChatInput from '../ChatInput';
+
+// Regression tests for issue #607 — the shortcut label must not be derived
+// from `navigator` during render, otherwise the server markup (no Apple
+// platform) and the first client render on an Apple device disagree and React
+// reports a hydration mismatch. The platform is now detected in an effect, so
+// the initial render is always the SSR-safe "Ctrl+Enter".
+
+const mockWalletContext = {
+  connection: {
+    address: '',
+    publicKey: '',
+    isConnected: true,
+    network: '',
+    networkPassphrase: '',
+  },
+  accounts: [],
+  selectedAccountIndex: 0,
+  selectAccount: vi.fn(),
+  connect: vi.fn(),
+  disconnect: vi.fn(),
+  signTx: vi.fn(),
+  isFreighterInstalled: false,
+  isLoading: false,
+  error: null,
+  sessionExpired: false,
+  clearSessionExpired: vi.fn(),
+  mockConnect: vi.fn(),
+  isNetworkMismatch: false,
+};
+
+vi.mock('@/contexts/StellarWalletContext', () => ({
+  useStellarWallet: () => mockWalletContext,
+}));
+
+vi.mock('@/contexts/TranslationContext', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/lib/draftUtils', () => ({
+  saveDraft: vi.fn(),
+  getDraft: vi.fn(() => ''),
+  clearDraft: vi.fn(),
+}));
+
+const defaultProps = {
+  onSendMessage: vi.fn(),
+  isLoading: false,
+  placeholder: 'Type a message...',
+};
+
+function setPlatform(platform: string) {
+  Object.defineProperty(window.navigator, 'platform', {
+    value: platform,
+    configurable: true,
+  });
+}
+
+describe('ChatInput - hydration safety of platform shortcut label (#607)', () => {
+  const originalPlatform = window.navigator.platform;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    setPlatform(originalPlatform);
+  });
+
+  it('server-renders the SSR-safe Ctrl+Enter label even on an Apple platform', () => {
+    // Simulate an Apple client. Before the fix, reading navigator during render
+    // made the initial render produce "Cmd+Enter", mismatching the server HTML.
+    setPlatform('MacIntel');
+
+    const markup = renderToString(<ChatInput {...defaultProps} />);
+
+    expect(markup).toContain('Ctrl+Enter');
+    expect(markup).not.toContain('Cmd+Enter');
+  });
+
+  it('upgrades to the Apple label after mount on an Apple platform', async () => {
+    setPlatform('MacIntel');
+
+    render(<ChatInput {...defaultProps} />);
+
+    // After the post-mount effect runs, the client shows the Apple shortcut.
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: /send message \(Cmd\+Enter\)/i }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('keeps the Ctrl+Enter label on a non-Apple platform', async () => {
+    setPlatform('Win32');
+
+    render(<ChatInput {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: /send message \(Ctrl\+Enter\)/i }),
+      ).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
# Pull Request: Fix Hydration Mismatch in ChatInput

## Description

Resolves the intermittent hydration-mismatch glitch in the chat input reported in #607.

**Closes #607**

## Root Cause

The submit-shortcut label was computed from `navigator.platform` **during render**:

```tsx
const isApplePlatform =
  typeof navigator !== 'undefined' &&
  /(Mac|iPhone|iPad|iPod)/i.test(navigator.platform);
const submitShortcutLabel = isApplePlatform ? 'Cmd+Enter' : 'Ctrl+Enter';
```

During SSR `navigator` is undefined, so the server renders **"Ctrl+Enter"**. On an Apple client the first render computes **"Cmd+Enter"**. That value is baked into the submit button's `title`, `aria-label`, `aria-keyshortcuts` and the sr-only hint, so the server markup and the first client render disagree — a React **hydration mismatch**.

## What's Changed

### `src/components/ChatInput.tsx`
- Default `isApplePlatform` to the SSR-safe `false` and detect the real platform in a post-mount `useEffect`. The initial client render now matches the server markup ("Ctrl+Enter"); the Apple label ("Cmd+Enter") is applied only after hydration.

### `src/components/__tests__/ChatInput.hydration.test.tsx`
- New regression test:
  - `renderToString` yields **"Ctrl+Enter"** (not "Cmd+Enter") even when `navigator.platform` is an Apple value — i.e. the render no longer depends on `navigator`.
  - after mount on an Apple platform the button label upgrades to **"Cmd+Enter"**, and stays **"Ctrl+Enter"** on non-Apple platforms.

## Acceptance Criteria
- [x] Investigate and fix the state/rendering issue in `ChatInput.tsx`
- [x] Write a regression test targeting the fix

## How to Test
```bash
cd dex_with_fiat_frontend
npm run test:unit -- src/components/__tests__/ChatInput.hydration.test.tsx
```

## Backward Compatibility
- ✅ No API changes; Apple users still get the `Cmd+Enter` label/shortcut after mount
- ✅ Keyboard handling (`metaKey || ctrlKey`) is unchanged — both shortcuts continue to work
- ✅ No new dependencies

## Checklist
- [x] Acceptance criteria met
- [x] Regression test added and passing (3/3)
- [x] No new TypeScript errors / ESLint clean on changed files