### PR TITLE
Xeladev4/fix/issues 1017 1023 1026 1037 contract validation

### DIFF
--- a/Dechat/stellar-contracts/src/lib.rs
+++ b/Dechat/stellar-contracts/src/lib.rs
@@ -24,6 +24,10 @@ pub const MIN_TTL: u32 = 518_400;
 pub const MAX_TTL: u32 = 535_680;
 /// Maximum byte length of a deposit reference string.
 const MAX_REFERENCE_LEN: u32 = 64;
+/// Canonical all-zero Stellar account strkey (G…), used to detect the "zero address".
+const ZERO_ACCOUNT_STRKEY: &str = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+/// Canonical all-zero Stellar contract strkey (C…), used to detect the "zero address".
+const ZERO_CONTRACT_STRKEY: &str = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4";
 /// Number of ledgers in a 24-hour rolling window (~5 s/ledger × 17 280 = 24 h).
 ///
 /// Used for daily deposit limits, fiat volume caps, and withdrawal quotas.
@@ -3100,6 +3104,18 @@ impl FiatBridge {
         admin.require_auth();
 
         // ── Parameter validation ───────────────────────────────────────────
+        // ── Issue #1026: reject the zero address ──
+        // Setting the recovery target to the all-zero account/contract address
+        // would permanently lock any funds routed through emergency recovery,
+        // so it is rejected explicitly before any state mutation.
+        let zero_account =
+            Address::from_string(&soroban_sdk::String::from_str(&env, ZERO_ACCOUNT_STRKEY));
+        let zero_contract =
+            Address::from_string(&soroban_sdk::String::from_str(&env, ZERO_CONTRACT_STRKEY));
+        if recovery == zero_account || recovery == zero_contract {
+            return Err(Error::InvalidRecipient);
+        }
+
         if cap_limit <= 0 {
             return Err(Error::ZeroAmount);
         }

--- a/Dechat/stellar-contracts/src/lib.rs
+++ b/Dechat/stellar-contracts/src/lib.rs
@@ -2169,6 +2169,21 @@ impl FiatBridge {
             return Err(Error::InvalidRecipient);
         }
 
+        // ── Issue #1017: reject requests exceeding the user's deposited balance ──
+        // The global liability/balance checks above only guarantee the *pool*
+        // can cover the request — without a per-user check a depositor could
+        // request more than they ever deposited and drain other users' funds
+        // (and over-requests would panic at settlement). Bound the request to
+        // what this recipient has actually deposited.
+        let user_deposited: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::UserDeposited(to.clone()))
+            .unwrap_or(0);
+        if amount > user_deposited {
+            return Err(Error::InsufficientFunds);
+        }
+
         // Denylist
         if env.storage().persistent().has(&DataKey::Denied(to.clone())) {
             return Err(Error::AddressDenied);

--- a/Dechat/stellar-contracts/src/lib.rs
+++ b/Dechat/stellar-contracts/src/lib.rs
@@ -7156,3 +7156,6 @@ mod test_issue_994_1003;
 
 #[cfg(test)]
 mod test_issue_572;
+
+#[cfg(test)]
+mod test_issues_1017_1023_1026_1037;

--- a/Dechat/stellar-contracts/src/lib.rs
+++ b/Dechat/stellar-contracts/src/lib.rs
@@ -98,6 +98,8 @@ pub enum Error {
     OperatorDailyLimitExceeded = 313,
     ExceedsLimitMaxCap = 314,
     MaxDeniedReached = 315,
+    /// Returned by `init` when the token address does not implement the SEP-41 token interface.
+    InvalidToken = 316,
 
     // --- 400 series: Funds & Balances ---
     InsufficientFunds = 401,
@@ -1115,6 +1117,7 @@ impl FiatBridge {
     /// - [`Error::MaxSignersReached`]  if `signers.len()` > [`MAX_SIGNERS`].
     /// - [`Error::InvalidThreshold`]   if `threshold` is 0 or > `signers.len()`.
     /// - [`Error::DuplicateSigner`]    if `signers` contains duplicate addresses.
+    /// - [`Error::InvalidToken`]       if `token` does not implement the SEP-41 token interface.
     pub fn init(
         env: Env,
         admin: Address,
@@ -1147,6 +1150,16 @@ impl FiatBridge {
             require!(!seen.contains(&s), Error::DuplicateSigner);
             seen.push_back(s);
         }
+
+        // ── Issue #1037: verify the token implements the SEP-41 interface ──
+        // Probe a mandatory SEP-41 read method (`decimals`) on the supplied
+        // address. A non-token contract — or a plain account address — cannot
+        // answer this call, so we reject it before any state is written and
+        // before funds can ever be locked against an unusable token.
+        require!(
+            token::Client::new(&env, &token).try_decimals().is_ok(),
+            Error::InvalidToken
+        );
 
         env.storage()
             .instance()

--- a/Dechat/stellar-contracts/src/lib.rs
+++ b/Dechat/stellar-contracts/src/lib.rs
@@ -5171,21 +5171,24 @@ impl FiatBridge {
 
     /// Returns the cumulative amount deposited across all users.
     ///
-    /// # Errors
-    /// - [`Error::NotInitialized`]      if the contract has not been initialised.
-    /// - [`Error::TokenNotWhitelisted`] if no token config exists.
-    pub fn get_total_deposited(env: Env) -> Result<i128, Error> {
-        let tok = env
+    /// Issue #1023: this is a public, unauthenticated view intended for
+    /// dashboards. It returns `0` on empty state — before initialization or
+    /// when no token config exists yet — rather than erroring, so callers can
+    /// treat the result as a plain running total.
+    pub fn get_total_deposited(env: Env) -> i128 {
+        match env
             .storage()
             .instance()
             .get::<_, Address>(&DataKey::Token)
-            .ok_or(Error::NotInitialized)?;
-        Ok(env
-            .storage()
-            .persistent()
-            .get::<_, TokenConfig>(&DataKey::TokenRegistry(tok))
-            .ok_or(Error::InternalError)?
-            .total_deposited)
+        {
+            Some(tok) => env
+                .storage()
+                .persistent()
+                .get::<_, TokenConfig>(&DataKey::TokenRegistry(tok))
+                .map(|c| c.total_deposited)
+                .unwrap_or(0),
+            None => 0,
+        }
     }
     /// Returns the current withdrawal lock period in ledgers.
     pub fn get_lock_period(env: Env) -> u32 {

--- a/Dechat/stellar-contracts/src/test_issue_970.rs
+++ b/Dechat/stellar-contracts/src/test_issue_970.rs
@@ -29,7 +29,9 @@ fn accept_admin_before_delay_returns_too_early() {
 
     let admin = Address::generate(&env);
     let new_admin = Address::generate(&env);
-    let token = Address::generate(&env);
+    let token = env
+        .register_stellar_asset_contract_v2(Address::generate(&env))
+        .address();
 
     let contract_id = env.register(FiatBridge, ());
     let client = FiatBridgeClient::new(&env, &contract_id);
@@ -54,7 +56,9 @@ fn accept_admin_at_delay_boundary_succeeds() {
 
     let admin = Address::generate(&env);
     let new_admin = Address::generate(&env);
-    let token = Address::generate(&env);
+    let token = env
+        .register_stellar_asset_contract_v2(Address::generate(&env))
+        .address();
 
     let contract_id = env.register(FiatBridge, ());
     let client = FiatBridgeClient::new(&env, &contract_id);
@@ -79,7 +83,9 @@ fn cancel_admin_transfer_removes_pending() {
 
     let admin = Address::generate(&env);
     let new_admin = Address::generate(&env);
-    let token = Address::generate(&env);
+    let token = env
+        .register_stellar_asset_contract_v2(Address::generate(&env))
+        .address();
 
     let contract_id = env.register(FiatBridge, ());
     let client = FiatBridgeClient::new(&env, &contract_id);
@@ -104,7 +110,9 @@ fn cancel_when_no_pending_returns_error() {
     env.mock_all_auths();
 
     let admin = Address::generate(&env);
-    let token = Address::generate(&env);
+    let token = env
+        .register_stellar_asset_contract_v2(Address::generate(&env))
+        .address();
 
     let contract_id = env.register(FiatBridge, ());
     let client = FiatBridgeClient::new(&env, &contract_id);
@@ -123,7 +131,9 @@ fn config_snapshot_includes_proposed_at() {
 
     let admin = Address::generate(&env);
     let new_admin = Address::generate(&env);
-    let token = Address::generate(&env);
+    let token = env
+        .register_stellar_asset_contract_v2(Address::generate(&env))
+        .address();
 
     let contract_id = env.register(FiatBridge, ());
     let client = FiatBridgeClient::new(&env, &contract_id);

--- a/Dechat/stellar-contracts/src/test_issues_1017_1023_1026_1037.rs
+++ b/Dechat/stellar-contracts/src/test_issues_1017_1023_1026_1037.rs
@@ -1,0 +1,178 @@
+//! Regression tests for:
+//! - #1017 `request_withdrawal` must reject amounts exceeding the user's deposited balance.
+//! - #1023 `get_total_deposited` view returns the running total and 0 on empty state.
+//! - #1026 `set_emergency_recovery` must reject the zero address.
+//! - #1037 `init` must reject tokens that do not implement the SEP-41 interface.
+
+#![cfg(test)]
+
+use soroban_sdk::{
+    testutils::Address as _,
+    token::StellarAssetClient,
+    vec, Address, Bytes, Env, String,
+};
+
+use crate::{Error, FiatBridge, FiatBridgeClient};
+
+const LIMIT: i128 = 1_000_000;
+
+/// Registers a bridge initialised against a real Stellar asset (SEP-41) token.
+fn setup(env: &Env) -> (FiatBridgeClient<'_>, Address, Address, StellarAssetClient<'_>) {
+    let contract_id = env.register(FiatBridge, ());
+    let client = FiatBridgeClient::new(env, &contract_id);
+
+    let admin = Address::generate(env);
+    let token_admin = Address::generate(env);
+    let token_addr = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+    let token_sac = StellarAssetClient::new(env, &token_addr);
+
+    let signers = vec![env, admin.clone()];
+    client.init(&admin, &token_addr, &LIMIT, &1, &signers, &1);
+
+    (client, admin, token_addr, token_sac)
+}
+
+// ── #1037: SEP-41 token validation in init ──────────────────────────────────
+
+/// A valid Stellar asset contract is accepted by `init`.
+#[test]
+fn init_accepts_sep41_token() {
+    let env = Env::default();
+    env.mock_all_auths();
+    // `setup` would panic if init rejected the SAC token.
+    let (client, _admin, _token, _sac) = setup(&env);
+    assert_eq!(client.get_total_deposited(), 0);
+}
+
+/// A registered contract that does not implement the SEP-41 interface is rejected.
+#[test]
+fn init_rejects_non_sep41_token() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(FiatBridge, ());
+    let client = FiatBridgeClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    // Another bridge contract: it exists on-ledger but has no `decimals` method.
+    let bogus_token = env.register(FiatBridge, ());
+    let signers = vec![&env, admin.clone()];
+
+    let result = client.try_init(&admin, &bogus_token, &LIMIT, &1, &signers, &1);
+    assert_eq!(result, Err(Ok(Error::InvalidToken)));
+}
+
+// ── #1026: zero-address rejection in set_emergency_recovery ──────────────────
+
+/// The all-zero account address (G…) is rejected as a recovery target.
+#[test]
+fn set_emergency_recovery_rejects_zero_account() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _token, _sac) = setup(&env);
+
+    let zero_account =
+        Address::from_string(&String::from_str(&env, crate::ZERO_ACCOUNT_STRKEY));
+    let result = client.try_set_emergency_recovery(&zero_account, &1_000);
+    assert_eq!(result, Err(Ok(Error::InvalidRecipient)));
+}
+
+/// The all-zero contract address (C…) is rejected as a recovery target.
+#[test]
+fn set_emergency_recovery_rejects_zero_contract() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _token, _sac) = setup(&env);
+
+    let zero_contract =
+        Address::from_string(&String::from_str(&env, crate::ZERO_CONTRACT_STRKEY));
+    let result = client.try_set_emergency_recovery(&zero_contract, &1_000);
+    assert_eq!(result, Err(Ok(Error::InvalidRecipient)));
+}
+
+/// A normal address is still accepted.
+#[test]
+fn set_emergency_recovery_accepts_valid_address() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _token, _sac) = setup(&env);
+
+    let recovery = Address::generate(&env);
+    client.set_emergency_recovery(&recovery, &1_000);
+    assert_eq!(client.get_emergency_recovery_cap(), Some(1_000));
+}
+
+// ── #1017: per-user balance validation in request_withdrawal ─────────────────
+
+/// A user cannot request more than they personally deposited, even when the
+/// pool holds enough liquidity from other depositors.
+#[test]
+fn request_withdrawal_rejects_amount_above_user_deposit() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, token_addr, token_sac) = setup(&env);
+
+    let small_depositor = Address::generate(&env);
+    let whale = Address::generate(&env);
+    token_sac.mint(&small_depositor, &10_000);
+    token_sac.mint(&whale, &10_000);
+
+    client.deposit(&small_depositor, &100, &token_addr, &Bytes::new(&env), &0, &0, &None);
+    client.deposit(&whale, &5_000, &token_addr, &Bytes::new(&env), &0, &0, &None);
+
+    // Pool holds 5_100, but the small depositor only ever deposited 100.
+    let result =
+        client.try_request_withdrawal(&small_depositor, &500, &token_addr, &None, &0);
+    assert_eq!(result, Err(Ok(Error::InsufficientFunds)));
+}
+
+/// A request up to the user's deposited balance succeeds.
+#[test]
+fn request_withdrawal_allows_up_to_user_deposit() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, token_addr, token_sac) = setup(&env);
+
+    let user = Address::generate(&env);
+    token_sac.mint(&user, &10_000);
+    client.deposit(&user, &1_000, &token_addr, &Bytes::new(&env), &0, &0, &None);
+
+    let req_id = client.request_withdrawal(&user, &1_000, &token_addr, &None, &0);
+    assert_eq!(req_id, 0);
+}
+
+// ── #1023: get_total_deposited view ─────────────────────────────────────────
+
+/// On a freshly registered (uninitialised) contract the view returns 0.
+#[test]
+fn get_total_deposited_zero_before_init() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(FiatBridge, ());
+    let client = FiatBridgeClient::new(&env, &contract_id);
+
+    assert_eq!(client.get_total_deposited(), 0);
+}
+
+/// The view reports the cumulative sum of all users' deposits.
+#[test]
+fn get_total_deposited_sums_all_deposits() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, token_addr, token_sac) = setup(&env);
+
+    assert_eq!(client.get_total_deposited(), 0);
+
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    token_sac.mint(&alice, &10_000);
+    token_sac.mint(&bob, &10_000);
+
+    client.deposit(&alice, &300, &token_addr, &Bytes::new(&env), &0, &0, &None);
+    client.deposit(&bob, &700, &token_addr, &Bytes::new(&env), &0, &0, &None);
+
+    assert_eq!(client.get_total_deposited(), 1_000);
+}


### PR DESCRIPTION
# Pull Request: Contract Hardening — Withdrawal Balance, Recovery Zero-Address, Token Validation, Total-Deposited View

## Summary

- `fix(contract): request_withdrawal validates amount against the user's deposited balance` — Closes #1017
- `fix(contract): set_emergency_recovery rejects the zero address` — Closes #1026
- `fix(contract): init validates the token implements the SEP-41 interface` — Closes #1037
- `feat(contract): get_total_deposited returns 0 on empty state for dashboard use` — Closes #1023

All changes are in `Dechat/stellar-contracts/src/lib.rs` with regression tests in
`Dechat/stellar-contracts/src/test_issues_1017_1023_1026_1037.rs`.

## Changes

### fix(contract): per-user balance validation in `request_withdrawal` — Closes #1017

`request_withdrawal` only validated the requested amount against the *pool-wide*
contract balance and net-deposited liabilities. Because there was no per-user
check, any depositor could request more than they personally deposited and drain
other users' funds (and an over-request would later panic at settlement).

The fix bounds each request to the recipient's own deposited balance
(`DataKey::UserDeposited`) and returns `Error::InsufficientFunds` when exceeded.
The check is placed after the existing `InvalidRecipient` (recipient-is-contract)
guard so prior error semantics are preserved.

### fix(contract): reject zero address in `set_emergency_recovery` — Closes #1026

`set_emergency_recovery` accepted the all-zero account/contract address, which
would permanently lock any funds routed through emergency recovery. The fix
rejects both canonical zero strkeys (the all-zero `G…` account and `C…`
contract) with `Error::InvalidRecipient` before any state is written.

### fix(contract): SEP-41 token validation in `init` — Closes #1037

`init` accepted any address as the managed token without verifying it was a
usable token contract. The fix probes the mandatory SEP-41 read method
`decimals()` on the supplied address; a non-token contract — or a plain account
address — cannot answer the call, so it is rejected with the new
`Error::InvalidToken` (316) before any state is written and before funds can be
locked against an unusable token.

`src/test_issue_970.rs` was updated to register real Stellar asset contracts for
its `init` calls (it previously passed generated placeholder addresses, which are
no longer valid token addresses under the new check).

### feat(contract): `get_total_deposited` view — Closes #1023

`get_total_deposited` now returns a plain `i128` and yields `0` on empty state
(before initialization or when no token config exists) instead of erroring, so
dashboards can treat it as a running total. It remains callable by anyone and
returns the cumulative sum of all users' deposits.

## New error variant

- `Error::InvalidToken = 316` — returned by `init` for non-SEP-41 token addresses.

## Test plan

New tests in `test_issues_1017_1023_1026_1037.rs`:

- **#1017** — `request_withdrawal_rejects_amount_above_user_deposit` (small depositor
  cannot withdraw against a whale's liquidity) and `request_withdrawal_allows_up_to_user_deposit`.
- **#1026** — `set_emergency_recovery_rejects_zero_account`,
  `set_emergency_recovery_rejects_zero_contract`, and `set_emergency_recovery_accepts_valid_address`.
- **#1037** — `init_rejects_non_sep41_token` and `init_accepts_sep41_token`.
- **#1023** — `get_total_deposited_zero_before_init` and `get_total_deposited_sums_all_deposits`.

Run locally from `Dechat/stellar-contracts`:

```bash
cargo test
cargo clippy --all-targets --all-features -- -D warnings
```
