### PR TITLE
feat: show XLM balance in chat header and add frontend build CI workflow

### DIFF
--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -1,0 +1,44 @@
+name: Frontend Build Check
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Next.js Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: dex_with_fiat_frontend/package-lock.json
+
+      - name: Install dependencies
+        working-directory: dex_with_fiat_frontend
+        run: npm ci
+
+      - name: Create .env.local with placeholder values
+        working-directory: dex_with_fiat_frontend
+        run: |
+          cat > .env.local <<'EOF'
+          NEXT_PUBLIC_STELLAR_RPC_URL=${{ secrets.NEXT_PUBLIC_STELLAR_RPC_URL || 'https://soroban-testnet.stellar.org' }}
+          NEXT_PUBLIC_FIAT_BRIDGE_CONTRACT=${{ secrets.NEXT_PUBLIC_FIAT_BRIDGE_CONTRACT || 'CAWYXBN4PSVXD7NIYEWVFFIIIEUCC6PUN3IMG3J2WHKDB4NVIISMXBPR' }}
+          NEXT_PUBLIC_XLM_SAC_CONTRACT=${{ secrets.NEXT_PUBLIC_XLM_SAC_CONTRACT || 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC' }}
+          NEXT_PUBLIC_GEMINI_API_KEY=${{ secrets.NEXT_PUBLIC_GEMINI_API_KEY || 'PLACEHOLDER' }}
+          PAYSTACK_SECRET_KEY=${{ secrets.PAYSTACK_SECRET_KEY || 'PLACEHOLDER' }}
+          PAYOUT_PROVIDER=${{ secrets.PAYOUT_PROVIDER || 'paystack' }}
+          EOF
+
+      - name: Build
+        working-directory: dex_with_fiat_frontend
+        run: npm run build

--- a/Dechat/dex_with_fiat_frontend/src/components/StellarChatInterface.tsx
+++ b/Dechat/dex_with_fiat_frontend/src/components/StellarChatInterface.tsx
@@ -77,6 +77,7 @@ function StellarChatInterfaceContent() {
     sessionExpired,
     clearSessionExpired,
     isNetworkMismatch,
+    xlmBalance,
     error: walletError,
   } = useStellarWallet();
   const { isDarkMode, toggleDarkMode } = useTheme();
@@ -675,6 +676,11 @@ function StellarChatInterfaceContent() {
                         {connection.address.slice(0, 6)}…
                         {connection.address.slice(-4)}
                       </span>
+                      {xlmBalance && (
+                        <span className={`text-xs ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}>
+                          — {xlmBalance} XLM
+                        </span>
+                      )}
                       {accounts.length > 1 && (
                         <ChevronDown
                           className={`w-3 h-3 transition-transform ${showAccountDropdown ? 'rotate-180' : ''}`}

--- a/Dechat/dex_with_fiat_frontend/src/contexts/StellarWalletContext.tsx
+++ b/Dechat/dex_with_fiat_frontend/src/contexts/StellarWalletContext.tsx
@@ -17,6 +17,7 @@ import {
   setAllowed,
 } from '@stellar/freighter-api';
 import { Networks } from '@stellar/stellar-sdk';
+import { fetchXlmBalance } from '@/lib/stellarContract';
 
 const SESSION_TTL_MS = 24 * 60 * 60 * 1000;
 const STORAGE_KEY_ADDRESS = 'stellar_address';
@@ -69,6 +70,7 @@ interface StellarWalletContextType {
   connection: StellarWalletConnection;
   accounts: WalletAccount[];
   selectedAccountIndex: number;
+  xlmBalance: string;
   selectAccount: (index: number) => void;
   connect: () => Promise<void>;
   disconnect: () => void;
@@ -94,6 +96,7 @@ const StellarWalletContext = createContext<StellarWalletContextType>({
   connection: defaultConnection,
   accounts: [],
   selectedAccountIndex: 0,
+  xlmBalance: '',
   selectAccount: () => {},
   connect: async () => {},
   disconnect: () => {},
@@ -116,6 +119,7 @@ export function StellarWalletProvider({ children }: { children: ReactNode }) {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [sessionExpired, setSessionExpired] = useState(false);
+  const [xlmBalance, setXlmBalance] = useState('');
 
   useEffect(() => {
     const check = async () => {
@@ -174,6 +178,7 @@ export function StellarWalletProvider({ children }: { children: ReactNode }) {
               network: netResult.network || 'TESTNET',
               networkPassphrase: netResult.networkPassphrase || '',
             });
+            fetchXlmBalance(addrResult.address).then(setXlmBalance).catch(() => {});
           }
         })
         .catch(() => {});
@@ -231,6 +236,7 @@ export function StellarWalletProvider({ children }: { children: ReactNode }) {
         network: netResult.network || 'TESTNET',
         networkPassphrase: passphrase,
       });
+      fetchXlmBalance(addr).then(setXlmBalance).catch(() => {});
     } catch (err) {
       setError(
         err instanceof Error ? err.message : 'Failed to connect Freighter',
@@ -247,6 +253,7 @@ export function StellarWalletProvider({ children }: { children: ReactNode }) {
     setConnection(defaultConnection);
     setAccounts([]);
     setSelectedAccountIndex(0);
+    setXlmBalance('');
     setError(null);
     setSessionExpired(false);
   }, []);
@@ -278,6 +285,7 @@ export function StellarWalletProvider({ children }: { children: ReactNode }) {
         }));
         localStorage.setItem(STORAGE_KEY_ADDRESS, selectedAccount.address);
         localStorage.setItem(STORAGE_KEY_TIMESTAMP, String(Date.now()));
+        fetchXlmBalance(selectedAccount.address).then(setXlmBalance).catch(() => {});
       } catch (err) {
         setError(
           err instanceof Error ? err.message : 'Failed to switch account',
@@ -321,6 +329,7 @@ export function StellarWalletProvider({ children }: { children: ReactNode }) {
         connection,
         accounts,
         selectedAccountIndex,
+        xlmBalance,
         selectAccount,
         connect,
         disconnect,

--- a/Dechat/dex_with_fiat_frontend/src/lib/stellarContract.ts
+++ b/Dechat/dex_with_fiat_frontend/src/lib/stellarContract.ts
@@ -7,6 +7,7 @@ import {
   nativeToScVal,
   scValToNative,
   rpc,
+  Horizon,
 } from '@stellar/stellar-sdk';
 import { stroopsToXlm } from '@/lib/stroops';
 import { env } from '@/lib/env';
@@ -46,6 +47,13 @@ export interface FeeEstimate {
 }
 
 const server = new rpc.Server(RPC_URL, { allowHttp: false });
+
+const HORIZON_URL =
+  process.env.NEXT_PUBLIC_STELLAR_HORIZON_URL ||
+  (RPC_URL.includes('testnet')
+    ? 'https://horizon-testnet.stellar.org'
+    : 'https://horizon.stellar.org');
+const horizonServer = new Horizon.Server(HORIZON_URL);
 
 // ── Helpers ───────────────────────────────────────────────────────────────
 
@@ -400,4 +408,18 @@ export async function getAccruedFees(tokenAddress: string): Promise<bigint> {
   const result = scValToNative(retval) as bigint;
   setCachedValue(functionName, result);
   return result;
+}
+
+/** Fetches the native XLM balance for the given public key. Returns empty string on failure. */
+export async function fetchXlmBalance(publicKey: string): Promise<string> {
+  try {
+    const account = await horizonServer.loadAccount(publicKey);
+    const native = account.balances.find(
+      (b: Horizon.HorizonApi.BalanceLine): b is Horizon.HorizonApi.BalanceLineNative =>
+        b.asset_type === 'native',
+    );
+    return native ? parseFloat(native.balance).toFixed(2) : '0.00';
+  } catch {
+    return '';
+  }
 }


### PR DESCRIPTION
## Summary

- **feat(#9):** Show connected wallet XLM balance in the chat header next to the address chip (e.g. `G1ABC…XYZ — 42.50 XLM`). Falls back to empty string if the fetch fails — no crash.
- **feat(#19):** Add `.github/workflows/frontend-build.yml` that runs a full `npm run build` check on every pull request targeting `main`, using Node.js 20 and a `.env.local` seeded from repository secrets (or safe hardcoded fallbacks).

## Changes

### Issue #9 — XLM balance in header

| File | Change |
|------|--------|
| `dex_with_fiat_frontend/src/lib/stellarContract.ts` | Added `fetchXlmBalance(publicKey)` helper that calls Horizon `loadAccount` and returns the native balance formatted to 2 decimal places; returns `''` on any error |
| `dex_with_fiat_frontend/src/contexts/StellarWalletContext.tsx` | Added `xlmBalance: string` to the context type and state; calls `fetchXlmBalance` after `connect`, session restore, and `selectAccount`; resets to `''` on `disconnect` |
| `dex_with_fiat_frontend/src/components/StellarChatInterface.tsx` | Reads `xlmBalance` from context and renders it inside the connected-wallet chip as `— {xlmBalance} XLM` |

### Issue #19 — Frontend build CI

| File | Change |
|------|--------|
| `.github/workflows/frontend-build.yml` | New workflow: triggers on every `pull_request → main`, checks out repo, sets up Node 20 with npm cache, runs `npm ci`, writes `.env.local` from secrets / fallbacks, then runs `npm run build` |

## Environment variables required as repository secrets for CI (Issue #19)

All variables have safe hardcoded fallbacks, so CI passes without any secrets configured. To use real values, add these repository secrets:

| Secret | Purpose | Fallback used when absent |
|--------|---------|--------------------------|
| `NEXT_PUBLIC_STELLAR_RPC_URL` | Soroban RPC endpoint | `https://soroban-testnet.stellar.org` |
| `NEXT_PUBLIC_FIAT_BRIDGE_CONTRACT` | Bridge contract address | testnet contract ID in source |
| `NEXT_PUBLIC_XLM_SAC_CONTRACT` | XLM SAC contract address | testnet SAC ID in source |
| `NEXT_PUBLIC_GEMINI_API_KEY` | Gemini AI key | `PLACEHOLDER` |
| `PAYSTACK_SECRET_KEY` | Paystack payout key (server-side only, not required for build) | `PLACEHOLDER` |
| `PAYOUT_PROVIDER` | Payout provider name | `paystack` |

## Test plan

- [ ] Connect Freighter wallet on testnet → balance chip shows `G1ABC…XYZ — 42.50 XLM`
- [ ] Switch accounts in the dropdown → balance updates to the new account
- [ ] Disconnect wallet → balance disappears from chip
- [ ] Disconnect network / use invalid key → chip shows only the address (no crash)
- [ ] Open any PR targeting `main` → `Frontend Build Check` workflow appears in CI checks and passes

Closes #9
Closes #19
