### PR TITLE
fix: search state reset, AI history window, i18n locales, admin transfer timelock

### DIFF
--- a/Dechat/dex_with_fiat_frontend/src/components/ChatSearchPanel.tsx
+++ b/Dechat/dex_with_fiat_frontend/src/components/ChatSearchPanel.tsx
@@ -66,21 +66,32 @@ function HighlightedSnippet({
   );
 }
 
+const EMPTY_FILTERS: SearchFilters = {
+  keyword: '',
+  walletAddress: '',
+  dateFrom: '',
+  dateTo: '',
+};
+
 export default function ChatSearchPanel({
   sessions,
   onSelectResult,
   onClose,
 }: ChatSearchPanelProps) {
   const { isDarkMode } = useTheme();
-  const [filters, setFilters] = useState<SearchFilters>({
-    keyword: '',
-    walletAddress: '',
-    dateFrom: '',
-    dateTo: '',
-  });
+  const [filters, setFilters] = useState<SearchFilters>(EMPTY_FILTERS);
   const [results, setResults] = useState<MessageMatch[]>([]);
   const [showAdvanced, setShowAdvanced] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
+
+  // Reset all search state whenever the panel is closed so stale results
+  // are never shown the next time the panel is opened (#947).
+  const handleClose = () => {
+    setFilters(EMPTY_FILTERS);
+    setResults([]);
+    setShowAdvanced(false);
+    onClose();
+  };
 
   // Debounced search — runs 300 ms after the last filter change
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -136,7 +147,7 @@ export default function ChatSearchPanel({
           </button>
         )}
         <button
-          onClick={onClose}
+          onClick={handleClose}
           className={`p-1 rounded transition-colors ${isDarkMode ? 'hover:bg-gray-700 text-gray-400' : 'hover:bg-gray-100 text-gray-500'}`}
           title="Close search"
           aria-label="Close search"

--- a/Dechat/dex_with_fiat_frontend/src/contexts/TranslationContext.tsx
+++ b/Dechat/dex_with_fiat_frontend/src/contexts/TranslationContext.tsx
@@ -2,6 +2,8 @@
 
 import React, { createContext, useContext, useState, useCallback, useMemo } from 'react';
 import en from '../locales/en.json';
+import fr from '../locales/fr.json';
+import es from '../locales/es.json';
 
 type TranslationKeys = typeof en;
 type NestedKeyOf<T> = T extends object
@@ -10,25 +12,67 @@ type NestedKeyOf<T> = T extends object
 
 export type TKey = NestedKeyOf<TranslationKeys>;
 
+/** Supported locale codes. */
+export type SupportedLocale = 'en' | 'fr' | 'es';
+
+export const SUPPORTED_LOCALES: SupportedLocale[] = ['en', 'fr', 'es'];
+
 interface TranslationContextType {
   t: (key: string, params?: Record<string, string | number>) => string;
-  locale: string;
-  setLocale: (locale: string) => void;
+  locale: SupportedLocale;
+  setLocale: (locale: SupportedLocale) => void;
 }
 
-const translations: Record<string, TranslationKeys> = { en };
+const translations: Record<SupportedLocale, TranslationKeys> = { en, fr: fr as TranslationKeys, es: es as TranslationKeys };
 
 const TranslationContext = createContext<TranslationContextType | undefined>(undefined);
 
+/**
+ * Detect the best supported locale from the browser's language preferences.
+ * Falls back to 'en' when no supported language matches (#999).
+ */
+function detectBrowserLocale(): SupportedLocale {
+  if (typeof window === 'undefined') return 'en';
+  const preferred = navigator.languages ?? [navigator.language];
+  for (const lang of preferred) {
+    // Match on the primary language subtag (e.g. "fr" from "fr-FR").
+    const primary = lang.split('-')[0].toLowerCase() as SupportedLocale;
+    if (SUPPORTED_LOCALES.includes(primary)) {
+      return primary;
+    }
+  }
+  return 'en';
+}
+
 export function TranslationProvider({ children }: { children: React.ReactNode }) {
-  const [locale, setLocale] = useState('en');
+  const [locale, setLocaleState] = useState<SupportedLocale>(detectBrowserLocale);
+
+  const setLocale = useCallback((next: SupportedLocale) => {
+    if (SUPPORTED_LOCALES.includes(next)) {
+      setLocaleState(next);
+    } else {
+      console.warn(`TranslationProvider: unsupported locale "${next}", falling back to "en"`);
+      setLocaleState('en');
+    }
+  }, []);
 
   const t = useCallback((key: string, params?: Record<string, string | number>) => {
     const keys = key.split('.');
-    let value: unknown = translations[locale];
-    
-    for (const k of keys) {
-      value = (value as Record<string, unknown>)?.[k];
+
+    // Resolve from the active locale; fall back to English for missing keys.
+    const resolveValue = (dict: Record<string, unknown>): unknown => {
+      let node: unknown = dict;
+      for (const k of keys) {
+        node = (node as Record<string, unknown>)?.[k];
+      }
+      return node;
+    };
+
+    let value = resolveValue(translations[locale] as unknown as Record<string, unknown>);
+
+    if (typeof value !== 'string' && locale !== 'en') {
+      // Fallback to English for missing translation keys (#999 acceptance criteria).
+      value = resolveValue(translations.en as unknown as Record<string, unknown>);
     }
 
     if (typeof value !== 'string') return key;
@@ -36,14 +80,14 @@ export function TranslationProvider({ children }: { children: React.ReactNode })
     if (params) {
       return Object.entries(params).reduce(
         (acc: string, [k, v]) => acc.replace(`{${k}}`, String(v)),
-        value as string
+        value as string,
       );
     }
 
     return value;
   }, [locale]);
 
-  const value = useMemo(() => ({ t, locale, setLocale }), [t, locale]);
+  const value = useMemo(() => ({ t, locale, setLocale }), [t, locale, setLocale]);
 
   return (
     <TranslationContext.Provider value={value}>

--- a/Dechat/dex_with_fiat_frontend/src/lib/aiAssistant.ts
+++ b/Dechat/dex_with_fiat_frontend/src/lib/aiAssistant.ts
@@ -203,6 +203,8 @@ export class AIAssistant {
 
   static readonly LOW_CONFIDENCE_THRESHOLD = 0.7;
   static readonly DEFAULT_PAGE_SIZE = 20;
+  /** Maximum number of recent messages included in each API request. */
+  static readonly CONVERSATION_WINDOW_SIZE = 20;
 
   /**
    * Safe fallback response returned when AI analysis fails critically.
@@ -273,6 +275,25 @@ export class AIAssistant {
   }
 
   /**
+   * Trim a conversation history array to the most recent N messages.
+   *
+   * Sending the full history on every request causes unbounded token growth.
+   * This helper keeps only the tail of the array so the payload stays within
+   * the model's context window regardless of conversation length (#991).
+   *
+   * @param history - Full array of past messages in chronological order.
+   * @param windowSize - Maximum number of messages to include (default: CONVERSATION_WINDOW_SIZE).
+   * @returns A new array containing only the last `windowSize` messages.
+   */
+  static trimConversationHistory(
+    history: ChatMessage[],
+    windowSize: number = AIAssistant.CONVERSATION_WINDOW_SIZE,
+  ): ChatMessage[] {
+    if (!Array.isArray(history) || history.length === 0) return [];
+    return history.slice(-Math.max(1, Math.floor(windowSize)));
+  }
+
+  /**
    * Analyze the user message and produce a structured AI analysis result.
    * Includes guardrail checks, FAQ matching, deterministic parsing, AI model
    * generation, and merged extracted data.
@@ -284,6 +305,9 @@ export class AIAssistant {
    *
    * @param message - Incoming user query or request text.
    * @param context - Optional context values to include in the AI prompt.
+   *   When `context.history` is a ChatMessage array it is automatically trimmed
+   *   to the last {@link AIAssistant.CONVERSATION_WINDOW_SIZE} messages before
+   *   being sent, preventing unbounded token growth over long conversations (#991).
    * @param signal - Optional AbortSignal for cancellation (does not trigger fallback).
    * @returns AIAnalysisResult with determined intent and suggested response. On errors,
    *          returns a safe fallback result that allows conversation to continue.
@@ -305,10 +329,23 @@ export class AIAssistant {
         return AIAssistant.SAFE_FALLBACK_RESULT;
       }
 
+      // Trim conversation history to a sliding window before sending (#991).
+      // Full history grows without bound and will eventually exceed the model's
+      // context window; we keep only the most recent messages plus the new one.
+      let trimmedContext = context;
+      if (context && Array.isArray(context.history)) {
+        trimmedContext = {
+          ...context,
+          history: AIAssistant.trimConversationHistory(
+            context.history as ChatMessage[],
+          ),
+        };
+      }
+
       const response = await fetch('/api/ai/chat', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ message, context }),
+        body: JSON.stringify({ message, context: trimmedContext }),
         signal: controllerSignal,
       });
 

--- a/Dechat/dex_with_fiat_frontend/src/locales/es.json
+++ b/Dechat/dex_with_fiat_frontend/src/locales/es.json
@@ -1,0 +1,56 @@
+{
+  "common": {
+    "loading": "Cargando...",
+    "retry": "Reintentar",
+    "cancel": "Cancelar",
+    "send": "Enviar",
+    "copy": "Copiar",
+    "copied": "¡Copiado!",
+    "offline": "Sin conexión detectado. Acciones en cola.",
+    "online": "De vuelta en línea. Reproduciendo acciones...",
+    "offline_detected": "Sin conexión detectado. Las operaciones de solo lectura están en cola y se reintentarán cuando haya conexión.",
+    "queued": "en cola",
+    "retry_now": "Reintentar ahora",
+    "network": "Red",
+    "unknown": "Desconocido",
+    "expected": "esperado",
+    "withdraw_xlm": "Retirar XLM",
+    "deposit_xlm": "Depositar XLM",
+    "network_mismatch_warning": "Los depósitos y retiros están deshabilitados. Cambie a {expectedNetwork} en Freighter: Configuración → Red → {expectedNetwork}.",
+    "loading_stats": "Cargando estadísticas…",
+    "bridge_balance": "Saldo Bridge",
+    "deposit_limit": "Límite de depósito",
+    "deposit_desc": "Agregar fondos a su cuenta Stellar",
+    "rates_desc": "Consultar las tasas de conversión actuales",
+    "portfolio_desc": "Ver el saldo y el valor de sus activos",
+    "help_desc": "Obtener ayuda con las funciones de la plataforma"
+  },
+  "chat": {
+    "placeholder": "Pregunte sobre las tasas de XLM, depósito, o cualquier cosa de Stellar...",
+    "new_chat": "Nueva conversación",
+    "commands": "Comandos",
+    "suggestions": {
+      "rates": "Consultar tasas de conversión",
+      "portfolio": "Ver historial de transacciones",
+      "convert": "Convertir 100 USDC a USD"
+    },
+    "error_message": "Error al enviar el mensaje. Verifique su conexión.",
+    "cancelled_message": "Solicitud cancelada por el usuario."
+  },
+  "header": {
+    "title": "DexFiat · Stellar",
+    "subtitle": "XLM-to-Fiat con IA",
+    "connect": "Conectar Freighter",
+    "disconnect": "Desconectar",
+    "settings": "Configuración",
+    "receipts": "Recibos"
+  },
+  "receipt": {
+    "title": "Recibos de transacciones",
+    "no_receipts": "No se encontraron transacciones recientes.",
+    "hash": "Hash Tx",
+    "amount": "Monto",
+    "status": "Estado",
+    "date": "Fecha"
+  }
+}

--- a/Dechat/dex_with_fiat_frontend/src/locales/fr.json
+++ b/Dechat/dex_with_fiat_frontend/src/locales/fr.json
@@ -1,0 +1,56 @@
+{
+  "common": {
+    "loading": "Chargement...",
+    "retry": "Réessayer",
+    "cancel": "Annuler",
+    "send": "Envoyer",
+    "copy": "Copier",
+    "copied": "Copié !",
+    "offline": "Hors ligne détecté. Actions en file d'attente.",
+    "online": "De retour en ligne. Reprise des actions...",
+    "offline_detected": "Hors ligne détecté. Les opérations en lecture seule sont mises en file d'attente et seront réessayées en ligne.",
+    "queued": "en file d'attente",
+    "retry_now": "Réessayer maintenant",
+    "network": "Réseau",
+    "unknown": "Inconnu",
+    "expected": "attendu",
+    "withdraw_xlm": "Retirer XLM",
+    "deposit_xlm": "Déposer XLM",
+    "network_mismatch_warning": "Les dépôts et retraits sont désactivés. Passez à {expectedNetwork} dans Freighter : Paramètres → Réseau → {expectedNetwork}.",
+    "loading_stats": "Chargement des statistiques…",
+    "bridge_balance": "Solde Bridge",
+    "deposit_limit": "Limite de dépôt",
+    "deposit_desc": "Ajouter des fonds à votre compte Stellar",
+    "rates_desc": "Vérifier les taux de conversion actuels",
+    "portfolio_desc": "Voir votre solde et la valeur de vos actifs",
+    "help_desc": "Obtenir de l'aide sur les fonctionnalités de la plateforme"
+  },
+  "chat": {
+    "placeholder": "Demandez les taux XLM, un dépôt, ou tout ce qui concerne Stellar...",
+    "new_chat": "Nouvelle discussion",
+    "commands": "Commandes",
+    "suggestions": {
+      "rates": "Vérifier les taux de conversion",
+      "portfolio": "Voir l'historique des transactions",
+      "convert": "Convertir 100 USDC en USD"
+    },
+    "error_message": "Échec de l'envoi du message. Vérifiez votre connexion.",
+    "cancelled_message": "Demande annulée par l'utilisateur."
+  },
+  "header": {
+    "title": "DexFiat · Stellar",
+    "subtitle": "XLM-to-Fiat propulsé par l'IA",
+    "connect": "Connecter Freighter",
+    "disconnect": "Déconnecter",
+    "settings": "Paramètres",
+    "receipts": "Reçus"
+  },
+  "receipt": {
+    "title": "Reçus de transaction",
+    "no_receipts": "Aucune transaction récente trouvée.",
+    "hash": "Hash Tx",
+    "amount": "Montant",
+    "status": "Statut",
+    "date": "Date"
+  }
+}

--- a/Dechat/stellar-contracts/src/lib.rs
+++ b/Dechat/stellar-contracts/src/lib.rs
@@ -112,6 +112,8 @@ pub enum Error {
     UpgradeNotReady = 605,
     UpgradeProposalMissing = 606,
     UpgradeDelayTooShort = 607,
+    /// Returned by `accept_admin` when the 48-hour mandatory delay has not yet elapsed.
+    AdminTransferTooEarly = 608,
 
     // --- 700 series: External Services ---
     OracleNotSet = 701,
@@ -396,6 +398,8 @@ pub struct BatchResult {
 pub struct ConfigSnapshot {
     pub admin: Address,
     pub pending_admin: Option<Address>,
+    /// Ledger at which the pending admin transfer was proposed; None when no transfer is in progress.
+    pub pending_admin_proposed_at: Option<u32>,
     pub token: Address,
     pub oracle: Option<Address>,
     pub fiat_limit: Option<i128>,
@@ -926,6 +930,11 @@ pub enum DataKey {
     SetLimitMaxCap,
     // ── Issue #fee_withdrawal_nonce: replay-protection nonce per admin ────
     FeeWithdrawalNonce(Address),
+    // ── Issue #970: 48-hour admin transfer timelock ───────────────────────
+    /// Ledger sequence number at which `transfer_admin` was called.
+    /// Stored alongside `PendingAdmin`; `accept_admin` checks that
+    /// `current_ledger >= proposed_at + MIN_TIMELOCK_DELAY` before completing.
+    AdminTransferProposedAt,
 
 }
 
@@ -2361,13 +2370,15 @@ impl FiatBridge {
         Ok(())
     }
 
-    /// Initiates a transfer of the administrative role to a new address.
+    /// Proposes a transfer of the administrative role to `new_admin`.
     ///
-    /// Follows a two-step transfer pattern:
-    /// 1. Current admin calls `transfer_admin(new_address)`.
-    /// 2. `new_address` must call `accept_admin()` to complete the transfer.
-    ///
-    /// This prevents accidental lockouts if the wrong address is provided.
+    /// Follows a three-step, time-locked transfer pattern (#970):
+    /// 1. Current admin calls `transfer_admin(new_admin)` — records the proposal
+    ///    and the current ledger as the proposal timestamp.
+    /// 2. At least 48 hours (≈ 34 560 ledgers) must pass before acceptance.
+    /// 3. `new_admin` calls `accept_admin()` to complete the transfer.
+    ///    The original admin may call `cancel_admin_transfer()` at any time
+    ///    during the waiting period to abort the transfer.
     pub fn transfer_admin(env: Env, new_admin: Address) -> Result<(), Error> {
         let admin: Address = env
             .storage()
@@ -2378,16 +2389,21 @@ impl FiatBridge {
         if new_admin == admin {
             return Err(Error::SameAdmin);
         }
+        let proposed_at: u32 = env.ledger().sequence();
         env.storage()
             .instance()
             .set(&DataKey::PendingAdmin, &new_admin);
+        env.storage()
+            .instance()
+            .set(&DataKey::AdminTransferProposedAt, &proposed_at);
         Ok(())
     }
 
-    /// Finalizes the administrative transfer process.
+    /// Finalizes the administrative transfer after the 48-hour mandatory delay.
     ///
-    /// Must be called by the `pending_admin` address set in a previous
-    /// `transfer_admin` call.
+    /// Must be called by the `pending_admin` set in `transfer_admin`.
+    /// Reverts with [`Error::AdminTransferTooEarly`] if fewer than
+    /// [`MIN_TIMELOCK_DELAY`] ledgers have elapsed since the proposal.
     pub fn accept_admin(env: Env) -> Result<(), Error> {
         let pending: Address = env
             .storage()
@@ -2395,8 +2411,44 @@ impl FiatBridge {
             .get(&DataKey::PendingAdmin)
             .ok_or(Error::NoPendingAdmin)?;
         pending.require_auth();
+
+        // Enforce the 48-hour mandatory delay before the transfer can be accepted.
+        let proposed_at: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::AdminTransferProposedAt)
+            .unwrap_or(0);
+        let current = env.ledger().sequence();
+        let earliest_accept = proposed_at.saturating_add(MIN_TIMELOCK_DELAY);
+        if current < earliest_accept {
+            return Err(Error::AdminTransferTooEarly);
+        }
+
         env.storage().instance().set(&DataKey::Admin, &pending);
         env.storage().instance().remove(&DataKey::PendingAdmin);
+        env.storage().instance().remove(&DataKey::AdminTransferProposedAt);
+        Ok(())
+    }
+
+    /// Cancels a pending admin transfer proposal.
+    ///
+    /// May only be called by the **current admin** and only while a pending
+    /// transfer exists.  Clears both the pending address and the proposal
+    /// timestamp, allowing a fresh `transfer_admin` call when appropriate.
+    pub fn cancel_admin_transfer(env: Env) -> Result<(), Error> {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::NotInitialized)?;
+        admin.require_auth();
+
+        if !env.storage().instance().has(&DataKey::PendingAdmin) {
+            return Err(Error::NoPendingAdmin);
+        }
+
+        env.storage().instance().remove(&DataKey::PendingAdmin);
+        env.storage().instance().remove(&DataKey::AdminTransferProposedAt);
         Ok(())
     }
 
@@ -4345,6 +4397,7 @@ impl FiatBridge {
         Ok(ConfigSnapshot {
             admin,
             pending_admin: env.storage().instance().get(&DataKey::PendingAdmin),
+            pending_admin_proposed_at: env.storage().instance().get(&DataKey::AdminTransferProposedAt),
             token,
             oracle: env.storage().instance().get(&DataKey::Oracle),
             fiat_limit: env.storage().instance().get(&DataKey::FiatLimit),
@@ -5999,3 +6052,6 @@ mod test_issue_676;
 
 #[cfg(test)]
 mod test_issue_681;
+
+#[cfg(test)]
+mod test_issue_970;

--- a/Dechat/stellar-contracts/src/test_issue_970.rs
+++ b/Dechat/stellar-contracts/src/test_issue_970.rs
@@ -1,0 +1,128 @@
+//! Tests for issue #970 — 48-hour admin transfer timelock.
+
+#![cfg(test)]
+
+use soroban_sdk::{testutils::Ledger, Env};
+
+use crate::{Error, FiatBridge, MIN_TIMELOCK_DELAY};
+
+fn env_with_sequence(seq: u32) -> Env {
+    let env = Env::default();
+    env.ledger().with_mut(|l| l.sequence_number = seq);
+    env
+}
+
+/// `accept_admin` must fail with AdminTransferTooEarly if called before the delay.
+#[test]
+fn accept_admin_before_delay_returns_too_early() {
+    let env = env_with_sequence(1000);
+    env.mock_all_auths();
+
+    let admin = soroban_sdk::Address::generate(&env);
+    let new_admin = soroban_sdk::Address::generate(&env);
+    let token = soroban_sdk::Address::generate(&env);
+
+    let contract_id = env.register(FiatBridge, ());
+    let client = crate::FiatBridgeClient::new(&env, &contract_id);
+
+    client.init(&admin, &token, &soroban_sdk::Vec::new(&env), &1);
+    client.transfer_admin(&new_admin);
+
+    // Advance ledger by less than MIN_TIMELOCK_DELAY.
+    env.ledger().with_mut(|l| {
+        l.sequence_number = 1000 + MIN_TIMELOCK_DELAY - 1;
+    });
+
+    let result = client.try_accept_admin();
+    assert_eq!(result, Err(Ok(Error::AdminTransferTooEarly)));
+}
+
+/// `accept_admin` must succeed exactly at the delay boundary.
+#[test]
+fn accept_admin_at_delay_boundary_succeeds() {
+    let env = env_with_sequence(1000);
+    env.mock_all_auths();
+
+    let admin = soroban_sdk::Address::generate(&env);
+    let new_admin = soroban_sdk::Address::generate(&env);
+    let token = soroban_sdk::Address::generate(&env);
+
+    let contract_id = env.register(FiatBridge, ());
+    let client = crate::FiatBridgeClient::new(&env, &contract_id);
+
+    client.init(&admin, &token, &soroban_sdk::Vec::new(&env), &1);
+    client.transfer_admin(&new_admin);
+
+    // Advance ledger to exactly the unlock boundary.
+    env.ledger().with_mut(|l| {
+        l.sequence_number = 1000 + MIN_TIMELOCK_DELAY;
+    });
+
+    client.accept_admin();
+    assert_eq!(client.get_admin(), new_admin);
+}
+
+/// Original admin can cancel the pending transfer within the waiting period.
+#[test]
+fn cancel_admin_transfer_removes_pending() {
+    let env = env_with_sequence(1000);
+    env.mock_all_auths();
+
+    let admin = soroban_sdk::Address::generate(&env);
+    let new_admin = soroban_sdk::Address::generate(&env);
+    let token = soroban_sdk::Address::generate(&env);
+
+    let contract_id = env.register(FiatBridge, ());
+    let client = crate::FiatBridgeClient::new(&env, &contract_id);
+
+    client.init(&admin, &token, &soroban_sdk::Vec::new(&env), &1);
+    client.transfer_admin(&new_admin);
+    client.cancel_admin_transfer();
+
+    // After cancellation, accept_admin should return NoPendingAdmin.
+    env.ledger().with_mut(|l| {
+        l.sequence_number = 1000 + MIN_TIMELOCK_DELAY;
+    });
+
+    let result = client.try_accept_admin();
+    assert_eq!(result, Err(Ok(Error::NoPendingAdmin)));
+}
+
+/// Cancelling when no transfer is pending returns NoPendingAdmin.
+#[test]
+fn cancel_when_no_pending_returns_error() {
+    let env = env_with_sequence(1000);
+    env.mock_all_auths();
+
+    let admin = soroban_sdk::Address::generate(&env);
+    let token = soroban_sdk::Address::generate(&env);
+
+    let contract_id = env.register(FiatBridge, ());
+    let client = crate::FiatBridgeClient::new(&env, &contract_id);
+
+    client.init(&admin, &token, &soroban_sdk::Vec::new(&env), &1);
+
+    let result = client.try_cancel_admin_transfer();
+    assert_eq!(result, Err(Ok(Error::NoPendingAdmin)));
+}
+
+/// ConfigSnapshot exposes the proposal ledger so clients can compute the unlock time.
+#[test]
+fn config_snapshot_includes_proposed_at() {
+    let env = env_with_sequence(5000);
+    env.mock_all_auths();
+
+    let admin = soroban_sdk::Address::generate(&env);
+    let new_admin = soroban_sdk::Address::generate(&env);
+    let token = soroban_sdk::Address::generate(&env);
+
+    let contract_id = env.register(FiatBridge, ());
+    let client = crate::FiatBridgeClient::new(&env, &contract_id);
+
+    client.init(&admin, &token, &soroban_sdk::Vec::new(&env), &1);
+    client.transfer_admin(&new_admin);
+
+    let snapshot = client.get_config_snapshot();
+    assert_eq!(snapshot.pending_admin, Some(new_admin));
+    assert_eq!(snapshot.pending_admin_proposed_at, Some(5000u32));
+}


### PR DESCRIPTION
## Summary

- **#947** — `ChatSearchPanel`: close button now calls `handleClose()` which resets `filters`, `results`, and `showAdvanced` before invoking `onClose`, so reopening the panel always starts clean
- **#991** — `aiAssistant.ts`: add `CONVERSATION_WINDOW_SIZE = 20` constant and `trimConversationHistory()` helper; `analyzeUserMessage` trims `context.history` to the last 20 messages before serialising the request, preventing unbounded token growth over long conversations
- **#999** — Add `src/locales/fr.json` and `src/locales/es.json` with complete French and Spanish translations; update `TranslationContext` to import both, expose `SupportedLocale` type, initialise locale from `navigator.languages` (English fallback), and fall through to English for any missing key
- **#970** — Soroban contract: `transfer_admin` now records the proposal ledger in `DataKey::AdminTransferProposedAt`; `accept_admin` enforces `MIN_TIMELOCK_DELAY` (34 560 ledgers ≈ 48h) before completing the transfer (`Error::AdminTransferTooEarly` otherwise); new `cancel_admin_transfer` lets the current admin abort the pending transfer; `ConfigSnapshot` exposes `pending_admin_proposed_at`; five unit tests added in `test_issue_970.rs`

## Test plan

- [ ] Open `ChatSearchPanel`, run a search, close it, reopen — verify the search field and results list are empty
- [ ] Send >20 messages in the AI chat; inspect the `/api/ai/chat` request body and confirm `context.history` has at most 20 entries
- [ ] Set browser language to `fr` or `es`; confirm the UI renders in that language; set to an unsupported language and confirm English fallback
- [ ] On Soroban testnet: call `transfer_admin`, immediately call `accept_admin` → expect `AdminTransferTooEarly`; wait 48h (or advance ledger sequence in test) → `accept_admin` succeeds; call `cancel_admin_transfer` mid-window → subsequent `accept_admin` returns `NoPendingAdmin`
- [ ] Run `cargo test -p stellar-contracts` — all `test_issue_970` tests pass

Closes #947
Closes #991
Closes #999
Closes #970