### PR TITLE
docs: improve inline documentation for circuit breaker

### DIFF
--- a/Dechat/stellar-contracts/FIAT_BRIDGE_README.md
+++ b/Dechat/stellar-contracts/FIAT_BRIDGE_README.md
@@ -41,6 +41,47 @@ flowchart TD
 
 ---
 
+## Circuit Breaker
+
+The FiatBridge uses a **global rolling withdrawal circuit breaker** as a last-resort safety stop for withdrawal flows.
+
+### What it watches
+
+- Every `withdraw`, `request_withdrawal`, and `execute_withdrawal` call contributes to a shared rolling withdrawal total.
+- The total is tracked in `GlobalDailyWithdrawn { amount, window_start }`.
+- The default evaluation window is 24 hours (`WINDOW_LEDGERS`).
+
+### When it trips
+
+- Admin configures the breaker with `set_circuit_breaker_threshold(threshold)`.
+- A threshold of `0` disables the breaker entirely.
+- If a withdrawal would push the rolling total **above** the configured threshold, that withdrawal is rejected and the contract marks the breaker as tripped.
+- The contract emits `CircuitBreakerTrippedEvent { new_total, threshold }` and stores the trip ledger in `CircuitBreakerTrippedAt`.
+
+### What gets blocked
+
+While the breaker is active, the contract refuses high-sensitivity operations that would otherwise continue withdrawal processing, including:
+
+- `withdraw`
+- `request_withdrawal`
+- `execute_withdrawal`
+- `heartbeat`
+- `get_receipt_by_index`
+- selected admin mutations such as `set_limit`
+
+### How reset works
+
+- Admin can clear it manually with `reset_circuit_breaker()`.
+- Admin can configure auto-reset behavior with `set_circuit_breaker_reset_window(ledgers)`.
+- `0` means "use the default 48-hour window" (`CIRCUIT_BREAKER_RESET_LEDGERS`).
+- `u32::MAX` disables auto-reset entirely.
+- On auto-reset, the breaker clears and the rolling withdrawal window is restarted, and the contract emits `CircuitBreakerAutoResetEvent { tripped_at, reset_at }`.
+
+### Operational guidance
+
+- Use the breaker as a **system-wide safety rail**, not as a user-specific rate limiter.
+- Keep the threshold high enough to tolerate normal batched withdrawals but low enough to catch runaway operator or automation behavior.
+- If the breaker trips unexpectedly, inspect recent withdrawal and heartbeat activity before manually resetting it.
 ## Admin Authentication Architecture
 
 Admin privileges in the FiatBridge are strictly tied to the on-chain state. The architecture ensures that no front-end spoofing or bypassed routing can escalate privileges.

--- a/Dechat/stellar-contracts/src/lib.rs
+++ b/Dechat/stellar-contracts/src/lib.rs
@@ -6259,8 +6259,19 @@ impl FiatBridge {
 
     // ── Issue #209: global circuit breaker ───────────────────────────────
 
-    /// Set the rolling 24-hour withdrawal volume threshold that triggers the
-    /// circuit breaker.  Pass `0` to disable.
+    /// Set the rolling withdrawal volume threshold that trips the global circuit breaker.
+    ///
+    /// The breaker is evaluated across all withdrawal-producing flows that call
+    /// [`Self::check_and_update_circuit_breaker`], including direct withdrawals,
+    /// queued withdrawal requests, and queued withdrawal execution.
+    ///
+    /// - `threshold > 0`: enables the breaker and rejects the withdrawal that
+    ///   would push the rolling total above the threshold.
+    /// - `threshold == 0`: disables the breaker entirely.
+    ///
+    /// This value is stored under [`DataKey::CircuitBreakerThreshold`]. It does
+    /// not itself reset an already-tripped breaker; use [`Self::reset_circuit_breaker`]
+    /// for that operational action.
     pub fn set_circuit_breaker_threshold(env: Env, threshold: i128) -> Result<(), Error> {
         let admin: Address = env
             .storage()
@@ -6274,10 +6285,19 @@ impl FiatBridge {
         Ok(())
     }
 
-    /// Set the number of ledgers after which a tripped circuit breaker
-    /// automatically resets. Pass `0` to use the compile-time default
-    /// (`CIRCUIT_BREAKER_RESET_LEDGERS`). Set to `u32::MAX` to disable
-    /// auto-reset entirely.
+    /// Configure the auto-reset window for a tripped circuit breaker.
+    ///
+    /// The breaker stores the ledger at which it tripped in
+    /// [`DataKey::CircuitBreakerTrippedAt`]. On the next guarded withdrawal or
+    /// heartbeat path, the contract compares the current ledger against that
+    /// trip point plus this reset window.
+    ///
+    /// - `0`: use the default 48-hour window [`CIRCUIT_BREAKER_RESET_LEDGERS`]
+    /// - `u32::MAX`: disable auto-reset entirely
+    /// - any other value: use that many ledgers as the reset window
+    ///
+    /// Auto-reset clears the tripped flag and rolls the global withdrawal window
+    /// forward before the next guarded operation resumes.
     pub fn set_circuit_breaker_reset_window(env: Env, ledgers: u32) -> Result<(), Error> {
         let admin: Address = env
             .storage()
@@ -6299,7 +6319,14 @@ impl FiatBridge {
             .unwrap_or(CIRCUIT_BREAKER_RESET_LEDGERS)
     }
 
-    /// Reset the circuit breaker so withdrawals can resume.
+    /// Manually clear the circuit breaker so guarded operations can resume.
+    ///
+    /// This admin-only action flips [`DataKey::CircuitBreakerTripped`] back to
+    /// `false` and emits [`CircuitBreakerResetEvent`]. It is intended for manual
+    /// recovery after operators have investigated the activity that caused the
+    /// breaker to trip.
+    ///
+    /// This function does not change the configured threshold or reset window.
     pub fn reset_circuit_breaker(env: Env) -> Result<(), Error> {
         let admin: Address = env
             .storage()
@@ -6385,9 +6412,21 @@ impl FiatBridge {
         }
     }
 
-    /// Accumulate `amount` into the rolling 24-h global withdrawal volume.
-    /// Returns `CircuitBreakerActive` if the threshold is already tripped **or**
-    /// if this withdrawal would breach it (breaching withdrawal is rejected).
+    /// Accumulate `amount` into the rolling global withdrawal volume and enforce
+    /// the circuit breaker threshold.
+    ///
+    /// Flow summary:
+    /// 1. Read the configured threshold; `<= 0` means the breaker is disabled.
+    /// 2. If already tripped, attempt auto-reset when the configured reset window
+    ///    has elapsed; otherwise reject immediately with [`Error::CircuitBreakerActive`].
+    /// 3. Roll the volume window forward when the previous rolling window expired.
+    /// 4. Add the new amount to the window total.
+    /// 5. If the new total exceeds the threshold, mark the breaker as tripped,
+    ///    store the trip ledger, emit [`CircuitBreakerTrippedEvent`], and reject
+    ///    the current operation.
+    ///
+    /// The withdrawal that breaches the threshold is intentionally rejected; it is
+    /// counted for trip detection but not allowed to continue execution.
     fn check_and_update_circuit_breaker(env: &Env, amount: i128) -> Result<(), Error> {
         let threshold: i128 = env
             .storage()


### PR DESCRIPTION
Closes #570
Closes #583
Closes #575
Closes #589


## Summary
This PR improves the circuit breaker documentation in both the contract guide and the inline Rust docs so contributors can understand how the breaker trips, what it blocks, and how reset behavior works.

## Changes
- Added a dedicated `Circuit Breaker` section to `Dechat/stellar-contracts/FIAT_BRIDGE_README.md`
- Documented the rolling withdrawal volume model and the `GlobalDailyWithdrawn` tracker
- Documented how `set_circuit_breaker_threshold` enables, disables, and trips the breaker
- Documented auto-reset semantics for `set_circuit_breaker_reset_window`, including default and disabled modes
- Documented manual recovery behavior for `reset_circuit_breaker`
- Expanded inline Rustdoc for the internal `check_and_update_circuit_breaker` flow so the trip-and-reject behavior is easier to reason about during maintenance

## Testing
Not run locally per request. Documentation-only change.