### PR TITLE
feat: telemetry motion, dark-mode chip fallback, debounced dispatch, request_withdrawal invariants

### DIFF
--- a/Dechat/dex_with_fiat_frontend/src/hooks/chatStateMachine.test.ts
+++ b/Dechat/dex_with_fiat_frontend/src/hooks/chatStateMachine.test.ts
@@ -1,5 +1,5 @@
 import { TransactionData } from '@/types';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
     ChatEvent,
     ChatGuards,
@@ -7,6 +7,8 @@ import {
     ChatState,
   copyChatStateSnapshot,
     createChatStateMachine,
+  createDebouncedDispatcher,
+  DEFAULT_DISPATCH_DEBOUNCE_MS,
   formatChatStateSnapshot,
 } from './chatStateMachine';
 
@@ -745,5 +747,83 @@ describe('chatStateMachine clipboard snapshot helpers', () => {
     const copied = await copyChatStateSnapshot(ChatState.SENDING_MESSAGE, context);
     expect(copied).toBe(true);
     expect(writeText).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ── Debounced dispatcher (issue #588) ───────────────────────────────────────
+describe('createDebouncedDispatcher (issue #588)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  it('applies a single dispatched event after the debounce delay', () => {
+    const machine = createChatStateMachine();
+    machine.transition(ChatEvent.INITIALIZE_SESSION);
+    const dispatcher = createDebouncedDispatcher(machine, 200);
+
+    dispatcher.dispatch(ChatEvent.SEND_MESSAGE);
+    // Not applied yet — still within the debounce window.
+    expect(machine.getState().state).toBe(ChatState.INITIALIZED);
+    expect(dispatcher.isPending()).toBe(true);
+
+    vi.advanceTimersByTime(200);
+    expect(machine.getState().state).toBe(ChatState.SENDING_MESSAGE);
+    expect(dispatcher.isPending()).toBe(false);
+  });
+
+  it('collapses a burst of events into the latest one', () => {
+    const machine = createChatStateMachine();
+    machine.transition(ChatEvent.INITIALIZE_SESSION);
+    const transitionSpy = vi.spyOn(machine, 'transition');
+    const dispatcher = createDebouncedDispatcher(machine, 150);
+
+    // Rapid burst — only the last event should be applied once.
+    dispatcher.dispatch(ChatEvent.CLEAR_CHAT);
+    dispatcher.dispatch(ChatEvent.LOAD_SESSION);
+    dispatcher.dispatch(ChatEvent.SEND_MESSAGE);
+
+    vi.advanceTimersByTime(150);
+
+    expect(transitionSpy).toHaveBeenCalledTimes(1);
+    expect(transitionSpy).toHaveBeenCalledWith(ChatEvent.SEND_MESSAGE);
+    expect(machine.getState().state).toBe(ChatState.SENDING_MESSAGE);
+  });
+
+  it('flush applies the pending event immediately and returns the result', () => {
+    const machine = createChatStateMachine();
+    machine.transition(ChatEvent.INITIALIZE_SESSION);
+    const dispatcher = createDebouncedDispatcher(machine);
+
+    dispatcher.dispatch(ChatEvent.SEND_MESSAGE);
+    const result = dispatcher.flush();
+
+    expect(result).toBe(true);
+    expect(machine.getState().state).toBe(ChatState.SENDING_MESSAGE);
+    expect(dispatcher.isPending()).toBe(false);
+
+    // Nothing left to flush.
+    expect(dispatcher.flush()).toBe(false);
+  });
+
+  it('cancel discards the pending event without applying it', () => {
+    const machine = createChatStateMachine();
+    machine.transition(ChatEvent.INITIALIZE_SESSION);
+    const dispatcher = createDebouncedDispatcher(machine, 200);
+
+    dispatcher.dispatch(ChatEvent.SEND_MESSAGE);
+    dispatcher.cancel();
+
+    vi.advanceTimersByTime(500);
+    expect(machine.getState().state).toBe(ChatState.INITIALIZED);
+    expect(dispatcher.isPending()).toBe(false);
+  });
+
+  it('exposes a sensible default debounce window', () => {
+    expect(DEFAULT_DISPATCH_DEBOUNCE_MS).toBeGreaterThan(0);
   });
 });

--- a/Dechat/dex_with_fiat_frontend/src/hooks/chatStateMachine.ts
+++ b/Dechat/dex_with_fiat_frontend/src/hooks/chatStateMachine.ts
@@ -330,4 +330,82 @@ export async function copyChatStateSnapshot(
   }
 }
 
+/** Default debounce window (ms) for {@link createDebouncedDispatcher}. */
+export const DEFAULT_DISPATCH_DEBOUNCE_MS = 250;
+
+/**
+ * A debounced dispatcher for chat state-machine events.
+ *
+ * Rapid calls to {@link DebouncedChatDispatcher.dispatch} within the debounce
+ * window collapse into a single trailing transition, so bursts of UI events
+ * (e.g. fast typing repeatedly firing `SEND_MESSAGE`, or a flurry of retries)
+ * don't flood the machine. The most recently queued event wins.
+ */
+export interface DebouncedChatDispatcher {
+  /** Queue an event; only the latest event in a burst is applied after the delay. */
+  dispatch: (event: ChatEvent) => void;
+  /**
+   * Immediately apply the pending event (if any), bypassing the remaining
+   * delay. Returns the underlying `transition` result, or `false` when nothing
+   * was pending.
+   */
+  flush: () => boolean;
+  /** Discard any pending event without applying it. */
+  cancel: () => void;
+  /** Whether an event is currently queued and waiting to be applied. */
+  isPending: () => boolean;
+}
+
+/**
+ * Create a debounced dispatcher bound to a chat state machine.
+ *
+ * @param machine - The machine whose `transition` is invoked on flush.
+ * @param delayMs - Debounce window in milliseconds (defaults to
+ *   {@link DEFAULT_DISPATCH_DEBOUNCE_MS}). Non-positive values apply events
+ *   on the next tick.
+ */
+export function createDebouncedDispatcher(
+  machine: StateMachine<ChatState, ChatEvent, ChatMachineContext>,
+  delayMs: number = DEFAULT_DISPATCH_DEBOUNCE_MS,
+): DebouncedChatDispatcher {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let pendingEvent: ChatEvent | null = null;
+
+  const clearTimer = (): void => {
+    if (timer !== null) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  };
+
+  const applyPending = (): boolean => {
+    if (pendingEvent === null) return false;
+    const event = pendingEvent;
+    pendingEvent = null;
+    return machine.transition(event);
+  };
+
+  return {
+    dispatch(event: ChatEvent): void {
+      pendingEvent = event;
+      clearTimer();
+      timer = setTimeout(() => {
+        timer = null;
+        applyPending();
+      }, Math.max(0, delayMs));
+    },
+    flush(): boolean {
+      clearTimer();
+      return applyPending();
+    },
+    cancel(): void {
+      clearTimer();
+      pendingEvent = null;
+    },
+    isPending(): boolean {
+      return pendingEvent !== null;
+    },
+  };
+}
+
 export { ChatGuards };

--- a/Dechat/dex_with_fiat_frontend/src/hooks/useTransactionFilters.test.ts
+++ b/Dechat/dex_with_fiat_frontend/src/hooks/useTransactionFilters.test.ts
@@ -1,7 +1,14 @@
 import { renderHook, act } from '@testing-library/react';
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 import type { TransactionHistoryEntry } from '@/types';
-import { KEYBOARD_SHORTCUTS, useTransactionFilters, getAccessibleFilterChipTone } from './useTransactionFilters';
+import {
+  KEYBOARD_SHORTCUTS,
+  useTransactionFilters,
+  getAccessibleFilterChipTone,
+  ensureDarkModeClasses,
+  withDarkModeFallback,
+  DARK_MODE_FALLBACK_CLASSES,
+} from './useTransactionFilters';
 
 let mockSearchParams = new URLSearchParams('tab=history');
 const mockPush = vi.fn((url: string) => {
@@ -151,5 +158,50 @@ describe('useTransactionFilters', () => {
     expect(KEYBOARD_SHORTCUTS.cycleStatus.key).toBe('1');
     expect(KEYBOARD_SHORTCUTS.cycleAsset.key).toBe('2');
     expect(KEYBOARD_SHORTCUTS.cycleNetwork.key).toBe('3');
+  });
+});
+
+// ── Dark mode fallback (issue #671) ────────────────────────────────────────
+
+describe('dark mode fallback for filter chip tones (issue #671)', () => {
+  it('leaves classes untouched when a dark variant is already present', () => {
+    const className = 'bg-blue-50 text-blue-800 dark:bg-blue-950 dark:text-blue-200';
+    expect(ensureDarkModeClasses(className, DARK_MODE_FALLBACK_CLASSES.chipClassName)).toBe(
+      className,
+    );
+  });
+
+  it('appends fallback dark classes when none are present', () => {
+    const result = ensureDarkModeClasses(
+      'bg-blue-50 text-blue-800',
+      DARK_MODE_FALLBACK_CLASSES.chipClassName,
+    );
+    expect(result).toBe(
+      `bg-blue-50 text-blue-800 ${DARK_MODE_FALLBACK_CLASSES.chipClassName}`,
+    );
+    expect(result).toContain('dark:');
+  });
+
+  it('returns only the fallback classes for an empty className', () => {
+    expect(ensureDarkModeClasses('', DARK_MODE_FALLBACK_CLASSES.countClassName)).toBe(
+      DARK_MODE_FALLBACK_CLASSES.countClassName,
+    );
+  });
+
+  it('backfills dark-mode classes on a tone missing them', () => {
+    const tone = withDarkModeFallback({
+      chipClassName: 'border-blue-200 bg-blue-50 text-blue-800',
+      countClassName: 'bg-blue-100 text-blue-800',
+    });
+    expect(tone.chipClassName).toContain('dark:');
+    expect(tone.countClassName).toContain('dark:');
+  });
+
+  it('keeps built-in palette tones (which already define dark variants) unchanged', () => {
+    const tone = getAccessibleFilterChipTone('status', 'completed', true);
+    // Built-in tones already ship dark: classes, so no fallback should be appended.
+    expect(tone.chipClassName).not.toContain(DARK_MODE_FALLBACK_CLASSES.chipClassName);
+    expect(tone.chipClassName).toContain('dark:');
+    expect(tone.countClassName).toContain('dark:');
   });
 });

--- a/Dechat/dex_with_fiat_frontend/src/hooks/useTransactionFilters.ts
+++ b/Dechat/dex_with_fiat_frontend/src/hooks/useTransactionFilters.ts
@@ -225,6 +225,50 @@ function getToneKeyForCategory(
   return sequence[hashFilterValue(value) % sequence.length];
 }
 
+/**
+ * Guaranteed dark-mode-safe utility classes appended when a tone definition is
+ * missing `dark:` variants. Acts as a neutral fallback so chips remain legible
+ * in dark mode even if a palette is extended without explicit dark-mode classes.
+ */
+export const DARK_MODE_FALLBACK_CLASSES = {
+  chipClassName: 'dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100',
+  countClassName: 'dark:bg-slate-800 dark:text-slate-100',
+} as const;
+
+/**
+ * Append fallback dark-mode classes when `className` declares no `dark:`
+ * variants. Tailwind keeps the last-declared utility per property, so the
+ * appended fallback only takes effect where a dark variant is otherwise absent.
+ */
+export function ensureDarkModeClasses(
+  className: string,
+  fallbackDarkClasses: string,
+): string {
+  if (/(?:^|\s)dark:/.test(className)) {
+    return className;
+  }
+  const trimmed = className.trim();
+  return trimmed ? `${trimmed} ${fallbackDarkClasses}` : fallbackDarkClasses;
+}
+
+/**
+ * Ensure a filter chip tone renders correctly in dark mode by backfilling
+ * fallback `dark:` classes on any field that lacks them. Tones that already
+ * declare dark-mode variants are returned unchanged.
+ */
+export function withDarkModeFallback(tone: FilterChipTone): FilterChipTone {
+  return {
+    chipClassName: ensureDarkModeClasses(
+      tone.chipClassName,
+      DARK_MODE_FALLBACK_CLASSES.chipClassName,
+    ),
+    countClassName: ensureDarkModeClasses(
+      tone.countClassName,
+      DARK_MODE_FALLBACK_CLASSES.countClassName,
+    ),
+  };
+}
+
 export function getAccessibleFilterChipTone(
   category: FilterCategory,
   value: string,
@@ -234,10 +278,10 @@ export function getAccessibleFilterChipTone(
   const palette = FILTER_TONE_PALETTES[toneKey];
   const toneState = selected ? palette.selected : palette.unselected;
 
-  return {
+  return withDarkModeFallback({
     chipClassName: toneState.chipClassName,
     countClassName: toneState.countClassName,
-  };
+  });
 }
 
 /**

--- a/Dechat/dex_with_fiat_frontend/src/lib/chatTelemetry.test.ts
+++ b/Dechat/dex_with_fiat_frontend/src/lib/chatTelemetry.test.ts
@@ -7,6 +7,10 @@ import {
   setTelemetryConsent,
   TELEMETRY_SCHEMA_VERSION,
   telemetryMotionVariants,
+  reducedTelemetryMotionVariants,
+  getTelemetryMotionVariants,
+  telemetryEventMotionIntent,
+  prefersReducedMotion,
   type ChatEvent,
   type AccessibleAvatarColorTelemetryPayload,
   type MessageSendPayload,
@@ -188,6 +192,61 @@ describe('Telemetry motion variants', () => {
     expect(telemetryMotionVariants.hidden).toBeDefined();
     expect(telemetryMotionVariants.visible).toBeDefined();
     expect(telemetryMotionVariants.exit).toBeDefined();
+  });
+});
+
+// ── Reduced-motion aware variants (issue #674) ─────────────────────────────
+
+describe('getTelemetryMotionVariants (issue #674)', () => {
+  function setReducedMotionPreference(matches: boolean) {
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })) as unknown as typeof window.matchMedia;
+  }
+
+  it('returns intent-weighted travel for the default (info) intent', () => {
+    const variants = getTelemetryMotionVariants({ reducedMotion: false });
+    expect((variants.hidden as { y: number }).y).toBe(6);
+    expect((variants.visible as { y: number }).y).toBe(0);
+  });
+
+  it('animates errors with more emphasis than info events', () => {
+    const info = getTelemetryMotionVariants({ reducedMotion: false, intent: 'info' });
+    const error = getTelemetryMotionVariants({ reducedMotion: false, intent: 'error' });
+    expect((error.hidden as { y: number }).y).toBeGreaterThan(
+      (info.hidden as { y: number }).y,
+    );
+  });
+
+  it('returns a movement-free fade when reduced motion is requested', () => {
+    const variants = getTelemetryMotionVariants({ reducedMotion: true });
+    expect(variants).toBe(reducedTelemetryMotionVariants);
+    expect((variants.hidden as { y?: number }).y).toBeUndefined();
+    expect((variants.hidden as { opacity: number }).opacity).toBe(0);
+  });
+
+  it('auto-detects prefers-reduced-motion from matchMedia', () => {
+    setReducedMotionPreference(true);
+    expect(prefersReducedMotion()).toBe(true);
+    expect(getTelemetryMotionVariants()).toBe(reducedTelemetryMotionVariants);
+
+    setReducedMotionPreference(false);
+    expect(prefersReducedMotion()).toBe(false);
+    expect((getTelemetryMotionVariants().hidden as { y: number }).y).toBe(6);
+  });
+
+  it('maps event names to an appropriate motion intent', () => {
+    expect(telemetryEventMotionIntent('message_retry')).toBe('error');
+    expect(telemetryEventMotionIntent('avatar_color_check')).toBe('warning');
+    expect(telemetryEventMotionIntent('tx_confirm')).toBe('success');
+    expect(telemetryEventMotionIntent('message_send')).toBe('info');
   });
 });
 

--- a/Dechat/dex_with_fiat_frontend/src/lib/chatTelemetry.ts
+++ b/Dechat/dex_with_fiat_frontend/src/lib/chatTelemetry.ts
@@ -108,6 +108,100 @@ export const telemetryMotionVariants: Variants = {
   },
 };
 
+/** Visual weight applied to a telemetry chip/toast animation. */
+export type TelemetryMotionIntent = 'info' | 'success' | 'warning' | 'error';
+
+/**
+ * Reduced-motion variant set used when the user has requested reduced motion.
+ * Animates opacity only — no transforms — so vestibular-sensitive users are
+ * not exposed to movement while telemetry chips/toasts mount and unmount.
+ */
+export const reducedTelemetryMotionVariants: Variants = {
+  hidden: { opacity: 0 },
+  visible: { opacity: 1, transition: { duration: 0.01 } },
+  exit: { opacity: 0, transition: { duration: 0.01 } },
+};
+
+/** Entry offset (px) per intent — higher-signal events animate with more travel. */
+const TELEMETRY_INTENT_OFFSETS: Record<TelemetryMotionIntent, number> = {
+  info: 6,
+  success: 6,
+  warning: 8,
+  error: 10,
+};
+
+/**
+ * Map a telemetry event name to the motion intent that best matches its
+ * visual weight, so higher-signal events (retries/contrast warnings) animate
+ * with a little more emphasis than routine ones.
+ */
+export function telemetryEventMotionIntent(
+  name: ChatEventName,
+): TelemetryMotionIntent {
+  switch (name) {
+    case 'message_retry':
+      return 'error';
+    case 'avatar_color_check':
+      return 'warning';
+    case 'tx_confirm':
+    case 'wallet_connect':
+      return 'success';
+    default:
+      return 'info';
+  }
+}
+
+/**
+ * SSR-safe detection of the user's `prefers-reduced-motion` setting.
+ * Returns false on the server or when matchMedia is unavailable/throws.
+ */
+export function prefersReducedMotion(): boolean {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return false;
+  }
+  try {
+    return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Build framer-motion variants for telemetry chips/toasts.
+ *
+ * Honors `prefers-reduced-motion` (passed explicitly via `options.reducedMotion`
+ * or auto-detected from the environment) by returning a movement-free fade.
+ * Otherwise returns intent-weighted enter/exit variants.
+ */
+export function getTelemetryMotionVariants(options?: {
+  reducedMotion?: boolean;
+  intent?: TelemetryMotionIntent;
+}): Variants {
+  const reducedMotion = options?.reducedMotion ?? prefersReducedMotion();
+  if (reducedMotion) {
+    return reducedTelemetryMotionVariants;
+  }
+
+  const intent = options?.intent ?? 'info';
+  const offset = TELEMETRY_INTENT_OFFSETS[intent];
+
+  return {
+    hidden: { opacity: 0, y: offset, scale: 0.98 },
+    visible: {
+      opacity: 1,
+      y: 0,
+      scale: 1,
+      transition: { duration: 0.2, ease: 'easeOut' },
+    },
+    exit: {
+      opacity: 0,
+      y: -Math.round(offset / 2),
+      scale: 0.98,
+      transition: { duration: 0.15, ease: 'easeIn' },
+    },
+  };
+}
+
 // ── Consent key ───────────────────────────────────────────────────────────
 
 const CONSENT_KEY = 'nova_telemetry_consent';

--- a/Dechat/stellar-contracts/src/lib.rs
+++ b/Dechat/stellar-contracts/src/lib.rs
@@ -7106,3 +7106,6 @@ mod test_issue_1002;
 
 #[cfg(test)]
 mod test_issue_994_1003;
+
+#[cfg(test)]
+mod test_issue_572;

--- a/Dechat/stellar-contracts/src/math.rs
+++ b/Dechat/stellar-contracts/src/math.rs
@@ -48,9 +48,9 @@ pub const FIXED_POINT: i128 = 10_000_000;
 /// // Negative: -7 * 3 / 2 = -10.5 → floor → -11
 /// assert_eq!(mul_div_floor(-7, 3, 2), -11);
 /// ```
-pub fn mul_div_floor(a: i128, b: i128, d: i128) -> i128 {
+pub fn checked_mul_div_floor(a: i128, b: i128, d: i128) -> Result<i128, Error> {
     // Issue #966: use checked_mul to prevent silent overflow on large deposits
-    let product = a.checked_mul(b).expect("mul_div_floor: overflow in a * b");
+    let product = a.checked_mul(b).ok_or(Error::Overflow)?;
     // Rust integer division already truncates toward zero.
     // For non-negative products that equals floor; for negative products we
     // subtract 1 if there is a remainder, giving true floor semantics.
@@ -96,13 +96,13 @@ pub fn mul_div_floor(a: i128, b: i128, d: i128) -> i128 {
 /// // Exact: 6 * 2 / 3 = 4.0 → ceil → 4
 /// assert_eq!(mul_div_ceil(6, 2, 3), 4);
 /// ```
-pub fn mul_div_ceil(a: i128, b: i128, d: i128) -> i128 {
+pub fn checked_mul_div_ceil(a: i128, b: i128, d: i128) -> Result<i128, Error> {
     // Issue #966: use checked_mul to prevent silent overflow on large deposits
-    let product = a.checked_mul(b).expect("mul_div_ceil: overflow in a * b");
+    let product = a.checked_mul(b).ok_or(Error::Overflow)?;
     // Ceiling division: (product + d - 1) / d for positive values
     // For negative products, we use floor semantics (same as mul_div_floor)
-    if product >= 0 {
-        product.checked_add(d - 1).expect("mul_div_ceil: overflow in product + d - 1") / d
+    Ok(if product >= 0 {
+        product.checked_add(d - 1).ok_or(Error::Overflow)? / d
     } else if product % d == 0 {
         product / d
     } else {

--- a/Dechat/stellar-contracts/src/test.rs
+++ b/Dechat/stellar-contracts/src/test.rs
@@ -1100,7 +1100,7 @@ fn test_fallback_oracle_used_when_primary_stale() {
         &600,
         &None,
     );
-    assert_eq!(token.balance(&user), 99_000);
+    assert_eq!(_token.balance(&user), 99_000);
 }
 
 #[test]

--- a/Dechat/stellar-contracts/src/test_issue_572.rs
+++ b/Dechat/stellar-contracts/src/test_issue_572.rs
@@ -1,0 +1,278 @@
+//! Issue #572 — invariant tests for `request_withdrawal`.
+//!
+//! `request_withdrawal` queues a withdrawal and bumps the token's
+//! `total_liabilities`. It calls `check_invariants` before returning, which
+//! enforces the contract's core accounting invariants:
+//!
+//!   1. `total_deposited >= total_withdrawn`
+//!   2. `net_deposited (= total_deposited - total_withdrawn) >= total_liabilities`
+//!   3. `on_chain_balance >= net_deposited`
+//!
+//! These tests lock in those invariants for the `request_withdrawal` path,
+//! plus the request-specific guarantees: liabilities grow by exactly the
+//! requested amount, the queue depth increments by one, rejected requests
+//! leave state untouched, and a `WithdrawalRequested` event is emitted.
+
+#![cfg(test)]
+
+use crate::{Error, FiatBridge, FiatBridgeClient};
+use soroban_sdk::{
+    testutils::{Address as _, Events as _},
+    token, Address, Bytes, Env, Vec,
+};
+
+fn create_token_contract<'a>(
+    env: &Env,
+    admin: &Address,
+) -> (token::Client<'a>, token::StellarAssetClient<'a>) {
+    let contract_address = env.register_stellar_asset_contract_v2(admin.clone());
+    (
+        token::Client::new(env, &contract_address.address()),
+        token::StellarAssetClient::new(env, &contract_address.address()),
+    )
+}
+
+fn setup_bridge(
+    env: &Env,
+) -> (
+    Address,
+    FiatBridgeClient<'_>,
+    Address,
+    Address,
+    token::Client<'_>,
+    token::StellarAssetClient<'_>,
+) {
+    let admin = Address::generate(env);
+    let (token_client, token_admin) = create_token_contract(env, &admin);
+    let token_address = token_client.address.clone();
+
+    let contract_id = env.register(FiatBridge, ());
+    let client = FiatBridgeClient::new(env, &contract_id);
+
+    let mut signers = Vec::new(env);
+    signers.push_back(admin.clone());
+
+    client.init(&admin, &token_address, &1_000_000, &100, &signers, &1);
+
+    (
+        contract_id,
+        client,
+        admin,
+        token_address,
+        token_client,
+        token_admin,
+    )
+}
+
+/// Fund `user` and deposit `amount` so the contract holds real tokens and has
+/// a positive net position that withdrawals can be queued against.
+fn fund_and_deposit(
+    env: &Env,
+    bridge: &FiatBridgeClient<'_>,
+    token_admin: &token::StellarAssetClient<'_>,
+    token_addr: &Address,
+    user: &Address,
+    amount: i128,
+) {
+    token_admin.mint(user, &amount);
+    let reference = Bytes::from_slice(env, b"deposit-ref");
+    bridge.deposit(user, &amount, token_addr, &reference, &0, &0, &None);
+}
+
+/// Invariant: a successful request increases `total_liabilities` by exactly the
+/// requested amount and increments the queue depth by exactly one.
+#[test]
+fn test_request_withdrawal_invariant_liabilities_and_queue_grow_by_request() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_, bridge, _, token_addr, _, token_admin) = setup_bridge(&env);
+    let user = Address::generate(&env);
+
+    fund_and_deposit(&env, &bridge, &token_admin, &token_addr, &user, 5_000);
+
+    let liabilities_before = bridge.get_total_liabilities();
+    let depth_before = bridge.get_wq_depth();
+
+    let request_id = bridge.request_withdrawal(&user, &1_200, &token_addr, &None, &0);
+
+    assert_eq!(
+        bridge.get_total_liabilities(),
+        liabilities_before + 1_200,
+        "liabilities must increase by exactly the requested amount",
+    );
+    assert_eq!(
+        bridge.get_wq_depth(),
+        depth_before + 1,
+        "queue depth must increment by exactly one",
+    );
+    assert!(
+        bridge.get_withdrawal_request(&request_id).is_some(),
+        "the queued request must be retrievable by its id",
+    );
+}
+
+/// Invariant 2 + 3: after queuing, `total_liabilities <= net_deposited` and the
+/// on-chain balance still covers the net position (queuing moves no tokens).
+#[test]
+fn test_request_withdrawal_invariant_liabilities_covered_by_net_position() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, bridge, _, token_addr, token_client, token_admin) = setup_bridge(&env);
+    let user = Address::generate(&env);
+
+    fund_and_deposit(&env, &bridge, &token_admin, &token_addr, &user, 5_000);
+
+    bridge.request_withdrawal(&user, &2_000, &token_addr, &None, &0);
+    bridge.request_withdrawal(&user, &1_500, &token_addr, &None, &0);
+
+    let net_deposited = bridge.get_total_deposited() - bridge.get_total_withdrawn();
+    let liabilities = bridge.get_total_liabilities();
+    let balance = token_client.balance(&contract_id);
+
+    assert_eq!(liabilities, 3_500, "liabilities must accumulate additively");
+    assert!(
+        liabilities <= net_deposited,
+        "invariant: queued liabilities must be covered by the net position",
+    );
+    assert!(
+        balance >= net_deposited,
+        "invariant: on-chain balance must cover the net position",
+    );
+}
+
+/// Invariant: a request that would push `total_liabilities` beyond
+/// `net_deposited` is rejected and leaves all state untouched (no partial
+/// mutation of liabilities, queue depth, or request id counter).
+#[test]
+fn test_request_withdrawal_invariant_overcommit_rejected_and_state_unchanged() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_, bridge, _, token_addr, _, token_admin) = setup_bridge(&env);
+    let user = Address::generate(&env);
+
+    fund_and_deposit(&env, &bridge, &token_admin, &token_addr, &user, 5_000);
+
+    // First request consumes most of the net position.
+    bridge.request_withdrawal(&user, &3_000, &token_addr, &None, &0);
+
+    let liabilities_before = bridge.get_total_liabilities();
+    let depth_before = bridge.get_wq_depth();
+
+    // Second request (3_000) would make liabilities 6_000 > net_deposited 5_000.
+    let result = bridge.try_request_withdrawal(&user, &3_000, &token_addr, &None, &0);
+    assert_eq!(result, Err(Ok(Error::InsufficientFunds)));
+
+    assert_eq!(
+        bridge.get_total_liabilities(),
+        liabilities_before,
+        "a rejected request must not change liabilities",
+    );
+    assert_eq!(
+        bridge.get_wq_depth(),
+        depth_before,
+        "a rejected request must not change the queue depth",
+    );
+
+    // A subsequent request that fits the remaining net position still succeeds.
+    let fitting_id = bridge.request_withdrawal(&user, &2_000, &token_addr, &None, &0);
+    assert!(bridge.get_withdrawal_request(&fitting_id).is_some());
+    assert_eq!(bridge.get_total_liabilities(), 5_000);
+}
+
+/// Invariant: a zero-amount request is rejected with `ZeroAmount` and does not
+/// mutate liabilities or the queue.
+#[test]
+fn test_request_withdrawal_invariant_zero_amount_rejected_and_state_unchanged() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_, bridge, _, token_addr, _, token_admin) = setup_bridge(&env);
+    let user = Address::generate(&env);
+
+    fund_and_deposit(&env, &bridge, &token_admin, &token_addr, &user, 5_000);
+
+    let liabilities_before = bridge.get_total_liabilities();
+    let depth_before = bridge.get_wq_depth();
+
+    let result = bridge.try_request_withdrawal(&user, &0, &token_addr, &None, &0);
+    assert_eq!(result, Err(Ok(Error::ZeroAmount)));
+
+    assert_eq!(bridge.get_total_liabilities(), liabilities_before);
+    assert_eq!(bridge.get_wq_depth(), depth_before);
+}
+
+/// Invariant: each successful request yields a distinct, monotonically
+/// increasing request id, and every queued request stays retrievable.
+#[test]
+fn test_request_withdrawal_invariant_unique_monotonic_request_ids() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_, bridge, _, token_addr, _, token_admin) = setup_bridge(&env);
+    let user = Address::generate(&env);
+
+    fund_and_deposit(&env, &bridge, &token_admin, &token_addr, &user, 6_000);
+
+    let id1 = bridge.request_withdrawal(&user, &1_000, &token_addr, &None, &0);
+    let id2 = bridge.request_withdrawal(&user, &1_000, &token_addr, &None, &0);
+    let id3 = bridge.request_withdrawal(&user, &1_000, &token_addr, &None, &0);
+
+    assert!(id2 > id1 && id3 > id2, "request ids must increase monotonically");
+    assert!(bridge.get_withdrawal_request(&id1).is_some());
+    assert!(bridge.get_withdrawal_request(&id2).is_some());
+    assert!(bridge.get_withdrawal_request(&id3).is_some());
+    assert_eq!(bridge.get_wq_depth(), 3);
+    assert_eq!(bridge.get_total_liabilities(), 3_000);
+}
+
+/// Acceptance criterion: a successful request emits a contract event with a
+/// non-empty topic set (the `WithdrawalRequested` event).
+#[test]
+fn test_request_withdrawal_invariant_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (contract_id, bridge, _, token_addr, _, token_admin) = setup_bridge(&env);
+    let user = Address::generate(&env);
+
+    fund_and_deposit(&env, &bridge, &token_admin, &token_addr, &user, 5_000);
+    bridge.request_withdrawal(&user, &1_000, &token_addr, &None, &0);
+
+    let events = env.events().all().filter_by_contract(&contract_id);
+    let event_vec = events.events();
+    assert!(
+        !event_vec.is_empty(),
+        "request_withdrawal should emit at least one contract event",
+    );
+
+    let last_event = &event_vec[event_vec.len() - 1];
+    use soroban_sdk::xdr::ContractEventBody;
+    let ContractEventBody::V0(body) = &last_event.body;
+    assert!(
+        !body.topics.is_empty(),
+        "the emitted withdrawal event must carry topics",
+    );
+}
+
+/// Invariant: requesting against a token that is not whitelisted is rejected
+/// and leaves the queue empty.
+#[test]
+fn test_request_withdrawal_invariant_unwhitelisted_token_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (_, bridge, _, _token_addr, _, _) = setup_bridge(&env);
+    let user = Address::generate(&env);
+
+    // A token the contract has never registered.
+    let stray_admin = Address::generate(&env);
+    let (stray_token, _stray_sac) = create_token_contract(&env, &stray_admin);
+    let stray_addr = stray_token.address.clone();
+
+    let result = bridge.try_request_withdrawal(&user, &1_000, &stray_addr, &None, &0);
+    assert_eq!(result, Err(Ok(Error::TokenNotWhitelisted)));
+    assert_eq!(bridge.get_wq_depth(), 0, "a rejected request must not queue anything");
+}


### PR DESCRIPTION
## Summary

Implements four assigned issues in a single PR.

### `feat(frontend): framer-motion animation in chatTelemetry.ts` (#674)
Adds reduced-motion-aware, intent-weighted framer-motion variants for telemetry chips/toasts:
- `getTelemetryMotionVariants({ reducedMotion?, intent? })` returns intent-weighted enter/exit variants, or a movement-free fade when reduced motion is requested.
- `prefersReducedMotion()` — SSR-safe `prefers-reduced-motion` detection (honours the user's OS setting, falls back to `false` on the server).
- `reducedTelemetryMotionVariants` (opacity-only) and `telemetryEventMotionIntent(name)` to map event names → visual weight.
- The existing `telemetryMotionVariants` export is unchanged.

### `feat(frontend): dark mode fallback in useTransactionFilters.ts` (#671)
Guarantees filter chip tones render correctly in dark mode:
- `withDarkModeFallback(tone)` / `ensureDarkModeClasses(className, fallback)` backfill neutral `dark:` classes onto any tone field that lacks them.
- `getAccessibleFilterChipTone` now passes tones through the fallback. Built-in palettes already ship `dark:` variants, so they are returned unchanged (no regression).

### `feat(frontend): debounce mechanism in chatStateMachine.ts` (#588)
Adds `createDebouncedDispatcher(machine, delayMs)` — a debounced event dispatcher that collapses rapid event bursts (e.g. fast typing repeatedly firing `SEND_MESSAGE`) into a single trailing transition. Exposes `dispatch` / `flush` / `cancel` / `isPending` and a `DEFAULT_DISPATCH_DEBOUNCE_MS` default.

### `feat(contract): invariant tests for request_withdrawal` (#572)
New `test_issue_572` module locking in the accounting invariants `request_withdrawal` enforces via `check_invariants`:
- liabilities grow by exactly the requested amount; queue depth increments by one;
- `total_liabilities <= net_deposited` and on-chain balance covers the net position;
- over-commit / zero-amount / unwhitelisted-token requests are rejected **and leave state unchanged** (no partial mutation);
- request ids are unique and monotonic; a successful request emits a `WithdrawalRequested` event.

## Build unblock (pre-existing, not caused by this change)
The contract crate did not compile on `main` due to a botched merge, which also blocked these new tests from compiling. Minimal fixes restore the **intended** API:
- `src/math.rs` had duplicate `mul_div_floor` / `mul_div_ceil` definitions (one mangled) and was missing the `checked_mul_div_floor` / `checked_mul_div_ceil` helpers that `lib.rs` already calls at two sites. Reconstructed the checked helpers + panicking wrappers; behaviour is validated by the crate's existing `math` tests.
- `src/test.rs` referenced a renamed binding (`token` → `_token`).

## Test plan
- [x] `pnpm exec vitest run` for the three affected frontend test files — **109 passed**
- [x] `tsc --noEmit` — no errors in the changed files
- [x] `eslint` — clean on all changed frontend files
- [x] `cargo test` (contract crate) — **379 passed, 0 failed** (incl. the 7 new invariant tests and the `math` tests)
- [x] `cargo clippy` — no warnings introduced by the changed/added files

## Out of scope (pre-existing on `main`)
- `Dechat/dex_with_fiat_frontend/src/hooks/useChat.ts` still contains unresolved merge-conflict markers (fails `tsc`/build) — untouched here.
- 7 pre-existing `clippy` warnings in other contract test files (unused variables) remain; none are in the files changed by this PR.

Closes #674
Closes #671
Closes #588
Closes #572