### PR TITLE
feat(frontend): keyboard shortcuts + live-region announcements across 4 components

### DIFF
--- a/Dechat/dex_with_fiat_frontend/src/components/CCIPBridgeModal.tsx
+++ b/Dechat/dex_with_fiat_frontend/src/components/CCIPBridgeModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   AlertCircle,
   CheckCircle,
@@ -56,6 +56,29 @@ export default function CCIPBridgeModal({
   const [latestStatus, setLatestStatus] = useState<string>('');
   const [errorMessage, setErrorMessage] = useState('');
   const [networkChangedWhileActive, setNetworkChangedWhileActive] = useState(false);
+
+  // #1179: single sr-only live region announcing bridge state transitions.
+  // The visible per-state sections below aren't in an aria-live container,
+  // so a screen reader user starting a transfer would hear nothing as it
+  // moves through optimistic -> initiating -> polling -> success/error.
+  const bridgeAnnouncement = useMemo(() => {
+    switch (bridgeState) {
+      case 'optimistic':
+        return 'Transfer initiated. Preparing transaction.';
+      case 'initiating':
+        return 'Starting CCIP transfer.';
+      case 'polling':
+        return latestStatus
+          ? `Waiting for CCIP confirmation. Latest status: ${latestStatus}.`
+          : 'Waiting for CCIP confirmation.';
+      case 'success':
+        return `CCIP transfer confirmed. Status: ${latestStatus || 'SUCCESS'}.`;
+      case 'error':
+        return `CCIP transfer error. ${errorMessage}`;
+      default:
+        return '';
+    }
+  }, [bridgeState, latestStatus, errorMessage]);
 
   // Keep ref in sync with state.
   // Keep ref in sync with state.
@@ -289,6 +312,10 @@ export default function CCIPBridgeModal({
           >
             <X className="w-5 h-5" />
           </button>
+        </div>
+
+        <div role="status" aria-live="polite" className="sr-only">
+          {bridgeAnnouncement}
         </div>
 
         {networkChangedWhileActive && (

--- a/Dechat/dex_with_fiat_frontend/src/components/ChatSearchPanel.tsx
+++ b/Dechat/dex_with_fiat_frontend/src/components/ChatSearchPanel.tsx
@@ -82,7 +82,14 @@ export default function ChatSearchPanel({
   const [filters, setFilters] = useState<SearchFilters>(EMPTY_FILTERS);
   const [results, setResults] = useState<MessageMatch[]>([]);
   const [showAdvanced, setShowAdvanced] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
   const inputRef = useRef<HTMLInputElement>(null);
+
+  // #1183: keep the active-result index in range whenever the result set
+  // changes (e.g. a new keystroke narrows/reorders matches).
+  useEffect(() => {
+    setActiveIndex(results.length > 0 ? 0 : -1);
+  }, [results]);
 
   // Reset all search state whenever the panel is closed so stale results
   // are never shown the next time the panel is opened (#947).
@@ -111,8 +118,27 @@ export default function ChatSearchPanel({
     inputRef.current?.focus();
   }, []);
 
+  // #1183: ArrowDown/ArrowUp move the active result, Enter selects it,
+  // Escape still closes the panel.
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Escape') onClose();
+    if (e.key === 'Escape') {
+      onClose();
+      return;
+    }
+    if (results.length === 0) {
+      return;
+    }
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setActiveIndex((i) => (i + 1) % results.length);
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setActiveIndex((i) => (i - 1 + results.length) % results.length);
+    } else if (e.key === 'Enter' && activeIndex >= 0) {
+      e.preventDefault();
+      const match = results[activeIndex];
+      if (match) onSelectResult(match.sessionId, match.message.id);
+    }
   };
 
   const hasAnyFilter =
@@ -236,12 +262,21 @@ export default function ChatSearchPanel({
             <p className="text-sm">No messages found</p>
           </div>
         ) : (
-          <ul className="divide-y" aria-label="Search results">
-            {results.map((match) => (
-              <li key={`${match.sessionId}-${match.message.id}`}>
+          <ul className="divide-y" role="listbox" aria-label="Search results">
+            {results.map((match, index) => (
+              <li key={`${match.sessionId}-${match.message.id}`} role="option" aria-selected={index === activeIndex}>
                 <button
                   onClick={() => onSelectResult(match.sessionId, match.message.id)}
-                  className={`w-full text-left px-4 py-3 transition-colors ${isDarkMode ? 'hover:bg-gray-800' : 'hover:bg-gray-50'}`}
+                  onMouseEnter={() => setActiveIndex(index)}
+                  className={`w-full text-left px-4 py-3 transition-colors ${
+                    index === activeIndex
+                      ? isDarkMode
+                        ? 'bg-gray-800'
+                        : 'bg-gray-50'
+                      : isDarkMode
+                        ? 'hover:bg-gray-800'
+                        : 'hover:bg-gray-50'
+                  }`}
                 >
                   <p className={`text-xs font-semibold truncate ${isDarkMode ? 'text-blue-400' : 'text-blue-600'}`}>
                     {match.sessionTitle}

--- a/Dechat/dex_with_fiat_frontend/src/components/ErrorBoundary.tsx
+++ b/Dechat/dex_with_fiat_frontend/src/components/ErrorBoundary.tsx
@@ -36,6 +36,42 @@ export default class ErrorBoundary extends React.Component<
     return { hasError: true };
   }
 
+  // #1184: "r" / "Enter" retries the same way the button's onClick does,
+  // for keyboard users who'd rather not reach for the mouse after a crash.
+  // Only acts while the fallback is actually showing, and ignores the
+  // shortcut while focus is in a form field so it can't hijack typing.
+  private handleKeyDown = (event: KeyboardEvent) => {
+    if (!this.state.hasError) {
+      return;
+    }
+    const target = event.target as HTMLElement | null;
+    const tag = target?.tagName;
+    if (tag === 'INPUT' || tag === 'TEXTAREA' || target?.isContentEditable) {
+      return;
+    }
+    if (event.key === 'Enter' || event.key === 'r' || event.key === 'R') {
+      event.preventDefault();
+      this.retry();
+    }
+  };
+
+  private retry = () => {
+    if (this.props.onRetry) {
+      this.setState({ hasError: false });
+      this.props.onRetry();
+      return;
+    }
+    window.location.reload();
+  };
+
+  public componentDidMount() {
+    window.addEventListener('keydown', this.handleKeyDown);
+  }
+
+  public componentWillUnmount() {
+    window.removeEventListener('keydown', this.handleKeyDown);
+  }
+
   public componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
     console.error('Chat UI crashed:', error, errorInfo);
 
@@ -91,18 +127,38 @@ export default class ErrorBoundary extends React.Component<
             </p>
             <button
               type="button"
-              onClick={() => {
-                if (this.props.onRetry) {
-                  this.setState({ hasError: false });
-                  this.props.onRetry();
-                  return;
-                }
-                window.location.reload();
-              }}
+              onClick={this.retry}
               className="mt-5 inline-flex items-center justify-center rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700"
             >
               {this.props.retryLabel ?? 'Reload'}
             </button>
+            <p
+              className={`mt-3 text-xs ${
+                isDarkMode ? 'text-gray-400' : 'text-gray-500'
+              }`}
+            >
+              Press{' '}
+              <kbd
+                className={`rounded border px-1.5 py-0.5 font-mono text-[11px] ${
+                  isDarkMode
+                    ? 'border-gray-600 bg-gray-700 text-gray-200'
+                    : 'border-gray-300 bg-gray-100 text-gray-700'
+                }`}
+              >
+                Enter
+              </kbd>{' '}
+              or{' '}
+              <kbd
+                className={`rounded border px-1.5 py-0.5 font-mono text-[11px] ${
+                  isDarkMode
+                    ? 'border-gray-600 bg-gray-700 text-gray-200'
+                    : 'border-gray-300 bg-gray-100 text-gray-700'
+                }`}
+              >
+                R
+              </kbd>{' '}
+              to retry
+            </p>
           </div>
         </div>
       );

--- a/Dechat/dex_with_fiat_frontend/src/components/LandingPage.tsx
+++ b/Dechat/dex_with_fiat_frontend/src/components/LandingPage.tsx
@@ -150,6 +150,30 @@ export default function LandingPage() {
     router.push('/chat');
   };
 
+  // #1185: "g" launches the app (same as the Get Started CTA), "d" toggles
+  // the theme. Ignored while focus is in the email field (or any other
+  // form control) so typing "g"/"d" there isn't hijacked.
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement | null;
+      const tag = target?.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || target?.isContentEditable) {
+        return;
+      }
+      if (event.key === 'g' || event.key === 'G') {
+        event.preventDefault();
+        handleGetStarted();
+      } else if (event.key === 'd' || event.key === 'D') {
+        event.preventDefault();
+        toggleDarkMode();
+      }
+    };
+
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [router]);
+
   const handleEmailSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     setIsSubmitted(true);

--- a/Dechat/dex_with_fiat_frontend/src/components/__tests__/CCIPBridgeModal.test.tsx
+++ b/Dechat/dex_with_fiat_frontend/src/components/__tests__/CCIPBridgeModal.test.tsx
@@ -109,7 +109,7 @@ describe('CCIPBridgeModal', () => {
 
     expect(screen.getByText('CCIP transfer error')).toBeInTheDocument();
     expect(
-      screen.getByText(/timed out after 10 minutes/i),
+      screen.getAllByText(/timed out after 10 minutes/i)[0],
     ).toBeInTheDocument();
   });
 
@@ -584,7 +584,7 @@ describe('CCIPBridgeModal', () => {
 
       expect(screen.getByText('CCIP transfer error')).toBeInTheDocument();
       expect(
-        screen.getByText(/timed out after 10 minutes/i),
+        screen.getAllByText(/timed out after 10 minutes/i)[0],
       ).toBeInTheDocument();
     });
   });
@@ -677,7 +677,7 @@ describe('CCIPBridgeModal', () => {
         await screen.findByText('CCIP transfer error'),
       ).toBeInTheDocument();
       expect(
-        screen.getByText(/CCIP transfer failed with status "FAILED"/),
+        screen.getAllByText(/CCIP transfer failed with status "FAILED"/)[0],
       ).toBeInTheDocument();
     });
 
@@ -990,6 +990,48 @@ describe('CCIPBridgeModal', () => {
         vi.advanceTimersByTime(15_000);
       });
       expect(screen.getByText('CCIP transfer confirmed')).toBeInTheDocument();
+    });
+  });
+
+  describe('accessibility: live region announcements (#1179)', () => {
+    it('announces confirmation and status through a polite live region while polling', async () => {
+      const fetchTransferStatus = vi
+        .fn()
+        .mockResolvedValueOnce({ status: 'PENDING' });
+
+      render(
+        <CCIPBridgeModal
+          {...defaultProps}
+          fetchTransferStatus={fetchTransferStatus}
+        />,
+      );
+
+      fireEvent.click(screen.getByText('Start CCIP Transfer'));
+
+      await screen.findByText('Waiting for CCIP confirmation…');
+
+      const liveRegion = screen.getByRole('status');
+      expect(liveRegion).toHaveAttribute('aria-live', 'polite');
+      expect(liveRegion.textContent).toMatch(/Waiting for CCIP confirmation/);
+      expect(liveRegion.textContent).toMatch(/PENDING/);
+    });
+
+    it('announces transfer errors through the live region', async () => {
+      const onStartTransfer = vi
+        .fn()
+        .mockRejectedValue(new Error('Insufficient allowance'));
+
+      render(
+        <CCIPBridgeModal {...defaultProps} onStartTransfer={onStartTransfer} />,
+      );
+
+      fireEvent.click(screen.getByText('Start CCIP Transfer'));
+
+      await screen.findByText('CCIP transfer error');
+
+      const liveRegion = screen.getByRole('status');
+      expect(liveRegion.textContent).toMatch(/CCIP transfer error/);
+      expect(liveRegion.textContent).toMatch(/Insufficient allowance/);
     });
   });
 });

--- a/Dechat/dex_with_fiat_frontend/src/components/__tests__/ChatSearchPanel.test.tsx
+++ b/Dechat/dex_with_fiat_frontend/src/components/__tests__/ChatSearchPanel.test.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import ChatSearchPanel from '../ChatSearchPanel';
+import { ChatMessage, ChatSession } from '@/types';
+
+vi.mock('@/contexts/ThemeContext', () => ({
+  useTheme: () => ({ isDarkMode: false }),
+}));
+
+function makeMessage(overrides: Partial<ChatMessage> & { content: string }): ChatMessage {
+  return {
+    id: Math.random().toString(36).slice(2),
+    role: 'assistant',
+    timestamp: new Date('2024-06-15T12:00:00Z'),
+    ...overrides,
+  };
+}
+
+function makeSession(overrides: Partial<ChatSession> = {}): ChatSession {
+  return {
+    id: Math.random().toString(36).slice(2),
+    title: 'Test Chat',
+    messages: [],
+    createdAt: new Date('2024-06-15'),
+    lastUpdated: new Date('2024-06-15'),
+    ...overrides,
+  };
+}
+
+describe('ChatSearchPanel – keyboard shortcuts (#1183)', () => {
+  afterEach(cleanup);
+
+  function renderPanel() {
+    const sessions: ChatSession[] = [
+      makeSession({
+        id: 'session-1',
+        title: 'Bridging XLM',
+        messages: [makeMessage({ id: 'm1', content: 'How do I bridge XLM to USDC?' })],
+      }),
+      makeSession({
+        id: 'session-2',
+        title: 'Wallet setup',
+        messages: [makeMessage({ id: 'm2', content: 'Connect your XLM wallet first' })],
+      }),
+    ];
+    const onSelectResult = vi.fn();
+    const onClose = vi.fn();
+    const utils = render(
+      <ChatSearchPanel sessions={sessions} onSelectResult={onSelectResult} onClose={onClose} />,
+    );
+    return { ...utils, onSelectResult, onClose };
+  }
+
+  it('selects the first result with Enter after typing a search', async () => {
+    const { onSelectResult, container } = renderPanel();
+    const input = screen.getByLabelText('Search keyword');
+    const root = container.firstChild as HTMLElement;
+
+    fireEvent.change(input, { target: { value: 'XLM' } });
+    // Wait for the debounced search (300ms) to actually populate results,
+    // not just for the (synchronously-rendered) results container to exist.
+    // Generous timeout: real (non-fake) timers under a loaded test runner.
+    await screen.findByText('Bridging XLM', {}, { timeout: 3000 });
+
+    fireEvent.keyDown(root, { key: 'Enter' });
+
+    expect(onSelectResult).toHaveBeenCalledWith('session-1', 'm1');
+  });
+
+  it('moves the active result with ArrowDown before selecting', async () => {
+    const { onSelectResult, container } = renderPanel();
+    const input = screen.getByLabelText('Search keyword');
+    const root = container.firstChild as HTMLElement;
+
+    fireEvent.change(input, { target: { value: 'XLM' } });
+    await screen.findByText('Wallet setup', {}, { timeout: 3000 });
+
+    fireEvent.keyDown(root, { key: 'ArrowDown' });
+    fireEvent.keyDown(root, { key: 'Enter' });
+
+    expect(onSelectResult).toHaveBeenCalledWith('session-2', 'm2');
+  });
+
+  it('still closes on Escape', async () => {
+    const { onClose, container } = renderPanel();
+    const root = container.firstChild as HTMLElement;
+
+    fireEvent.keyDown(root, { key: 'Escape' });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/Dechat/dex_with_fiat_frontend/src/components/__tests__/ErrorBoundary.test.tsx
+++ b/Dechat/dex_with_fiat_frontend/src/components/__tests__/ErrorBoundary.test.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import ErrorBoundary from '../ErrorBoundary';
+
+function Boom(): React.ReactElement {
+  throw new Error('kaboom');
+}
+
+describe('ErrorBoundary keyboard shortcuts (#1184)', () => {
+  it('retries via the "R" key', () => {
+    const onRetry = vi.fn();
+    render(
+      <ErrorBoundary onRetry={onRetry}>
+        <Boom />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText('Something went wrong.')).toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: 'r' });
+
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries via the Enter key', () => {
+    const onRetry = vi.fn();
+    render(
+      <ErrorBoundary onRetry={onRetry}>
+        <Boom />
+      </ErrorBoundary>,
+    );
+
+    fireEvent.keyDown(window, { key: 'Enter' });
+
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('reloads the page via keyboard when no onRetry is provided', () => {
+    const reload = vi.fn();
+    Object.defineProperty(window, 'location', {
+      value: { reload },
+      writable: true,
+    });
+
+    render(
+      <ErrorBoundary>
+        <Boom />
+      </ErrorBoundary>,
+    );
+
+    fireEvent.keyDown(window, { key: 'r' });
+
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores the shortcut while no error is present', () => {
+    const onRetry = vi.fn();
+    render(
+      <ErrorBoundary onRetry={onRetry}>
+        <div>fine</div>
+      </ErrorBoundary>,
+    );
+
+    fireEvent.keyDown(window, { key: 'r' });
+
+    expect(onRetry).not.toHaveBeenCalled();
+  });
+
+  it('shows a keyboard hint alongside the retry button', () => {
+    render(
+      <ErrorBoundary>
+        <Boom />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText('Enter')).toBeInTheDocument();
+    expect(screen.getByText('R')).toBeInTheDocument();
+  });
+});

--- a/Dechat/dex_with_fiat_frontend/src/components/__tests__/LandingPage.test.tsx
+++ b/Dechat/dex_with_fiat_frontend/src/components/__tests__/LandingPage.test.tsx
@@ -1,19 +1,21 @@
 import React from 'react';
 import { describe, expect, it, vi, afterEach } from 'vitest';
-import { render, screen, cleanup } from '@testing-library/react';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { useRouter } from 'next/navigation';
 import LandingPage from '@/components/LandingPage';
+import { useTheme } from '../../contexts/ThemeContext';
 
 vi.mock('next/navigation', () => ({
-  useRouter: () => ({
+  useRouter: vi.fn(() => ({
     push: vi.fn(),
-  }),
+  })),
 }));
 
 vi.mock('../../contexts/ThemeContext', () => ({
-  useTheme: () => ({
+  useTheme: vi.fn(() => ({
     isDarkMode: false,
     toggleDarkMode: vi.fn(),
-  }),
+  })),
   ThemeProvider: ({ children }: { children: React.ReactNode }) => children,
 }));
 
@@ -49,5 +51,40 @@ describe('LandingPage – accessibility', () => {
     render(<LandingPage />);
     expect(screen.getByRole('link', { name: /DexFiat on Twitter/i })).toBeDefined();
     expect(screen.getByRole('link', { name: /DexFiat on GitHub/i })).toBeDefined();
+  });
+});
+
+describe('LandingPage – keyboard shortcuts (#1185)', () => {
+  afterEach(cleanup);
+
+  it('navigates to /chat when "g" is pressed', () => {
+    const push = vi.fn();
+    vi.mocked(useRouter).mockReturnValue({ push } as unknown as ReturnType<typeof useRouter>);
+
+    render(<LandingPage />);
+    fireEvent.keyDown(window, { key: 'g' });
+
+    expect(push).toHaveBeenCalledWith('/chat');
+  });
+
+  it('toggles the theme when "d" is pressed', () => {
+    const toggleDarkMode = vi.fn();
+    vi.mocked(useTheme).mockReturnValue({ isDarkMode: false, toggleDarkMode });
+
+    render(<LandingPage />);
+    fireEvent.keyDown(window, { key: 'd' });
+
+    expect(toggleDarkMode).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not trigger the shortcut while typing in the email field', () => {
+    const push = vi.fn();
+    vi.mocked(useRouter).mockReturnValue({ push } as unknown as ReturnType<typeof useRouter>);
+
+    render(<LandingPage />);
+    const emailInput = screen.getByLabelText(/email address for early access/i);
+    fireEvent.keyDown(emailInput, { key: 'g' });
+
+    expect(push).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

**#1184 — ErrorBoundary.** `Enter`/`R` retry from the error fallback (only while it's showing, ignored while focus is in a form field). Shares the retry logic with the existing button's `onClick` rather than duplicating it. Added a visible `<kbd>` hint.

**#1185 — LandingPage.** `g` navigates to `/chat` (same as the Get Started CTA), `d` toggles the theme. Both ignored while focus is in the email field or any other form control.

**#1183 — ChatSearchPanel.** `ArrowDown`/`ArrowUp` move an active-result index (wraps around), `Enter` selects it, `Escape` still closes the panel. Added `role="listbox"`/`role="option"` + `aria-selected` so the active item is exposed to assistive tech, not just visually highlighted.

**#1179 — CCIPBridgeModal.** None of the bridge-state sections (`optimistic`/`initiating`/`polling`/`success`/`error`) were in an `aria-live` container — a screen reader user starting a transfer heard nothing as it progressed. Added a single `sr-only` `role="status" aria-live="polite"` region that announces a derived message on every state transition.

All four: theme-aware via the existing `ThemeContext`/`isDarkMode` patterns already in each file, no animation involved in any of the additions (so `prefers-reduced-motion` doesn't apply), and none change existing behavior for mouse/click users.

Closes #1179
Closes #1183
Closes #1184
Closes #1185

## Test plan

- [x] `npx tsc --noEmit`: clean
- [x] `npx eslint` on all changed files: clean (fixed one `jsx-a11y/role-supports-aria-props` warning by moving `aria-selected` from the `<button>` to the `<li role="option">` it actually belongs on)
- [x] `npx vitest run` on the 4 changed test files: 51/51 pass, including 3 pre-existing `CCIPBridgeModal.test.tsx` assertions adjusted from `getByText` to `getAllByText(...)[0]` — they broke because the new live region's announcement text now also contains the same substrings those queries matched against the visible UI (both matches are correct; a single-match assumption was the thing that needed to change)
- [x] Full `npx vitest run` (730 tests): ran twice: each run had 2 failures, but a *different* 2 each time, including one in `SplitViewComparison.test.tsx` — a file untouched by this PR — confirming pre-existing flakiness under full-suite parallel load, not something introduced here. All 4 of this PR's own test files pass reliably in isolation.