### PR TITLE
feat(frontend): add transaction status polling with SSE fallback in useChat.ts

### DIFF
--- a/Dechat/dex_with_fiat_frontend/src/hooks/useChat.ts
+++ b/Dechat/dex_with_fiat_frontend/src/hooks/useChat.ts
@@ -2,7 +2,9 @@
 
 import { useStellarWallet } from '@/contexts/StellarWalletContext';
 import { AIAssistant } from '@/lib/aiAssistant';
+import { getOrCreateClientSessionId } from '@/lib/clientSession';
 import { perf } from '@/lib/perf';
+import { type PaymentStatusEvent } from '@/lib/paymentStatusEvents';
 import {
   AIAnalysisResult,
   ChatMessage,
@@ -47,6 +49,8 @@ type QueuedSend = {
   };
 };
 
+const POLL_INTERVAL_MS = 3_000;
+
 const useChat = () => {
   const { connection } = useStellarWallet();
   const {
@@ -67,6 +71,13 @@ const useChat = () => {
   const [onTransactionReady, setOnTransactionReady] = useState<
     ((data: TransactionData) => void) | null
   >(null);
+
+  // Transaction status – updated via SSE or polling fallback
+  const [transactionStatus, setTransactionStatus] = useState<PaymentStatusEvent | null>(null);
+
+  // SSE connection and polling fallback refs
+  const sseRef = useRef<EventSource | null>(null);
+  const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const getInitialSuggestedActions = useCallback(() => {
     if (connection.isConnected) {
@@ -109,9 +120,9 @@ I'm your AI specialist for seamless XLM-to-fiat conversions on Stellar. I can he
 **Optimize timing** for better conversion rates
 
 ${connection.isConnected
-          ? `**Freighter Connected**: Ready to check your XLM portfolio and start conversions!`
-          : `**Connect Freighter** to get started with personalized XLM portfolio analysis.`
-        }
+        ? `**Freighter Connected**: Ready to check your XLM portfolio and start conversions!`
+        : `**Connect Freighter** to get started with personalized XLM portfolio analysis.`
+      }
 
 What would you like to do today? I'm here to make your XLM-to-fiat journey smooth and profitable!`,
       timestamp: new Date(),
@@ -146,6 +157,81 @@ What would you like to do today? I'm here to make your XLM-to-fiat journey smoot
   useEffect(() => {
     messagesRef.current = messages;
   }, [messages]);
+
+  // ── Transaction status: SSE with 3s polling fallback ─────────────────────────
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const sessionId = getOrCreateClientSessionId();
+    if (!sessionId) return;
+
+    const streamUrl = `/api/payment-status/stream?sessionId=${encodeURIComponent(sessionId)}`;
+
+    const handleStatusEvent = (payload: PaymentStatusEvent) => {
+      setTransactionStatus(payload);
+    };
+
+    const stopPolling = () => {
+      if (pollIntervalRef.current !== null) {
+        clearInterval(pollIntervalRef.current);
+        pollIntervalRef.current = null;
+      }
+    };
+
+    const startPolling = () => {
+      stopPolling();
+      pollIntervalRef.current = setInterval(async () => {
+        const reference =
+          machineRef.current.getState().context.pendingTransactionData?.reference;
+        if (!reference) return;
+        try {
+          const res = await fetch(
+            `/api/transfer-status/${encodeURIComponent(reference)}`,
+          );
+          if (res.ok) {
+            const json = (await res.json()) as { success: boolean; data?: PaymentStatusEvent };
+            if (json.success && json.data) {
+              handleStatusEvent(json.data);
+            }
+          }
+        } catch {
+          // network failure during polling — retry on next tick
+        }
+      }, POLL_INTERVAL_MS);
+    };
+
+    if (typeof EventSource === 'undefined') {
+      // SSE not available in this environment — go straight to polling
+      startPolling();
+    } else {
+      const es = new EventSource(streamUrl);
+      sseRef.current = es;
+
+      es.onmessage = (event) => {
+        try {
+          const payload = JSON.parse(event.data as string) as PaymentStatusEvent;
+          handleStatusEvent(payload);
+        } catch {
+          // malformed SSE data — ignore
+        }
+      };
+
+      es.onerror = () => {
+        es.close();
+        sseRef.current = null;
+        // SSE failed — fall back to polling
+        startPolling();
+      };
+    }
+
+    return () => {
+      sseRef.current?.close();
+      sseRef.current = null;
+      stopPolling();
+    };
+  // Re-run only when the session changes so the connection tracks the right session.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentSessionId]);
 
   const appendCancelledMessage = useCallback((content: string) => {
     const uid =
@@ -234,7 +320,6 @@ What would you like to do today? I'm here to make your XLM-to-fiat journey smoot
       prev.map((m) =>
         m.id === pendingAssistantId
           ? {
-<<<<<<< HEAD:dex_with_fiat_frontend/src/hooks/useChat.ts
               ...m,
               content:
                 'Sorry, I encountered an error processing your request. Please try again.',
@@ -256,16 +341,6 @@ What would you like to do today? I'm here to make your XLM-to-fiat journey smoot
                 status: 'failed',
               },
             }
-=======
-            ...m,
-            content:
-              'Sorry, I encountered an error processing your request. Please try again.',
-            metadata: {
-              ...m.metadata,
-              status: 'failed',
-            },
-          }
->>>>>>> origin/main:Dechat/dex_with_fiat_frontend/src/hooks/useChat.ts
           : m,
       ),
     );
@@ -444,26 +519,32 @@ What would you like to do today? I'm here to make your XLM-to-fiat journey smoot
         prev.map((m) =>
           m.id === pendingAssistantId
             ? {
-              ...m,
-              content: enhancedResponse,
-              metadata: {
-                ...m.metadata,
-                status: 'sent',
-                guardrail: analysis.guardrail,
-                transactionData: shouldShowTransactionData
-                  ? (analysis.extractedData as TransactionData)
-                  : undefined,
-                suggestedActions: generateSuggestedActions(analysis, {
-                  isWalletConnected: connection.isConnected,
-                  messageCount: newMessageCount,
-                  hasTransactionData: !!pendingTransactionData,
-                  shouldAutoTrigger: !!shouldAutoTrigger,
-                  isAdmin: isAdmin,
+                ...m,
+                content: enhancedResponse,
+                metadata: {
+                  ...m.metadata,
+                  status: 'sent',
+                  guardrail: analysis.guardrail,
+                  transactionData: shouldShowTransactionData
+                    ? (analysis.extractedData as TransactionData)
+                    : undefined,
+                  suggestedActions: generateSuggestedActions(analysis, {
+                    isWalletConnected: connection.isConnected,
+                    messageCount: newMessageCount,
+                    hasTransactionData: !!pendingTransactionData,
+                    shouldAutoTrigger: !!shouldAutoTrigger,
+                    isAdmin: isAdmin,
+                    lowConfidence: needsClarification,
+                  }),
+                  confirmationRequired:
+                    analysis.intent === 'fiat_conversion' ||
+                    shouldTriggerTransaction,
+                  autoTriggerTransaction: shouldTriggerTransaction,
+                  conversationCount: newMessageCount,
                   lowConfidence: needsClarification,
-<<<<<<< HEAD:dex_with_fiat_frontend/src/hooks/useChat.ts
                   clarificationQuestion: clarificationQuestion || undefined,
                 },
-            }
+              }
             : m,
         ),
       );
@@ -478,18 +559,6 @@ What would you like to do today? I'm here to make your XLM-to-fiat journey smoot
                   status: 'sent',
                 },
               }
-=======
-                }),
-                confirmationRequired:
-                  analysis.intent === 'fiat_conversion' ||
-                  shouldTriggerTransaction,
-                autoTriggerTransaction: shouldTriggerTransaction,
-                conversationCount: newMessageCount,
-                lowConfidence: needsClarification,
-                clarificationQuestion: clarificationQuestion || undefined,
-              },
-            }
->>>>>>> origin/main:Dechat/dex_with_fiat_frontend/src/hooks/useChat.ts
             : m,
         ),
       );
@@ -831,6 +900,7 @@ What would you like to do today? I'm here to make your XLM-to-fiat journey smoot
     loadChatSession,
     currentSessionId,
     conversationState,
+    transactionStatus,
     setTransactionReadyCallback,
     setIsAdmin: setIsAdminState,
     cancelPendingRequest,


### PR DESCRIPTION
## Summary

- Replaces interval-based transaction status polling with a Server-Sent Events (SSE) connection to `/api/payment-status/stream`
- Automatically falls back to 3-second polling against `/api/transfer-status/{reference}` when `EventSource` is unavailable or the SSE connection drops
- SSE connection and polling interval are both cleaned up on component unmount, preventing memory leaks
- Resolves pre-existing merge conflict in `markMessageFailed` and `analyzeAndRespond`
- Exposes `transactionStatus: PaymentStatusEvent | null` in the hook's return value

## Acceptance Criteria

- [x] SSE used when supported (`EventSource` available)
- [x] Auto-fallback to 3s polling when SSE is not supported or errors
- [x] Connection cleaned up on unmount

## Test plan

- [ ] Open chat — verify SSE connection is established to `/api/payment-status/stream`
- [ ] Trigger a payment and confirm `transactionStatus` updates in real time via SSE
- [ ] Simulate SSE failure (block the endpoint) and confirm polling kicks in every 3s
- [ ] Navigate away and confirm no lingering EventSource or setInterval

Closes #1012
Closes #1010
Closes #1015
Closes #998