### PR TITLE
fix(frontend): resolve issues #945, #952, #953, #954 — null-ref, IBAN validation, stale fees, sort pagination

### DIFF
--- a/Dechat/dex_with_fiat_frontend/src/components/AuditTable.tsx
+++ b/Dechat/dex_with_fiat_frontend/src/components/AuditTable.tsx
@@ -7,6 +7,9 @@ import { useToast } from '@/hooks/useToast';
 import Skeleton from '@/components/ui/skeleton/Skeleton';
 import { withNetworkReadQueue, subscribeToQueue } from '@/lib/networkQueue';
 
+type SortKey = 'timestamp' | 'adminAddress' | 'actionType' | 'status';
+type SortOrder = 'asc' | 'desc';
+
 interface AuditTableProps {
   onRefresh?: () => void;
 }
@@ -26,6 +29,8 @@ export default function AuditTable({}: AuditTableProps) {
   const [error, setError] = useState<string | null>(null);
   const [totalEntries, setTotalEntries] = useState(0);
   const [currentPage, setCurrentPage] = useState(0);
+  const [sortKey, setSortKey] = useState<SortKey>('timestamp');
+  const [sortOrder, setSortOrder] = useState<SortOrder>('desc');
   const [filters, setFilters] = useState<FilterState>({
     actionType: '',
     status: '',
@@ -69,6 +74,8 @@ export default function AuditTable({}: AuditTableProps) {
 
       params.append('limit', pageSize.toString());
       params.append('offset', (currentPage * pageSize).toString());
+      params.append('sortKey', sortKey);
+      params.append('sortOrder', sortOrder);
 
       const url = `/api/admin-audit?${params.toString()}`;
 
@@ -104,7 +111,7 @@ export default function AuditTable({}: AuditTableProps) {
         setLoading(false);
       }
     }
-  }, [filters, currentPage]);
+  }, [filters, currentPage, sortKey, sortOrder]);
 
   useEffect(() => {
     void fetchAuditEntries();
@@ -157,6 +164,32 @@ export default function AuditTable({}: AuditTableProps) {
       endDate: '',
     });
     setCurrentPage(0);
+  };
+
+  // Toggling sort order on the same column or switching to a new column must
+  // NOT reset the page — the user may intentionally be reading page 3 and want
+  // to flip the sort direction without losing their position.
+  const handleSortChange = (key: SortKey) => {
+    if (key === sortKey) {
+      setSortOrder((prev) => (prev === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortKey(key);
+      setSortOrder('asc');
+    }
+  };
+
+  const SortIndicator = ({ column }: { column: SortKey }) => {
+    if (sortKey !== column) {
+      return <span className="ml-1 text-gray-500" aria-hidden="true">↕</span>;
+    }
+    return (
+      <span
+        className="ml-1 text-blue-400"
+        aria-label={sortOrder === 'asc' ? 'sorted ascending' : 'sorted descending'}
+      >
+        {sortOrder === 'asc' ? '↑' : '↓'}
+      </span>
+    );
   };
 
   const formatTimestamp = (date: Date) => {
@@ -403,13 +436,34 @@ export default function AuditTable({}: AuditTableProps) {
             <thead className="bg-gray-50 dark:bg-gray-700 border-b border-gray-200 dark:border-gray-600">
               <tr>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-700 dark:text-gray-300 uppercase tracking-wider">
-                  Timestamp
+                  <button
+                    type="button"
+                    onClick={() => handleSortChange('timestamp')}
+                    className="flex items-center hover:text-blue-500 transition-colors"
+                    aria-label="Sort by Timestamp"
+                  >
+                    Timestamp <SortIndicator column="timestamp" />
+                  </button>
                 </th>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-700 dark:text-gray-300 uppercase tracking-wider">
-                  Admin
+                  <button
+                    type="button"
+                    onClick={() => handleSortChange('adminAddress')}
+                    className="flex items-center hover:text-blue-500 transition-colors"
+                    aria-label="Sort by Admin"
+                  >
+                    Admin <SortIndicator column="adminAddress" />
+                  </button>
                 </th>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-700 dark:text-gray-300 uppercase tracking-wider">
-                  Action
+                  <button
+                    type="button"
+                    onClick={() => handleSortChange('actionType')}
+                    className="flex items-center hover:text-blue-500 transition-colors"
+                    aria-label="Sort by Action"
+                  >
+                    Action <SortIndicator column="actionType" />
+                  </button>
                 </th>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-700 dark:text-gray-300 uppercase tracking-wider">
                   Description
@@ -418,7 +472,14 @@ export default function AuditTable({}: AuditTableProps) {
                   TX Hash
                 </th>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-700 dark:text-gray-300 uppercase tracking-wider">
-                  Status
+                  <button
+                    type="button"
+                    onClick={() => handleSortChange('status')}
+                    className="flex items-center hover:text-blue-500 transition-colors"
+                    aria-label="Sort by Status"
+                  >
+                    Status <SortIndicator column="status" />
+                  </button>
                 </th>
               </tr>
             </thead>

--- a/Dechat/dex_with_fiat_frontend/src/components/BankDetailsModal.tsx
+++ b/Dechat/dex_with_fiat_frontend/src/components/BankDetailsModal.tsx
@@ -34,10 +34,39 @@ import { getOrCreateClientSessionId } from '@/lib/clientSession';
 import { chatTelemetry } from '@/lib/chatTelemetry';
 import { z } from 'zod';
 
+/** ISO 13616 MOD-97 check used by the IBAN standard. */
+function validateIbanMod97(iban: string): boolean {
+  // Move first 4 chars to end, convert letters to digits (A=10…Z=35), then MOD 97.
+  const rearranged = iban.slice(4) + iban.slice(0, 4);
+  const numeric = rearranged
+    .toUpperCase()
+    .split('')
+    .map((ch) => {
+      const code = ch.charCodeAt(0);
+      return code >= 65 && code <= 90 ? String(code - 55) : ch;
+    })
+    .join('');
+  // BigInt handles the 30+ digit number without loss of precision.
+  return BigInt(numeric) % 97n === 1n;
+}
+
 export const bankDetailsSchema = z.object({
   accountNumber: z
     .string()
     .regex(/^\d{10}$/, 'Account number must be exactly 10 digits'),
+  iban: z
+    .string()
+    .optional()
+    .refine(
+      (val) => {
+        if (!val || val.trim() === '') return true; // optional field
+        const cleaned = val.replace(/\s+/g, '').toUpperCase();
+        // Basic format: 2 letters + 2 digits + 11-30 alphanumeric chars (total 15-34)
+        if (!/^[A-Z]{2}\d{2}[A-Z0-9]{11,30}$/.test(cleaned)) return false;
+        return validateIbanMod97(cleaned);
+      },
+      { message: 'Invalid IBAN — please check the format and check digits' },
+    ),
   saveCustomName: z
     .string()
     .max(50, 'Beneficiary name must be less than 50 characters')
@@ -175,6 +204,9 @@ export default function BankDetailsModal({
 
   // Step 2 - account details
   const [accountNumber, setAccountNumber] = useState('');
+  const [iban, setIban] = useState('');
+  const [ibanError, setIbanError] = useState('');
+  const [ibanTouched, setIbanTouched] = useState(false);
   const [verifying, setVerifying] = useState(false);
   const [verifyError, setVerifyError] = useState('');
   const [verifiedAccount, setVerifiedAccount] =
@@ -302,6 +334,25 @@ export default function BankDetailsModal({
     b.name.toLowerCase().includes(bankSearch.toLowerCase()),
   );
 
+  const validateIban = (value: string): string => {
+    const result = bankDetailsSchema
+      .pick({ iban: true })
+      .safeParse({ iban: value });
+    return result.success ? '' : (result.error.issues[0]?.message ?? 'Invalid IBAN');
+  };
+
+  const handleIbanChange = (value: string) => {
+    setIban(value);
+    if (ibanTouched) {
+      setIbanError(validateIban(value));
+    }
+  };
+
+  const handleIbanBlur = () => {
+    setIbanTouched(true);
+    setIbanError(validateIban(iban));
+  };
+
   const handleVerifyAccount = useCallback(async () => {
     if (!accountNumber || !selectedBank) return;
 
@@ -311,6 +362,18 @@ export default function BankDetailsModal({
     if (!validation.success) {
       setVerifyError(validation.error.issues[0].message);
       return;
+    }
+
+    // Validate IBAN if the user filled it in
+    if (iban.trim()) {
+      const ibanValidation = bankDetailsSchema
+        .pick({ iban: true })
+        .safeParse({ iban });
+      if (!ibanValidation.success) {
+        setIbanError(ibanValidation.error.issues[0]?.message ?? 'Invalid IBAN');
+        setIbanTouched(true);
+        return;
+      }
     }
 
     setVerifying(true);
@@ -357,7 +420,7 @@ export default function BankDetailsModal({
     } finally {
       setVerifying(false);
     }
-  }, [accountNumber, selectedBank, xlmAmount]);
+  }, [accountNumber, iban, ibanTouched, selectedBank, xlmAmount]);
 
   const handleConfirmPayout = async () => {
     if (
@@ -512,6 +575,9 @@ export default function BankDetailsModal({
     setBankSearch('');
     setSelectedBank(null);
     setAccountNumber('');
+    setIban('');
+    setIbanError('');
+    setIbanTouched(false);
     setVerifying(false);
     setVerifyError('');
     setVerifiedAccount(null);
@@ -878,6 +944,51 @@ export default function BankDetailsModal({
                     placeholder="0000000000"
                     className="w-full bg-gray-800 border border-gray-600 rounded-lg px-4 py-3 text-white placeholder-gray-500 focus:outline-none focus:border-blue-500"
                   />
+                </div>
+
+                <div className="mb-3">
+                  <label className="block text-sm text-gray-400 mb-1">
+                    IBAN{' '}
+                    <span className="text-gray-500 text-xs">(optional — for international transfers)</span>
+                  </label>
+                  <input
+                    type="text"
+                    value={iban}
+                    onChange={(e) => handleIbanChange(e.target.value)}
+                    onBlur={handleIbanBlur}
+                    placeholder="GB29 NWBK 6016 1331 9268 19"
+                    aria-describedby={ibanError ? 'iban-error' : undefined}
+                    aria-invalid={ibanTouched && !!ibanError}
+                    className={`w-full bg-gray-800 border rounded-lg px-4 py-3 text-white placeholder-gray-500 focus:outline-none uppercase tracking-widest text-sm ${
+                      ibanTouched && ibanError
+                        ? 'border-red-500 focus:border-red-500'
+                        : ibanTouched && iban && !ibanError
+                          ? 'border-green-500 focus:border-green-500'
+                          : 'border-gray-600 focus:border-blue-500'
+                    }`}
+                  />
+                  {ibanTouched && ibanError && (
+                    <motion.p
+                      id="iban-error"
+                      role="alert"
+                      initial={{ opacity: 0, y: -4 }}
+                      animate={{ opacity: 1, y: 0 }}
+                      className="flex items-center gap-1 mt-1 text-xs text-red-400"
+                    >
+                      <AlertCircle className="w-3 h-3 flex-shrink-0" />
+                      {ibanError}
+                    </motion.p>
+                  )}
+                  {ibanTouched && iban && !ibanError && (
+                    <motion.p
+                      initial={{ opacity: 0, y: -4 }}
+                      animate={{ opacity: 1, y: 0 }}
+                      className="flex items-center gap-1 mt-1 text-xs text-green-400"
+                    >
+                      <CheckCircle className="w-3 h-3 flex-shrink-0" />
+                      IBAN format valid
+                    </motion.p>
+                  )}
                 </div>
 
                 {verifying && (

--- a/Dechat/dex_with_fiat_frontend/src/components/CCIPBridgeModal.tsx
+++ b/Dechat/dex_with_fiat_frontend/src/components/CCIPBridgeModal.tsx
@@ -26,6 +26,13 @@ export interface CCIPBridgeModalProps {
   fetchTransferStatus: (transactionHash: string) => Promise<CCIPStatusResult>;
   pollIntervalMs?: number;
   timeoutMs?: number;
+  /**
+   * Currently selected network identifier (chain ID or name).
+   * When this value changes the modal immediately invalidates any in-progress
+   * fee estimate or polling state so stale data from the previous network is
+   * never shown to the user.
+   */
+  network?: string | number;
 }
 
 export default function CCIPBridgeModal({
@@ -35,6 +42,7 @@ export default function CCIPBridgeModal({
   fetchTransferStatus,
   pollIntervalMs = CCIP_POLL_INTERVAL_MS,
   timeoutMs = CCIP_POLL_TIMEOUT_MS,
+  network,
 }: CCIPBridgeModalProps) {
   const modalRef = useRef<HTMLDivElement>(null);
   const pollingStartedAtRef = useRef<number | null>(null);
@@ -47,6 +55,7 @@ export default function CCIPBridgeModal({
   const [explorerUrl, setExplorerUrl] = useState('');
   const [latestStatus, setLatestStatus] = useState<string>('');
   const [errorMessage, setErrorMessage] = useState('');
+  const [networkChangedWhileActive, setNetworkChangedWhileActive] = useState(false);
 
   // Keep ref in sync with state.
   useEffect(() => {
@@ -63,6 +72,7 @@ export default function CCIPBridgeModal({
     setExplorerUrl('');
     setLatestStatus('');
     setErrorMessage('');
+    setNetworkChangedWhileActive(false);
   }, []);
 
   useEffect(() => {
@@ -70,6 +80,32 @@ export default function CCIPBridgeModal({
       resetState();
     }
   }, [isOpen, resetState]);
+
+  // Fix #954: immediately invalidate in-progress state when the network changes
+  // so the stale fee estimate / polling result from the previous network is never
+  // visible to the user.  Skip the very first render (network undefined → value).
+  const prevNetworkRef = useRef(network);
+  useEffect(() => {
+    const prev = prevNetworkRef.current;
+    prevNetworkRef.current = network;
+
+    // Only act if the network actually changed (not just on first mount).
+    if (prev === undefined || prev === network) return;
+
+    if (bridgeState !== 'idle' && bridgeState !== 'success') {
+      // Reset fee/status display immediately; keep bridgeState readable so
+      // we can show the "network changed" notice.
+      setLatestStatus('');
+      setExplorerUrl('');
+      setNetworkChangedWhileActive(true);
+      // Abort any outstanding polling by resetting to idle.
+      pollingStartedAtRef.current = null;
+      transactionHashRef.current = '';
+      setBridgeState('idle');
+      setTransactionHash('');
+      setErrorMessage('');
+    }
+  }, [network, bridgeState]);
 
   const handleStartTransfer = useCallback(async () => {
     // Immediately show optimistic UI
@@ -239,10 +275,25 @@ export default function CCIPBridgeModal({
           </button>
         </div>
 
+        {networkChangedWhileActive && (
+          <div
+            role="alert"
+            aria-live="polite"
+            className="mb-4 flex items-center gap-2 rounded-lg border border-yellow-500/40 bg-yellow-500/10 px-3 py-2 text-xs text-yellow-700 dark:text-yellow-400"
+          >
+            <AlertCircle className="h-4 w-4 flex-shrink-0" />
+            Network changed — fee estimate cleared. Start a new transfer on the
+            current network.
+          </div>
+        )}
+
         {bridgeState === 'idle' && (
           <button
             type="button"
-            onClick={() => void handleStartTransfer()}
+            onClick={() => {
+              setNetworkChangedWhileActive(false);
+              void handleStartTransfer();
+            }}
             className="theme-primary-button w-full py-3 rounded-lg font-medium"
           >
             Start CCIP Transfer

--- a/Dechat/dex_with_fiat_frontend/src/components/WalletConnectionTimeline.tsx
+++ b/Dechat/dex_with_fiat_frontend/src/components/WalletConnectionTimeline.tsx
@@ -1,46 +1,93 @@
 'use client';
 
+import { useEffect, useRef } from 'react';
+
 interface WalletConnectionTimelineProps {
   isConnected: boolean;
   isNetworkMismatch: boolean;
   isConnecting: boolean;
+  /** When true, the wallet disconnected while a transfer was active. */
+  transferInProgress?: boolean;
   contextMode?: 'simple' | 'advanced';
   onRetry?: () => void;
+  /** Called once when the wallet drops while transferInProgress is true. */
+  onDisconnectMidTransfer?: () => void;
 }
 
 type TimelineStep = {
   id: string;
   label: string;
   status: 'done' | 'active' | 'pending' | 'error';
+  detail?: string;
 };
 
 export default function WalletConnectionTimeline({
   isConnected,
   isNetworkMismatch,
   isConnecting,
+  transferInProgress = false,
   contextMode = 'simple',
   onRetry,
+  onDisconnectMidTransfer,
 }: WalletConnectionTimelineProps) {
+  // Detect wallet drop mid-transfer: was connected on the previous render,
+  // now disconnected while a transfer was still active.
+  const wasConnectedRef = useRef(isConnected);
+  useEffect(() => {
+    const wasConnected = wasConnectedRef.current;
+    wasConnectedRef.current = isConnected;
+
+    if (wasConnected && !isConnected && transferInProgress) {
+      onDisconnectMidTransfer?.();
+    }
+  }, [isConnected, transferInProgress, onDisconnectMidTransfer]);
+
+  // Defensive guard: treat any falsy prop values as their safe defaults so the
+  // component never throws even if a parent passes null/undefined.
+  const connected = Boolean(isConnected);
+  const mismatch = Boolean(isNetworkMismatch);
+  const connecting = Boolean(isConnecting);
+  const midTransferDisconnect = !connected && transferInProgress;
+
   const steps: TimelineStep[] = [
     {
       id: 'connect',
       label: 'Connect wallet',
-      status: isConnected ? 'done' : isConnecting ? 'active' : 'pending',
+      status: midTransferDisconnect
+        ? 'error'
+        : connected
+          ? 'done'
+          : connecting
+            ? 'active'
+            : 'pending',
+      detail: midTransferDisconnect ? 'Wallet disconnected during transfer' : undefined,
     },
     {
       id: 'sign',
       label: 'Sign session',
-      status: isConnected ? 'done' : isConnecting ? 'active' : 'pending',
+      status: midTransferDisconnect
+        ? 'error'
+        : connected
+          ? 'done'
+          : connecting
+            ? 'active'
+            : 'pending',
     },
     {
       id: 'verify',
       label: 'Verify network',
-      status: isConnected && isNetworkMismatch ? 'error' : isConnected ? 'done' : 'pending',
+      status: midTransferDisconnect
+        ? 'pending'
+        : connected && mismatch
+          ? 'error'
+          : connected
+            ? 'done'
+            : 'pending',
     },
     {
       id: 'ready',
       label: 'Ready',
-      status: isConnected && !isNetworkMismatch ? 'done' : 'pending',
+      status: connected && !mismatch && !midTransferDisconnect ? 'done' : 'pending',
     },
   ];
 
@@ -51,29 +98,49 @@ export default function WalletConnectionTimeline({
       <div className="theme-text-muted mb-2 text-[10px] font-bold uppercase tracking-widest">
         Wallet connection timeline
       </div>
+
+      {midTransferDisconnect && (
+        <div
+          role="alert"
+          aria-live="assertive"
+          className="mb-2 rounded-lg border border-red-500/40 bg-red-500/10 px-3 py-2 text-xs text-red-600 dark:text-red-400"
+        >
+          Wallet disconnected mid-transfer. Please reconnect and retry.
+        </div>
+      )}
+
       <ol className="space-y-2" aria-label="Wallet connection timeline">
         {visibleSteps.map((step) => (
-          <li key={step.id} className="flex items-center gap-2 text-xs">
-            <span
-              className={`inline-block h-2.5 w-2.5 rounded-full ${
-                step.status === 'done'
-                  ? 'bg-green-500'
-                  : step.status === 'active'
-                    ? 'bg-blue-500 animate-pulse'
-                    : step.status === 'error'
-                      ? 'bg-red-500'
-                      : 'bg-gray-500'
-              }`}
-            />
-            <span className="theme-text-secondary">{step.label}</span>
+          <li key={step.id} className="flex flex-col gap-0.5">
+            <div className="flex items-center gap-2 text-xs">
+              <span
+                aria-hidden="true"
+                className={`inline-block h-2.5 w-2.5 flex-shrink-0 rounded-full ${
+                  step.status === 'done'
+                    ? 'bg-green-500'
+                    : step.status === 'active'
+                      ? 'animate-pulse bg-blue-500'
+                      : step.status === 'error'
+                        ? 'bg-red-500'
+                        : 'bg-gray-500'
+                }`}
+              />
+              <span className="theme-text-secondary">{step.label}</span>
+            </div>
+            {step.detail && (
+              <p className="pl-[18px] text-[10px] text-red-500 dark:text-red-400">
+                {step.detail}
+              </p>
+            )}
           </li>
         ))}
       </ol>
-      {isNetworkMismatch && onRetry && (
+
+      {(mismatch || midTransferDisconnect) && onRetry && (
         <button
           type="button"
           onClick={onRetry}
-          className="mt-3 w-full rounded-lg border border-red-500/40 px-3 py-2 text-xs font-medium text-red-700 dark:text-red-400 hover:bg-red-100 dark:hover:bg-red-900/40"
+          className="mt-3 w-full rounded-lg border border-red-500/40 px-3 py-2 text-xs font-medium text-red-700 hover:bg-red-100 dark:text-red-400 dark:hover:bg-red-900/40"
         >
           Retry wallet connection
         </button>


### PR DESCRIPTION
## Summary

Fixes four frontend bugs across the DEX Chat UI:

- **#945** `WalletConnectionTimeline` — null reference crash on wallet disconnect mid-transfer
- **#952** `AuditTable` — pagination resets to page 1 when sorting a column
- **#953** `BankDetailsModal` — no IBAN format validation before submission
- **#954** `CCIPBridgeModal` — stale fee estimate shown after network switch

---
Closes #945 
Closes #952 
Closes #953 
Closes #954 

## Changes

### fix(#945) — WalletConnectionTimeline: graceful degradation on mid-transfer disconnect

- Add `transferInProgress` and `onDisconnectMidTransfer` props
- A `useEffect` ref comparison detects the exact render where `isConnected` flips `false` while a transfer is active and fires `onDisconnectMidTransfer` once
- All boolean props are coerced with `Boolean()` so `null`/`undefined` from a parent never reaches property-access code
- Renders a `role="alert"` banner with clear reconnect guidance; step dots switch to error state; Retry button appears

### fix(#952) — AuditTable: preserve page position on column sort

- Add `SortKey` / `SortOrder` types and `sortKey` / `sortOrder` state (default: `timestamp desc`)
- `handleSortChange()` toggles order on the same column or switches column — **does not call `setCurrentPage(0)`** so position is preserved
- `SortIndicator` component renders ↕ / ↑ / ↓ with ARIA labels
- Timestamp, Admin, Action, Status headers are now `<button>` elements; `sortKey` + `sortOrder` appended to the API params

### fix(#953) — BankDetailsModal: client-side IBAN validation

- Add `validateIbanMod97()` using `BigInt` for precision-safe MOD-97 calculation per ISO 13616
- Extend `bankDetailsSchema` with an optional `iban` field: format regex check + MOD-97 refine
- Add `iban` / `ibanError` / `ibanTouched` state; inline `SortIndicator`-style feedback (green ✓ / red ✗)
- `handleVerifyAccount` blocks API call when IBAN is filled but invalid; state resets on modal close

### fix(#954) — CCIPBridgeModal: invalidate stale fee on network switch

- Accept optional `network?: string | number` prop
- `useEffect` compares previous vs current network via ref; on change during an active bridge state: clears `latestStatus`, `explorerUrl`, aborts polling (resets to `idle`)
- Shows a yellow `role="alert"` banner explaining the reset; dismissed when the user starts a new transfer

## Test plan

- [ ] #945: Connect wallet, start a transfer, disconnect wallet — expect banner + error steps, no crash; Retry button appears
- [ ] #952: Navigate to audit page 3, click a column header — expect same page remains, sort indicator flips; change to different column — expect order resets to asc, page stays
- [ ] #953: Enter valid IBAN (e.g. `GB29NWBK60161331926819`) → green checkmark; enter invalid IBAN → red error; leave blank → no error; form blocks submission on invalid
- [ ] #954: Open CCIP modal, start transfer, switch network while polling — expect fee cleared immediately and yellow banner shown; new transfer on new network works normally