### PR TITLE
feat(frontend): emoji refocus, connection indicator, and wallet watch…

### DIFF
--- a/Dechat/dex_with_fiat_frontend/src/components/ChatInput.tsx
+++ b/Dechat/dex_with_fiat_frontend/src/components/ChatInput.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useEffect, useRef, useState } from 'react';
-import { Send, Loader2, AlertTriangle } from 'lucide-react';
+import { Send, Loader2, AlertTriangle, Smile } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useTranslation } from '@/contexts/TranslationContext';
 import { useStellarWallet } from '@/contexts/StellarWalletContext';
@@ -40,6 +40,8 @@ interface ChatInputProps {
  * - Ctrl+Shift+C (Cmd+Shift+C on Mac): Cancel pending request
  */
 
+const COMMON_EMOJIS = ['😊', '😂', '🙏', '👍', '❤️', '🔥', '✅', '🚀', '💰', '📊', '⭐', '🎉'];
+
 export default function ChatInput({
   onSendMessage,
   onCancelRequest,
@@ -76,7 +78,28 @@ export default function ChatInput({
   const [paletteIndex, setPaletteIndex] = useState(0);
   
   const bottomRef = useRef<HTMLDivElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const [showEmojiPicker, setShowEmojiPicker] = useState(false);
   const isMobile = useMediaQuery('(max-width: 639px)');
+
+  const insertEmoji = (emoji: string) => {
+    const el = textareaRef.current;
+    if (el) {
+      const start = el.selectionStart ?? message.length;
+      const end = el.selectionEnd ?? message.length;
+      const next = message.slice(0, start) + emoji + message.slice(end);
+      setMessage(next);
+      // iOS Safari loses focus when the emoji picker opens; re-focus after state update
+      setTimeout(() => {
+        el.focus();
+        const pos = start + emoji.length;
+        el.setSelectionRange(pos, pos);
+      }, 0);
+    } else {
+      setMessage((prev) => prev + emoji);
+    }
+    setShowEmojiPicker(false);
+  };
 
   const { execute: executeSubmit, isProcessing: isSubmitting } = useIdempotentAction({
     cooldownMs: 1000,
@@ -237,6 +260,20 @@ export default function ChatInput({
     return () => window.removeEventListener('keydown', handler);
   }, [onNewChat, onOpenHistory, onOpenBridgeModal, onCancelRequest]);
 
+  // Close emoji picker on outside click
+  useEffect(() => {
+    if (!showEmojiPicker) return;
+    const handler = (e: MouseEvent) => {
+      const target = e.target as Node;
+      const picker = document.querySelector('[aria-label="Emoji picker"]');
+      if (picker && !picker.contains(target)) {
+        setShowEmojiPicker(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [showEmojiPicker]);
+
   // Load draft when session changes
   useEffect(() => {
     if (sessionId) {
@@ -383,7 +420,27 @@ export default function ChatInput({
         className={isMobile ? 'flex flex-col gap-2' : 'flex items-end space-x-3'}
       >
         <div className="flex-1 relative min-w-0">
+          {showEmojiPicker && (
+            <div
+              className="absolute bottom-full mb-2 left-0 z-50 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl shadow-2xl p-2 grid grid-cols-6 gap-1"
+              role="dialog"
+              aria-label="Emoji picker"
+            >
+              {COMMON_EMOJIS.map((emoji) => (
+                <button
+                  key={emoji}
+                  type="button"
+                  onClick={() => insertEmoji(emoji)}
+                  className="text-xl p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+                  aria-label={emoji}
+                >
+                  {emoji}
+                </button>
+              ))}
+            </div>
+          )}
           <textarea
+            ref={textareaRef}
             data-testid="chat-input-textarea"
             value={message}
             onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => handleInputChange(e.target.value)}
@@ -414,6 +471,17 @@ export default function ChatInput({
             }}
           />
         </div>
+
+        <button
+          type="button"
+          onClick={() => setShowEmojiPicker((v) => !v)}
+          title="Insert emoji"
+          aria-label="Insert emoji"
+          aria-expanded={showEmojiPicker}
+          className={`flex items-center justify-center text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 rounded-lg transition-colors ${isMobile ? 'h-11 w-11' : 'w-10 h-10'}`}
+        >
+          <Smile className="w-5 h-5" />
+        </button>
 
         <button
           type="submit"

--- a/Dechat/dex_with_fiat_frontend/src/components/NetworkStatusModal.tsx
+++ b/Dechat/dex_with_fiat_frontend/src/components/NetworkStatusModal.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import { X, Wifi, WifiOff, AlertTriangle } from 'lucide-react';
+import { useTheme } from '@/contexts/ThemeContext';
+import { useStellarWallet, EXPECTED_NETWORK } from '@/contexts/StellarWalletContext';
+
+interface NetworkStatusModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export default function NetworkStatusModal({ isOpen, onClose }: NetworkStatusModalProps) {
+  const { isDarkMode } = useTheme();
+  const { connection, isNetworkMismatch } = useStellarWallet();
+
+  if (!isOpen) return null;
+
+  const status = !connection.isConnected
+    ? 'disconnected'
+    : isNetworkMismatch
+      ? 'mismatch'
+      : 'connected';
+
+  const statusConfig = {
+    connected: {
+      dot: 'bg-green-400',
+      label: 'Connected',
+      description: `Wallet is connected to the Stellar ${connection.network} network.`,
+      Icon: Wifi,
+      iconClass: isDarkMode ? 'text-green-400' : 'text-green-600',
+    },
+    mismatch: {
+      dot: 'bg-amber-400',
+      label: 'Network Mismatch',
+      description: `Wallet is connected to ${connection.network} but the app expects ${EXPECTED_NETWORK}. Transactions are disabled.`,
+      Icon: AlertTriangle,
+      iconClass: isDarkMode ? 'text-amber-400' : 'text-amber-600',
+    },
+    disconnected: {
+      dot: 'bg-red-500',
+      label: 'Disconnected',
+      description: 'No Stellar wallet is connected. Connect Freighter to send transactions.',
+      Icon: WifiOff,
+      iconClass: isDarkMode ? 'text-red-400' : 'text-red-600',
+    },
+  }[status];
+
+  return (
+    <>
+      <div
+        className="fixed inset-0 z-40 bg-black/50 backdrop-blur-sm"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Network status"
+        className={`fixed z-50 top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-80 rounded-xl shadow-2xl border p-6 transition-colors duration-300 ${
+          isDarkMode
+            ? 'bg-gray-900 border-gray-700 text-gray-100'
+            : 'bg-white border-gray-200 text-gray-900'
+        }`}
+      >
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-base font-semibold">Network Status</h2>
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            className={`p-1.5 rounded-lg transition-colors ${
+              isDarkMode
+                ? 'text-gray-400 hover:text-gray-200 hover:bg-gray-800'
+                : 'text-gray-500 hover:text-gray-700 hover:bg-gray-100'
+            }`}
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        <div className="flex items-start gap-3">
+          <span className={`mt-1 w-3 h-3 rounded-full flex-shrink-0 ${statusConfig.dot}`} />
+          <div>
+            <p className="font-medium text-sm">{statusConfig.label}</p>
+            <p className={`text-xs mt-1 ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}>
+              {statusConfig.description}
+            </p>
+          </div>
+        </div>
+
+        {connection.isConnected && (
+          <dl className={`mt-4 space-y-2 text-xs border-t pt-4 ${isDarkMode ? 'border-gray-700' : 'border-gray-200'}`}>
+            <div className="flex justify-between">
+              <dt className={isDarkMode ? 'text-gray-400' : 'text-gray-500'}>Address</dt>
+              <dd className="font-mono">
+                {connection.address.slice(0, 6)}…{connection.address.slice(-4)}
+              </dd>
+            </div>
+            <div className="flex justify-between">
+              <dt className={isDarkMode ? 'text-gray-400' : 'text-gray-500'}>Network</dt>
+              <dd>{connection.network || '—'}</dd>
+            </div>
+            <div className="flex justify-between">
+              <dt className={isDarkMode ? 'text-gray-400' : 'text-gray-500'}>Expected</dt>
+              <dd>{EXPECTED_NETWORK}</dd>
+            </div>
+          </dl>
+        )}
+      </div>
+    </>
+  );
+}

--- a/Dechat/dex_with_fiat_frontend/src/components/StellarChatInterface.tsx
+++ b/Dechat/dex_with_fiat_frontend/src/components/StellarChatInterface.tsx
@@ -43,6 +43,7 @@ import ChatHistorySidebar from './ChatHistorySidebar';
 import ChatInput from './ChatInput';
 import ChatMessages from './ChatMessages';
 import ErrorBoundary from './ErrorBoundary';
+import NetworkStatusModal from './NetworkStatusModal';
 import NotificationsCenter from './NotificationsCenter';
 import StellarFiatModal from './StellarFiatModal';
 import UserSettings from './UserSettings';
@@ -52,6 +53,8 @@ import ReceiptDrawer from './ReceiptDrawerWrapper';
 import { useTxHistory } from '@/hooks/useTxHistory';
 import { useChatHistory } from '@/hooks/useChatHistory';
 import { useSplitView } from '@/hooks/useSplitView';
+import { useWatchlist } from '@/hooks/useWatchlist';
+import { useWatchedWalletNotifications } from '@/hooks/useWatchedWalletNotifications';
 import { subscribeToQueue, processQueue } from '@/lib/networkQueue';
 import CopyButton from '@/components/ui/CopyButton';
 import SplitViewComparison from './SplitViewComparison';
@@ -108,6 +111,12 @@ function StellarChatInterfaceContent() {
   >(null);
   const [isReceiptDrawerOpen, setIsReceiptDrawerOpen] = useState(false);
   const [showSearch, setShowSearch] = useState(false);
+  const [showNetworkStatusModal, setShowNetworkStatusModal] = useState(false);
+
+  // Watched wallet notifications (issue #1032)
+  const { watchlist } = useWatchlist();
+  useWatchedWalletNotifications(watchlist);
+
   // Show the chat skeleton until the client has hydrated so the first paint
   // isn't an empty conversation pane before messages are restored.
   const [isHydrated, setIsHydrated] = useState(false);
@@ -548,6 +557,37 @@ function StellarChatInterfaceContent() {
                 <span className={`w-2 h-2 rounded-full flex-shrink-0 ${healthBadge.dot}`} />
                 {healthBadge.label}
               </div>
+              {/* ─────────────────────────────────────────────────────────────── */}
+
+              {/* ── Stellar connection status indicator (issue #1030) ─────────── */}
+              {(() => {
+                const connDot = !connection.isConnected
+                  ? 'bg-red-500'
+                  : isNetworkMismatch
+                    ? 'bg-amber-400'
+                    : 'bg-green-400';
+                const connTitle = !connection.isConnected
+                  ? 'Stellar: Disconnected'
+                  : isNetworkMismatch
+                    ? `Stellar: Network mismatch (${connection.network})`
+                    : `Stellar: Connected (${connection.network})`;
+                return (
+                  <button
+                    type="button"
+                    title={connTitle}
+                    aria-label={connTitle}
+                    onClick={() => setShowNetworkStatusModal(true)}
+                    className={`hidden sm:flex items-center gap-1.5 px-2 py-1 rounded-full text-[11px] font-medium transition-colors ${
+                      isDarkMode
+                        ? 'bg-gray-800 text-gray-300 hover:bg-gray-700'
+                        : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                    }`}
+                  >
+                    <span className={`w-2 h-2 rounded-full flex-shrink-0 ${connDot}`} />
+                    Stellar
+                  </button>
+                );
+              })()}
               {/* ─────────────────────────────────────────────────────────────── */}
             </div>
 
@@ -1014,6 +1054,12 @@ function StellarChatInterfaceContent() {
         <UserSettings
           isOpen={showSettings}
           onClose={() => setShowSettings(false)}
+        />
+
+        {/* Network status modal (issue #1030) */}
+        <NetworkStatusModal
+          isOpen={showNetworkStatusModal}
+          onClose={() => setShowNetworkStatusModal(false)}
         />
 
         {/* Receipt Drawer */}

--- a/Dechat/dex_with_fiat_frontend/src/components/UserSettings.tsx
+++ b/Dechat/dex_with_fiat_frontend/src/components/UserSettings.tsx
@@ -16,6 +16,7 @@ import {
 import { useAccessibleModal } from '@/hooks/useAccessibleModal';
 import { useChatTelemetry } from '@/hooks/useChatTelemetry';
 import { useBeneficiaries, Beneficiary } from '@/hooks/useBeneficiaries';
+import { useWatchlist } from '@/hooks/useWatchlist';
 
 interface UserSettingsProps {
   isOpen: boolean;
@@ -36,8 +37,14 @@ export default function UserSettings({ isOpen, onClose }: UserSettingsProps) {
   } = useUserPreferences();
   const { consented: telemetryConsented, setConsent: setTelemetryConsent } = useChatTelemetry();
   const { beneficiaries, isLoaded, addBeneficiary, deleteBeneficiary, renameBeneficiary } = useBeneficiaries();
+  const { watchlist, isLoaded: watchlistLoaded, addAddress, removeAddress } = useWatchlist();
   const panelRef = useRef<HTMLDivElement>(null);
-  
+
+  // Watchlist states
+  const [showAddWatch, setShowAddWatch] = useState(false);
+  const [watchAddress, setWatchAddress] = useState('');
+  const [watchLabel, setWatchLabel] = useState('');
+
   // Beneficiary management states
   const [showAddBeneficiary, setShowAddBeneficiary] = useState(false);
   const [editingBeneficiary, setEditingBeneficiary] = useState<Beneficiary | null>(null);
@@ -303,6 +310,149 @@ export default function UserSettings({ isOpen, onClose }: UserSettingsProps) {
                 }`}
               >
                 Loading beneficiaries...
+              </p>
+            )}
+          </section>
+
+          {/* Watchlist section (issue #1032) */}
+          <section>
+            <div className="flex items-center justify-between mb-3">
+              <h3
+                className={`text-xs font-semibold uppercase tracking-wider ${
+                  isDarkMode ? 'text-gray-400' : 'text-gray-500'
+                }`}
+              >
+                Wallet Watchlist
+              </h3>
+              <button
+                onClick={() => {
+                  setWatchAddress('');
+                  setWatchLabel('');
+                  setShowAddWatch(!showAddWatch);
+                }}
+                className={`p-1.5 rounded-lg transition-colors ${
+                  isDarkMode
+                    ? 'text-blue-400 hover:bg-blue-900/20'
+                    : 'text-blue-600 hover:bg-blue-100'
+                }`}
+                aria-label="Add wallet to watchlist"
+              >
+                <Plus className="w-4 h-4" />
+              </button>
+            </div>
+            <p className={`text-xs mb-4 ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}>
+              Receive a toast and browser notification when a watched wallet receives funds.
+            </p>
+
+            {showAddWatch && (
+              <div className={`p-3 rounded-lg mb-3 border ${isDarkMode ? 'bg-gray-800 border-gray-700' : 'bg-gray-50 border-gray-200'}`}>
+                <div className="space-y-3">
+                  <div>
+                    <label className={`text-xs font-medium block mb-1 ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}>
+                      Stellar Address
+                    </label>
+                    <input
+                      type="text"
+                      placeholder="G…"
+                      value={watchAddress}
+                      onChange={(e) => setWatchAddress(e.target.value)}
+                      aria-label="Wallet address to watch"
+                      className={`w-full px-3 py-2 rounded-lg text-sm border transition-colors font-mono ${
+                        isDarkMode
+                          ? 'bg-gray-700 border-gray-600 text-white focus:border-blue-500'
+                          : 'bg-white border-gray-300 text-gray-900 focus:border-blue-500'
+                      }`}
+                    />
+                  </div>
+                  <div>
+                    <label className={`text-xs font-medium block mb-1 ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}>
+                      Label (optional)
+                    </label>
+                    <input
+                      type="text"
+                      placeholder="e.g., Treasury"
+                      value={watchLabel}
+                      onChange={(e) => setWatchLabel(e.target.value)}
+                      aria-label="Label for this address"
+                      className={`w-full px-3 py-2 rounded-lg text-sm border transition-colors ${
+                        isDarkMode
+                          ? 'bg-gray-700 border-gray-600 text-white focus:border-blue-500'
+                          : 'bg-white border-gray-300 text-gray-900 focus:border-blue-500'
+                      }`}
+                    />
+                  </div>
+                  <div className="flex gap-2">
+                    <button
+                      onClick={() => {
+                        if (watchAddress.trim()) {
+                          addAddress(watchAddress.trim(), watchLabel.trim());
+                          setWatchAddress('');
+                          setWatchLabel('');
+                          setShowAddWatch(false);
+                        }
+                      }}
+                      className="flex-1 py-2 rounded-lg text-xs font-medium bg-blue-600 text-white hover:bg-blue-700 transition-colors flex items-center justify-center gap-1"
+                    >
+                      <Check className="w-3 h-3" />
+                      Add
+                    </button>
+                    <button
+                      onClick={() => setShowAddWatch(false)}
+                      className={`flex-1 py-2 rounded-lg text-xs font-medium transition-colors ${
+                        isDarkMode
+                          ? 'bg-gray-700 text-gray-300 hover:bg-gray-600'
+                          : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                      }`}
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {watchlistLoaded ? (
+              watchlist.length === 0 ? (
+                <p className={`text-xs italic ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}>
+                  No addresses being watched.
+                </p>
+              ) : (
+                <div className="space-y-2">
+                  {watchlist.map((entry) => (
+                    <div
+                      key={entry.id}
+                      className={`p-2 rounded-lg border flex items-center justify-between group ${
+                        isDarkMode
+                          ? 'bg-gray-800 border-gray-700 hover:border-gray-600'
+                          : 'bg-gray-50 border-gray-200 hover:border-gray-300'
+                      }`}
+                    >
+                      <div className="min-w-0 flex-1">
+                        <p className={`text-xs font-medium truncate ${isDarkMode ? 'text-gray-200' : 'text-gray-900'}`}>
+                          {entry.label || entry.address.slice(0, 8)}
+                        </p>
+                        <p className={`text-[10px] font-mono truncate ${isDarkMode ? 'text-gray-500' : 'text-gray-500'}`}>
+                          {entry.address.slice(0, 6)}…{entry.address.slice(-4)}
+                        </p>
+                      </div>
+                      <button
+                        onClick={() => removeAddress(entry.id)}
+                        aria-label={`Remove ${entry.label || entry.address} from watchlist`}
+                        className={`p-1.5 rounded opacity-0 group-hover:opacity-100 transition-opacity ${
+                          isDarkMode
+                            ? 'text-red-400 hover:bg-red-900/20'
+                            : 'text-red-600 hover:bg-red-100'
+                        }`}
+                      >
+                        <Trash2 className="w-3 h-3" />
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              )
+            ) : (
+              <p className={`text-xs italic ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`}>
+                Loading…
               </p>
             )}
           </section>

--- a/Dechat/dex_with_fiat_frontend/src/hooks/useWatchedWalletNotifications.ts
+++ b/Dechat/dex_with_fiat_frontend/src/hooks/useWatchedWalletNotifications.ts
@@ -1,0 +1,111 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { WatchedAddress } from '@/hooks/useWatchlist';
+import { toastStore } from '@/lib/toastStore';
+
+const HORIZON_URL = 'https://horizon-testnet.stellar.org';
+const POLL_INTERVAL_MS = 30_000;
+
+type PaymentRecord = {
+  id: string;
+  type: string;
+  to?: string;
+  amount?: string;
+  asset_type?: string;
+};
+
+type HorizonPaymentsResponse = {
+  _embedded?: { records?: PaymentRecord[] };
+};
+
+function browserNotify(title: string, body: string): void {
+  if (typeof window === 'undefined' || !('Notification' in window)) return;
+  if (Notification.permission !== 'granted') return;
+  try {
+    new Notification(title, { body, icon: '/favicon.ico' });
+  } catch {
+    // silently ignore
+  }
+}
+
+async function fetchPayments(address: string, limit = 5): Promise<PaymentRecord[]> {
+  try {
+    const res = await fetch(
+      `${HORIZON_URL}/accounts/${encodeURIComponent(address)}/payments?order=desc&limit=${limit}`,
+    );
+    if (!res.ok) return [];
+    const data = (await res.json()) as HorizonPaymentsResponse;
+    return data._embedded?.records ?? [];
+  } catch {
+    return [];
+  }
+}
+
+export function useWatchedWalletNotifications(watchlist: WatchedAddress[]) {
+  const lastSeenRef = useRef<Map<string, string | null>>(new Map());
+  const initializedRef = useRef<Set<string>>(new Set());
+  const watchlistKey = watchlist.map((w) => w.id).join(',');
+
+  useEffect(() => {
+    if (watchlist.length === 0) return;
+
+    let cancelled = false;
+    let intervalId: ReturnType<typeof setInterval> | null = null;
+
+    const poll = async () => {
+      for (const entry of watchlist) {
+        if (cancelled) break;
+        if (!initializedRef.current.has(entry.id)) continue;
+
+        const lastId = lastSeenRef.current.get(entry.id) ?? null;
+        const records = await fetchPayments(entry.address);
+        if (cancelled) break;
+
+        const newest = records[0]?.id ?? null;
+        if (!newest || newest === lastId) continue;
+
+        const incoming = records.find(
+          (r) => r.to === entry.address && r.id !== lastId,
+        );
+
+        lastSeenRef.current.set(entry.id, newest);
+
+        if (incoming) {
+          const label = entry.label || `${entry.address.slice(0, 6)}…`;
+          const amt = incoming.amount
+            ? `${incoming.amount}${incoming.asset_type === 'native' ? ' XLM' : ''}`
+            : '';
+          const msg = amt ? `${label} received ${amt}` : `${label} received funds`;
+          toastStore.addToast({ message: msg, variant: 'success' });
+          browserNotify('Incoming Deposit', msg);
+        }
+      }
+    };
+
+    const init = async () => {
+      for (const entry of watchlist) {
+        if (cancelled) return;
+        if (initializedRef.current.has(entry.id)) continue;
+        const records = await fetchPayments(entry.address, 1);
+        if (cancelled) return;
+        lastSeenRef.current.set(entry.id, records[0]?.id ?? null);
+        initializedRef.current.add(entry.id);
+      }
+
+      if (!cancelled) {
+        intervalId = setInterval(() => {
+          void poll();
+        }, POLL_INTERVAL_MS);
+      }
+    };
+
+    void init();
+
+    return () => {
+      cancelled = true;
+      if (intervalId !== null) clearInterval(intervalId);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [watchlistKey]);
+}

--- a/Dechat/dex_with_fiat_frontend/src/hooks/useWatchlist.ts
+++ b/Dechat/dex_with_fiat_frontend/src/hooks/useWatchlist.ts
@@ -1,0 +1,58 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+
+const STORAGE_KEY = 'stellar_watchlist';
+
+export interface WatchedAddress {
+  id: string;
+  address: string;
+  label: string;
+}
+
+function loadFromStorage(): WatchedAddress[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    return stored ? (JSON.parse(stored) as WatchedAddress[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveToStorage(list: WatchedAddress[]): void {
+  if (typeof window === 'undefined') return;
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(list));
+}
+
+export function useWatchlist() {
+  const [watchlist, setWatchlist] = useState<WatchedAddress[]>([]);
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  useEffect(() => {
+    setWatchlist(loadFromStorage());
+    setIsLoaded(true);
+  }, []);
+
+  const addAddress = useCallback((address: string, label: string) => {
+    setWatchlist((prev) => {
+      if (prev.some((w) => w.address === address)) return prev;
+      const next = [
+        ...prev,
+        { id: crypto.randomUUID(), address: address.trim(), label: label.trim() || address.slice(0, 8) },
+      ];
+      saveToStorage(next);
+      return next;
+    });
+  }, []);
+
+  const removeAddress = useCallback((id: string) => {
+    setWatchlist((prev) => {
+      const next = prev.filter((w) => w.id !== id);
+      saveToStorage(next);
+      return next;
+    });
+  }, []);
+
+  return { watchlist, isLoaded, addAddress, removeAddress };
+}


### PR DESCRIPTION
…list (#1020 #1030 #1032)

Closes #1020
Closes #1030
Closes #1032

## Summary

Resolves three frontend issues in a single PR:

- **#1020** — `ChatInput.tsx` emoji picker with iOS Safari refocus fix: after emoji insertion the textarea is re-focused via `setTimeout(() => el.focus(), 0)` to work around the iOS Safari focus-loss bug on input fields.
- **#1030** — Stellar network connection status indicator in the toolbar: a green/amber/red dot labelled "Stellar" sits next to the existing API health badge. Clicking it opens the new `NetworkStatusModal` which shows connection state, wallet address, active network, and expected network.
- **#1032** — Watched wallet notifications: a new "Wallet Watchlist" section in `UserSettings` lets users add/remove Stellar addresses to monitor. The `useWatchedWalletNotifications` hook polls Horizon every 30 s for incoming payments and fires both an in-app toast (via the existing `toastStore`) and a browser `Notification` (if permission is granted).

## Changes

| File | What changed |
|---|---|
| `src/components/ChatInput.tsx` | Added `textareaRef`, emoji picker popover (12 common emojis), `Smile` button, `insertEmoji` helper with iOS Safari refocus via `setTimeout`, outside-click dismissal |
| `src/components/NetworkStatusModal.tsx` | **New** — modal showing Stellar connection status (connected/mismatch/disconnected), wallet address, active network, and expected network |
| `src/components/StellarChatInterface.tsx` | Added green/amber/red connection dot in header toolbar; wired `useWatchlist` + `useWatchedWalletNotifications`; renders `NetworkStatusModal` |
| `src/components/UserSettings.tsx` | Added "Wallet Watchlist" section with add/remove Stellar address UI and optional label |
| `src/hooks/useWatchlist.ts` | **New** — `localStorage`-backed watchlist CRUD hook (`addAddress`, `removeAddress`) |
| `src/hooks/useWatchedWalletNotifications.ts` | **New** — Horizon polling hook; seeds last-known payment on mount, then polls every 30 s and fires toast + browser notification on new incoming deposits |

## Test plan

- [ ] Open chat on iOS Safari, tap the 😊 button, select an emoji — input retains focus
- [ ] Verify emoji is inserted at the cursor position (not always appended to the end)
- [ ] Emoji picker closes when clicking outside it
- [ ] Toolbar shows a **green** dot ("Stellar") when Freighter is connected on TESTNET
- [ ] Dot turns **amber** when connected to a mismatched network
- [ ] Dot is **red** when Freighter is disconnected
- [ ] Clicking the dot opens `NetworkStatusModal` with correct address/network details
- [ ] Open Settings → "Wallet Watchlist" → add a Stellar testnet address with a label
- [ ] Address appears in list with label and truncated public key
- [ ] Delete button removes the address; change persists on reload
- [ ] When a watched address receives a payment, a toast appears bottom-right
- [ ] If browser notification permission is granted, a `Notification` fires too


