### PR TITLE
Chore/docs retry and modal race fixes

### DIFF
--- a/Dechat/dex_with_fiat_frontend/src/components/ChatMessages.tsx
+++ b/Dechat/dex_with_fiat_frontend/src/components/ChatMessages.tsx
@@ -22,6 +22,11 @@ interface ChatMessagesProps {
     actionType: string,
     data?: Record<string, unknown>,
   ) => void;
+  /**
+   * Resend a message that failed to send. Receives the failed message's id and
+   * its original content, ready to be submitted again as-is.
+   */
+  onRetry?: (messageId: string, content: string) => void | Promise<void>;
   isLoading?: boolean;
   searchQuery?: string;
 }
@@ -107,6 +112,7 @@ function HelpCard({
 export default function ChatMessages({
   messages: allMessages,
   onActionClick,
+  onRetry,
   isLoading = false,
   searchQuery = '',
 }: ChatMessagesProps) {
@@ -402,6 +408,7 @@ export default function ChatMessages({
               key={message.id}
               message={message}
               onActionClick={onActionClick}
+              onRetry={onRetry}
               shouldAnimate={isReadyToAnimate && !isLoadingMore && !seenMessageIds.current.has(message.id)}
             />
           ))}

--- a/Dechat/dex_with_fiat_frontend/src/components/Message.tsx
+++ b/Dechat/dex_with_fiat_frontend/src/components/Message.tsx
@@ -12,6 +12,7 @@ import React from 'react';
 import ReactMarkdown from 'react-markdown';
 import type { Components } from 'react-markdown';
 import { toDate } from '@/lib/messageUtils';
+import { MAX_AUTO_RETRIES, useMessageRetry } from '@/hooks/useMessageRetry';
 import { useTranslation } from '@/contexts/TranslationContext';
 import { motion, useReducedMotion } from 'framer-motion';
 import CopyButton from '@/components/ui/CopyButton';
@@ -23,7 +24,12 @@ interface MessageProps {
     actionType: string,
     data?: Record<string, unknown>,
   ) => void;
-  onRetry?: (messageId: string) => void;
+  /**
+   * Resend a message that failed to send. Receives the message id and the
+   * *original* content the user typed (from `originalPayload` when available),
+   * so the caller never has to reconstruct it and the user never has to retype.
+   */
+  onRetry?: (messageId: string, content: string) => void | Promise<void>;
   shouldAnimate?: boolean;
 }
 
@@ -43,6 +49,19 @@ export default function Message({ message, onActionClick, onRetry, shouldAnimate
   const { t } = useTranslation();
   const isPending = message.metadata?.status === 'pending';
   const isFailed = message.metadata?.status === 'failed';
+
+  // Resend uses the payload captured at send time so the user's original text
+  // survives any post-failure rewrite of `content`.
+  const retryContent = message.originalPayload?.content ?? message.content;
+  const retry = useMessageRetry({
+    messageId: message.id,
+    content: retryContent,
+    isFailed: hasError,
+    onRetry,
+  });
+  // Attempts already recorded on the message, plus the ones this component has
+  // made since it mounted.
+  const totalRetryAttempts = (message.error?.retryAttempts ?? 0) + retry.attempts;
 
 
   // Currency conversion hook for transaction amounts
@@ -216,6 +235,8 @@ export default function Message({ message, onActionClick, onRetry, shouldAnimate
             {/* Error State */}
             {hasError && (
               <div
+                data-testid="message-error"
+                role="alert"
                 className={`mt-3 inline-flex flex-col gap-2 rounded-lg border px-3 py-2 text-xs ${
                   isDarkMode
                     ? 'border-red-700 bg-red-950/40 text-red-200'
@@ -228,23 +249,51 @@ export default function Message({ message, onActionClick, onRetry, shouldAnimate
                     {message.error?.message || 'Failed to send message'}
                   </span>
                 </div>
-                {message.error?.retryAttempts && message.error.retryAttempts > 0 && (
+                {totalRetryAttempts > 0 && (
                   <div className="text-xs opacity-75">
-                    Retry attempts: {message.error.retryAttempts}
+                    Retry attempts: {totalRetryAttempts}
                   </div>
                 )}
                 {onRetry && (
-                  <button
-                    onClick={() => onRetry(message.id)}
-                    className={`mt-2 flex items-center justify-center gap-2 px-3 py-1 rounded-lg text-xs font-medium transition-all transform hover:scale-105 active:scale-95 ${
-                      isDarkMode
-                        ? 'bg-red-700/40 hover:bg-red-700/60 border border-red-600'
-                        : 'bg-red-100 hover:bg-red-200 border border-red-300'
-                    }`}
-                  >
-                    <RotateCcw className="w-3 h-3" />
-                    Retry
-                  </button>
+                  <>
+                    <div
+                      className="text-xs opacity-75"
+                      aria-live="polite"
+                      data-testid="message-retry-status"
+                    >
+                      {retry.isRetrying
+                        ? t('chat.resending')
+                        : retry.secondsUntilNextRetry !== null
+                          ? t('chat.retry_countdown', {
+                              seconds: retry.secondsUntilNextRetry,
+                              attempt: retry.attempts + 1,
+                              max: MAX_AUTO_RETRIES,
+                            })
+                          : t('chat.retry_exhausted', {
+                              max: MAX_AUTO_RETRIES,
+                            })}
+                    </div>
+                    <button
+                      type="button"
+                      onClick={retry.retryNow}
+                      disabled={retry.isRetrying}
+                      data-testid="message-retry-button"
+                      aria-label={t('chat.retry_message', {
+                        content: retryContent,
+                      })}
+                      title={retryContent}
+                      className={`mt-2 flex items-center justify-center gap-2 px-3 py-1 rounded-lg text-xs font-medium transition-all transform hover:scale-105 active:scale-95 disabled:opacity-60 disabled:cursor-not-allowed disabled:hover:scale-100 ${
+                        isDarkMode
+                          ? 'bg-red-700/40 hover:bg-red-700/60 border border-red-600'
+                          : 'bg-red-100 hover:bg-red-200 border border-red-300'
+                      }`}
+                    >
+                      <RotateCcw
+                        className={`w-3 h-3 ${retry.isRetrying ? 'animate-spin' : ''}`}
+                      />
+                      {retry.isRetrying ? t('common.loading') : t('common.retry')}
+                    </button>
+                  </>
                 )}
               </div>
             )}

--- a/Dechat/dex_with_fiat_frontend/src/components/OfflineStatusBanner.test.tsx
+++ b/Dechat/dex_with_fiat_frontend/src/components/OfflineStatusBanner.test.tsx
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { renderHook, act } from '@testing-library/react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import OfflineStatusBanner from './OfflineStatusBanner';
-import * as offlineMessageQueue from '@/lib/offlineMessageQueue';
+import { useOnlineStatus } from '@/hooks/useOnlineStatus';
+import { subscribeToQueuedMessageCount } from '@/lib/offlineMessageQueue';
 
 // Mock dependencies
 vi.mock('@/hooks/useOnlineStatus', () => ({
@@ -26,14 +26,42 @@ vi.mock('@/lib/offlineStatusSchema', () => ({
 }));
 
 vi.mock('@/lib/offlineMessageQueue', () => ({
-  subscribeToQueuedMessageCount: vi.fn(),
+  subscribeToQueuedMessageCount: vi.fn(() => () => {}),
   setQueuedMessageCount: vi.fn(),
   getQueuedMessageCount: vi.fn(() => 0),
 }));
 
+const mockedUseOnlineStatus = vi.mocked(useOnlineStatus);
+const mockedSubscribe = vi.mocked(subscribeToQueuedMessageCount);
+
+/** Elapse the 300ms initial loading gate so it cannot mask later renders. */
+function settleLoadingGate() {
+  act(() => {
+    vi.advanceTimersByTime(300);
+  });
+}
+
+/** Point `useOnlineStatus` at a value the test can flip between renders. */
+function stubOnlineStatus(getIsOnline: () => boolean, wasOffline = false) {
+  const resetWasOffline = vi.fn();
+  mockedUseOnlineStatus.mockImplementation(() => ({
+    get isOnline() {
+      return getIsOnline();
+    },
+    wasOffline,
+    resetWasOffline,
+  }));
+  return resetWasOffline;
+}
+
 describe('OfflineStatusBanner - Optimistic UI Updates', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockedSubscribe.mockImplementation(() => () => {});
+    // Fake timers are required for the 300ms loading skeleton and the 500ms
+    // reconnect dismissal. Assertions below are made directly after an explicit
+    // `advanceTimersByTime` rather than through `waitFor`, whose polling never
+    // fires while the clock is frozen.
     vi.useFakeTimers();
   });
 
@@ -42,138 +70,104 @@ describe('OfflineStatusBanner - Optimistic UI Updates', () => {
     vi.useRealTimers();
   });
 
-  it('should show banner immediately when going offline', async () => {
-    const { useOnlineStatus } = await import('@/hooks/useOnlineStatus');
-    (useOnlineStatus as any).mockReturnValue({
-      isOnline: false,
-      wasOffline: false,
-      resetWasOffline: vi.fn(),
-    });
+  it('should show banner immediately when going offline', () => {
+    stubOnlineStatus(() => false);
 
     render(<OfflineStatusBanner />);
 
-    await waitFor(() => {
-      expect(screen.getByRole('status')).toBeInTheDocument();
-    });
-
+    expect(screen.getByRole('status')).toBeInTheDocument();
     expect(screen.getByText(/You are offline/i)).toBeInTheDocument();
   });
 
-  it('should show reconnecting state when coming back online', async () => {
-    const { useOnlineStatus } = await import('@/hooks/useOnlineStatus');
+  it('should show reconnecting state when coming back online', () => {
     let isOnline = false;
-    
-    (useOnlineStatus as any).mockImplementation(() => ({
-      get isOnline() { return isOnline; },
-      wasOffline: true,
-      resetWasOffline: vi.fn(),
-    }));
+    stubOnlineStatus(() => isOnline, true);
 
     const { rerender } = render(<OfflineStatusBanner />);
-
-    await waitFor(() => {
-      expect(screen.getByText(/You are offline/i)).toBeInTheDocument();
-    });
+    settleLoadingGate();
+    expect(screen.getByText(/You are offline/i)).toBeInTheDocument();
 
     // Simulate coming back online
     isOnline = true;
     rerender(<OfflineStatusBanner />);
 
-    await waitFor(() => {
-      expect(screen.getByText(/Reconnecting/i)).toBeInTheDocument();
-    });
+    expect(screen.getByText(/Reconnecting/i)).toBeInTheDocument();
   });
 
-  it('should display optimistic pending count', async () => {
-    const { useOnlineStatus } = await import('@/hooks/useOnlineStatus');
-    (useOnlineStatus as any).mockReturnValue({
-      isOnline: false,
-      wasOffline: false,
-      resetWasOffline: vi.fn(),
+  it('should display optimistic pending count', () => {
+    stubOnlineStatus(() => false);
+    // The count is pushed by `offlineMessageQueue` subscribers, not pulled.
+    mockedSubscribe.mockImplementation((listener) => {
+      listener(3);
+      return () => {};
     });
-
-    (offlineMessageQueue.getQueuedMessageCount as any).mockReturnValue(3);
 
     render(<OfflineStatusBanner />);
 
-    await waitFor(() => {
-      expect(screen.getByText(/3 messages waiting to send/i)).toBeInTheDocument();
-    });
+    expect(screen.getByText(/3 messages waiting to send/i)).toBeInTheDocument();
   });
 
-  it('should hide banner after reconnection delay', async () => {
-    const { useOnlineStatus } = await import('@/hooks/useOnlineStatus');
+  it('should pluralise a single pending message', () => {
+    stubOnlineStatus(() => false);
+    mockedSubscribe.mockImplementation((listener) => {
+      listener(1);
+      return () => {};
+    });
+
+    render(<OfflineStatusBanner />);
+
+    expect(screen.getByText(/1 message waiting to send/i)).toBeInTheDocument();
+  });
+
+  it('should hide banner after reconnection delay', () => {
     let isOnline = false;
-    
-    (useOnlineStatus as any).mockImplementation(() => ({
-      get isOnline() { return isOnline; },
-      wasOffline: true,
-      resetWasOffline: vi.fn(),
-    }));
+    const resetWasOffline = stubOnlineStatus(() => isOnline, true);
 
     const { rerender } = render(<OfflineStatusBanner />);
-
-    await waitFor(() => {
-      expect(screen.getByRole('status')).toBeInTheDocument();
-    });
+    settleLoadingGate();
+    expect(screen.getByRole('status')).toBeInTheDocument();
 
     // Simulate coming back online
     isOnline = true;
     rerender(<OfflineStatusBanner />);
+    expect(screen.getByRole('status')).toBeInTheDocument();
 
     act(() => {
       vi.advanceTimersByTime(500);
     });
 
-    await waitFor(() => {
-      expect(screen.queryByRole('status')).not.toBeInTheDocument();
-    });
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+    expect(resetWasOffline).toHaveBeenCalled();
   });
 
-  it('should update aria-label based on connection state', async () => {
-    const { useOnlineStatus } = await import('@/hooks/useOnlineStatus');
+  it('should update aria-label based on connection state', () => {
     let isOnline = false;
-    
-    (useOnlineStatus as any).mockImplementation(() => ({
-      get isOnline() { return isOnline; },
-      wasOffline: true,
-      resetWasOffline: vi.fn(),
-    }));
+    stubOnlineStatus(() => isOnline, true);
 
     const { rerender } = render(<OfflineStatusBanner />);
-
-    await waitFor(() => {
-      expect(screen.getByLabelText('Offline status')).toBeInTheDocument();
-    });
+    settleLoadingGate();
+    expect(screen.getByLabelText('Offline status')).toBeInTheDocument();
 
     isOnline = true;
     rerender(<OfflineStatusBanner />);
 
-    await waitFor(() => {
-      expect(screen.getByLabelText('Reconnecting')).toBeInTheDocument();
-    });
+    expect(screen.getByLabelText('Reconnecting')).toBeInTheDocument();
   });
 
-  it('should show loading skeleton initially when online', async () => {
-    const { useOnlineStatus } = await import('@/hooks/useOnlineStatus');
-    (useOnlineStatus as any).mockReturnValue({
-      isOnline: true,
-      wasOffline: false,
-      resetWasOffline: vi.fn(),
-    });
+  it('should show loading skeleton initially when online', () => {
+    stubOnlineStatus(() => true);
 
     render(<OfflineStatusBanner />);
 
     // Should show loading skeleton initially
-    const skeleton = document.querySelector('[aria-hidden="true"]');
-    expect(skeleton).toBeInTheDocument();
+    expect(document.querySelector('[aria-hidden="true"]')).toBeInTheDocument();
 
     act(() => {
       vi.advanceTimersByTime(300);
     });
 
-    await waitFor(() => {
-      expect(document.querySelector('[aria-hidden="true"]')).not.toBeInTheDocument();
-    });
+    expect(
+      document.querySelector('[aria-hidden="true"]'),
+    ).not.toBeInTheDocument();
   });
 });

--- a/Dechat/dex_with_fiat_frontend/src/components/OfflineStatusBanner.tsx
+++ b/Dechat/dex_with_fiat_frontend/src/components/OfflineStatusBanner.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import { useEffect, useState, useCallback, useRef } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import { AlertTriangle, WifiOff } from 'lucide-react';
 import { useOnlineStatus } from '@/hooks/useOnlineStatus';
 import { useToast } from '@/hooks/useToast';
 import { offlineStatusToastSchema } from '@/lib/offlineStatusSchema';
-import { subscribeToQueuedMessageCount, setQueuedMessageCount, getQueuedMessageCount } from '@/lib/offlineMessageQueue';
+import { subscribeToQueuedMessageCount } from '@/lib/offlineMessageQueue';
 
 /**
  * Offline Status Banner Component
@@ -18,7 +18,6 @@ export default function OfflineStatusBanner() {
   const { addToast } = useToast();
   const [showBanner, setShowBanner] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
-  const [pendingCount, setPendingCount] = useState(0);
   const [optimisticPendingCount, setOptimisticPendingCount] = useState(0);
   const [isReconnecting, setIsReconnecting] = useState(false);
   const previousOnlineState = useRef<boolean>(true);
@@ -31,33 +30,27 @@ export default function OfflineStatusBanner() {
     return () => clearTimeout(timer);
   }, []);
 
+  // The queue count is owned by `offlineMessageQueue` and published by
+  // `useChat` as sends are queued and drained; this component only mirrors it.
   useEffect(() => {
-    return subscribeToQueuedMessageCount((count) => {
-      setPendingCount(count);
-      setOptimisticPendingCount(count);
-    });
-  }, []);
-
-  // Optimistic update: increment pending count immediately when message is queued
-  const optimisticallyIncrementPending = useCallback(() => {
-    setOptimisticPendingCount((prev: number) => prev + 1);
-    setQueuedMessageCount(getQueuedMessageCount() + 1);
-  }, []);
-
-  // Optimistic update: decrement pending count immediately when message is sent
-  const optimisticallyDecrementPending = useCallback(() => {
-    setOptimisticPendingCount((prev: number) => Math.max(0, prev - 1));
-    setQueuedMessageCount(Math.max(0, getQueuedMessageCount() - 1));
+    return subscribeToQueuedMessageCount(setOptimisticPendingCount);
   }, []);
 
   useEffect(() => {
+    // A reconnect is either observed live (we saw the offline render) or
+    // reported after the fact by `wasOffline` — the latter happens when this
+    // banner mounts only once the connection is already back. Without the
+    // `wasOffline` arm the toast is skipped and the latch is never reset, so
+    // the hook keeps reporting a reconnect that was never announced.
+    const cameBackOnline = isOnline && (!previousOnlineState.current || wasOffline);
+
     // Optimistic UI: Show banner immediately when going offline
     if (!isOnline && previousOnlineState.current) {
       setShowBanner(true);
       setIsReconnecting(false);
     }
     // Optimistic UI: Hide banner immediately when coming back online
-    else if (isOnline && !previousOnlineState.current) {
+    else if (cameBackOnline) {
       setIsReconnecting(true);
       // Show toast when coming back online
       const toastOptions = {
@@ -82,11 +75,14 @@ export default function OfflineStatusBanner() {
         addToast(errorMessage);
       }
 
+      // Consume the latch straight away, so the reconnect is announced exactly
+      // once rather than on every subsequent render.
+      resetWasOffline();
+
       // Optimistically hide banner after short delay
       setTimeout(() => {
         setShowBanner(false);
         setIsReconnecting(false);
-        resetWasOffline();
       }, 500);
     }
 

--- a/Dechat/dex_with_fiat_frontend/src/components/StellarChatInterface.tsx
+++ b/Dechat/dex_with_fiat_frontend/src/components/StellarChatInterface.tsx
@@ -450,6 +450,18 @@ function StellarChatInterfaceContent() {
     [connect, isNetworkMismatch, sendMessage],
   );
 
+  /**
+   * Resend a message that failed to send (issue #1043).
+   *
+   * `content` is the original text captured at send time, so the user never has
+   * to retype it. Both the automatic backoff retries and the manual Retry button
+   * in the message's error state land here.
+   */
+  const handleRetryMessage = useCallback(
+    (_messageId: string, content: string) => sendMessage(content),
+    [sendMessage],
+  );
+
   // ── Health badge helper ─────────────────────────────────────────────────────
   const healthBadge = {
     checking: {
@@ -961,6 +973,7 @@ function StellarChatInterfaceContent() {
                 <ChatMessages
                   messages={messages}
                   onActionClick={handleActionClick}
+                  onRetry={handleRetryMessage}
                   isLoading={isLoading}
                 />
               </ErrorBoundary>

--- a/Dechat/dex_with_fiat_frontend/src/components/__tests__/Message.retry.test.tsx
+++ b/Dechat/dex_with_fiat_frontend/src/components/__tests__/Message.retry.test.tsx
@@ -1,0 +1,232 @@
+import { act, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ChatMessage } from '@/types';
+
+vi.mock('@/contexts/StellarWalletContext', () => ({
+  useStellarWallet: () => ({ connection: { isConnected: true } }),
+}));
+
+vi.mock('@/contexts/ThemeContext', () => ({
+  useTheme: () => ({ isDarkMode: false }),
+}));
+
+vi.mock('@/contexts/UserPreferencesContext', () => ({
+  useUserPreferences: () => ({ maskingEnabled: false, maskingStyle: 'full' }),
+}));
+
+// Resolve real copy so the assertions below exercise the actual strings.
+vi.mock('@/contexts/TranslationContext', async () => {
+  const en = (await import('@/locales/en.json')).default as Record<
+    string,
+    Record<string, string>
+  >;
+  return {
+    useTranslation: () => ({
+      t: (key: string, params?: Record<string, string | number>) => {
+        const [section, name] = key.split('.');
+        const value = en[section]?.[name] ?? key;
+        return params
+          ? Object.entries(params).reduce(
+              (acc, [k, v]) => acc.replace(`{${k}}`, String(v)),
+              value,
+            )
+          : value;
+      },
+    }),
+  };
+});
+
+vi.mock('@/hooks/useMasking', () => ({
+  useMasking: (content: string) => content,
+}));
+
+vi.mock('@/hooks/useCurrencyConversion', () => ({
+  useCurrencyConversion: () => ({ displayText: '' }),
+}));
+
+// react-markdown ships ESM-only deps that are noise for this test.
+vi.mock('react-markdown', () => ({
+  default: ({ children }: { children: string }) => <div>{children}</div>,
+}));
+
+const { default: Message } = await import('@/components/Message');
+const { MAX_AUTO_RETRIES, RETRY_BASE_DELAY_MS } = await import(
+  '@/hooks/useMessageRetry'
+);
+
+function failedMessage(overrides: Partial<ChatMessage> = {}): ChatMessage {
+  return {
+    id: 'msg-1',
+    role: 'user',
+    content: 'Sorry, something went wrong.',
+    timestamp: new Date('2026-01-01T00:00:00Z'),
+    error: {
+      message: 'Message failed to send. Please try again.',
+      timestamp: new Date('2026-01-01T00:00:00Z'),
+      retryAttempts: 0,
+    },
+    originalPayload: { content: 'Convert 100 XLM to USD' },
+    ...overrides,
+  };
+}
+
+describe('Message — failed message resend', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  const advance = async (ms: number) => {
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(ms);
+    });
+  };
+
+  it('renders a retry action in the error state', () => {
+    render(
+      <Message
+        message={failedMessage()}
+        onActionClick={vi.fn()}
+        onRetry={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('message-retry-button')).toBeTruthy();
+  });
+
+  it('omits the retry action when no handler is supplied', () => {
+    render(<Message message={failedMessage()} onActionClick={vi.fn()} />);
+
+    expect(screen.queryByTestId('message-retry-button')).toBeNull();
+  });
+
+  it('resends the original content, not the failure placeholder', () => {
+    const onRetry = vi.fn();
+    render(
+      <Message
+        message={failedMessage()}
+        onActionClick={vi.fn()}
+        onRetry={onRetry}
+      />,
+    );
+
+    act(() => {
+      screen.getByTestId('message-retry-button').click();
+    });
+
+    expect(onRetry).toHaveBeenCalledWith('msg-1', 'Convert 100 XLM to USD');
+  });
+
+  it('falls back to the message body when no original payload was captured', () => {
+    const onRetry = vi.fn();
+    render(
+      <Message
+        message={failedMessage({ originalPayload: undefined })}
+        onActionClick={vi.fn()}
+        onRetry={onRetry}
+      />,
+    );
+
+    act(() => {
+      screen.getByTestId('message-retry-button').click();
+    });
+
+    expect(onRetry).toHaveBeenCalledWith(
+      'msg-1',
+      'Sorry, something went wrong.',
+    );
+  });
+
+  it('retries automatically with backoff and stops after the budget is spent', async () => {
+    const onRetry = vi.fn();
+    render(
+      <Message
+        message={failedMessage()}
+        onActionClick={vi.fn()}
+        onRetry={onRetry}
+      />,
+    );
+
+    expect(onRetry).not.toHaveBeenCalled();
+
+    await advance(RETRY_BASE_DELAY_MS);
+    expect(onRetry).toHaveBeenCalledTimes(1);
+
+    await advance(RETRY_BASE_DELAY_MS * 2);
+    expect(onRetry).toHaveBeenCalledTimes(2);
+
+    await advance(RETRY_BASE_DELAY_MS * 4);
+    expect(onRetry).toHaveBeenCalledTimes(MAX_AUTO_RETRIES);
+
+    for (let i = 0; i < 40; i += 1) {
+      await advance(250);
+    }
+    expect(onRetry).toHaveBeenCalledTimes(MAX_AUTO_RETRIES);
+    expect(screen.getByTestId('message-retry-status').textContent).toContain(
+      'exhausted',
+    );
+  });
+
+  it('announces the countdown to the next automatic attempt', async () => {
+    render(
+      <Message
+        message={failedMessage()}
+        onActionClick={vi.fn()}
+        onRetry={vi.fn()}
+      />,
+    );
+
+    await advance(0);
+    const status = screen.getByTestId('message-retry-status');
+    expect(status.getAttribute('aria-live')).toBe('polite');
+    expect(status.textContent).toContain('Retrying automatically in 1s');
+    expect(status.textContent).toContain(`of ${MAX_AUTO_RETRIES}`);
+  });
+
+  it('counts prior server-side attempts alongside client-side ones', async () => {
+    render(
+      <Message
+        message={failedMessage({
+          error: {
+            message: 'Message failed to send. Please try again.',
+            timestamp: new Date('2026-01-01T00:00:00Z'),
+            retryAttempts: 2,
+          },
+        })}
+        onActionClick={vi.fn()}
+        onRetry={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('message-error').textContent).toContain(
+      'Retry attempts: 2',
+    );
+
+    await advance(RETRY_BASE_DELAY_MS);
+    expect(screen.getByTestId('message-error').textContent).toContain(
+      'Retry attempts: 3',
+    );
+  });
+
+  it('disables the button while a resend is in flight', () => {
+    const onRetry = vi.fn(() => new Promise<void>(() => {}));
+    render(
+      <Message
+        message={failedMessage()}
+        onActionClick={vi.fn()}
+        onRetry={onRetry}
+      />,
+    );
+
+    const button = screen.getByTestId('message-retry-button');
+    act(() => button.click());
+
+    expect(button.hasAttribute('disabled')).toBe(true);
+    act(() => button.click());
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+});

--- a/Dechat/dex_with_fiat_frontend/src/hooks/__tests__/useAccessibleModal.test.tsx
+++ b/Dechat/dex_with_fiat_frontend/src/hooks/__tests__/useAccessibleModal.test.tsx
@@ -1,0 +1,317 @@
+import { useRef } from 'react';
+import { render, act, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  useAccessibleModal,
+  FOCUS_TRAP_FAILURE_MESSAGE,
+} from '@/hooks/useAccessibleModal';
+import { toastStore } from '@/lib/toastStore';
+
+/**
+ * Minimal modal harness. `renderContainer` lets a test simulate a modal whose
+ * root element is not in the DOM when the effect first runs.
+ */
+function Modal({
+  isOpen,
+  onClose,
+  children,
+  renderContainer = true,
+  onError,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+  children?: React.ReactNode;
+  renderContainer?: boolean;
+  onError?: (message: string) => void;
+}) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  useAccessibleModal(isOpen, ref, onClose, onError ? { onError } : undefined);
+
+  if (!renderContainer) {
+    return null;
+  }
+
+  return (
+    <div ref={ref} role="dialog">
+      {children}
+    </div>
+  );
+}
+
+function press(key: string, init: KeyboardEventInit = {}) {
+  act(() => {
+    document.dispatchEvent(
+      new KeyboardEvent('keydown', { key, bubbles: true, ...init }),
+    );
+  });
+}
+
+describe('useAccessibleModal', () => {
+  beforeEach(() => {
+    document.body.style.overflow = '';
+    toastStore.clearToasts();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    document.body.style.overflow = '';
+    toastStore.clearToasts();
+  });
+
+  describe('body scroll lock', () => {
+    it('locks while open and restores the original value on close', () => {
+      document.body.style.overflow = 'scroll';
+
+      const { rerender } = render(
+        <Modal isOpen onClose={() => {}}>
+          <button>ok</button>
+        </Modal>,
+      );
+      expect(document.body.style.overflow).toBe('hidden');
+
+      rerender(
+        <Modal isOpen={false} onClose={() => {}}>
+          <button>ok</button>
+        </Modal>,
+      );
+      expect(document.body.style.overflow).toBe('scroll');
+    });
+
+    // Guard for the reference-counted lock: an unstable `onClose` used to be an
+    // effect dependency, so every parent re-render released and re-acquired the
+    // lock. That must stay balanced — and must never flicker the page unlocked
+    // mid-render.
+    it('does not leak the lock when onClose changes identity while open', () => {
+      const { rerender } = render(
+        <Modal isOpen onClose={() => {}}>
+          <button>ok</button>
+        </Modal>,
+      );
+      expect(document.body.style.overflow).toBe('hidden');
+
+      // Three re-renders, each with a brand-new inline callback.
+      for (let i = 0; i < 3; i += 1) {
+        rerender(
+          <Modal isOpen onClose={() => {}}>
+            <button>ok</button>
+          </Modal>,
+        );
+      }
+      expect(document.body.style.overflow).toBe('hidden');
+
+      rerender(
+        <Modal isOpen={false} onClose={() => {}}>
+          <button>ok</button>
+        </Modal>,
+      );
+      expect(document.body.style.overflow).toBe('');
+    });
+
+    // Regression: with two modals stacked, the inner one snapshotted the outer
+    // one's 'hidden'. Closing the outer modal first unlocked the page while the
+    // inner modal was still up, and closing the inner one then wrote 'hidden'
+    // back to a page with no modals on it.
+    it('reference-counts across overlapping modals', () => {
+      const outer = render(
+        <Modal isOpen onClose={() => {}}>
+          <button>outer</button>
+        </Modal>,
+      );
+      const inner = render(
+        <Modal isOpen onClose={() => {}}>
+          <button>inner</button>
+        </Modal>,
+      );
+      expect(document.body.style.overflow).toBe('hidden');
+
+      // Outer closes first — the inner modal is still open, so stay locked.
+      outer.unmount();
+      expect(document.body.style.overflow).toBe('hidden');
+
+      inner.unmount();
+      expect(document.body.style.overflow).toBe('');
+    });
+  });
+
+  describe('focus management', () => {
+    it('moves focus to the first focusable element on open', () => {
+      const { getByText } = render(
+        <Modal isOpen onClose={() => {}}>
+          <button>first</button>
+          <button>second</button>
+        </Modal>,
+      );
+      expect(document.activeElement).toBe(getByText('first'));
+    });
+
+    // Regression: the effect re-ran on every render, and each re-run re-applied
+    // initial focus — dragging the user back to the first control mid-form.
+    it('does not steal focus back on re-render while open', () => {
+      const { getByText, rerender } = render(
+        <Modal isOpen onClose={() => {}}>
+          <button>first</button>
+          <button>second</button>
+        </Modal>,
+      );
+
+      const second = getByText('second');
+      act(() => second.focus());
+      expect(document.activeElement).toBe(second);
+
+      rerender(
+        <Modal isOpen onClose={() => {}}>
+          <button>first</button>
+          <button>second</button>
+        </Modal>,
+      );
+
+      expect(document.activeElement).toBe(second);
+    });
+
+    it('restores focus to the opener on close', () => {
+      const trigger = document.createElement('button');
+      document.body.appendChild(trigger);
+      trigger.focus();
+
+      const { rerender } = render(
+        <Modal isOpen onClose={() => {}}>
+          <button>ok</button>
+        </Modal>,
+      );
+      expect(document.activeElement).not.toBe(trigger);
+
+      rerender(
+        <Modal isOpen={false} onClose={() => {}}>
+          <button>ok</button>
+        </Modal>,
+      );
+      expect(document.activeElement).toBe(trigger);
+    });
+
+    it('falls back to the body when the opener has been removed', () => {
+      const trigger = document.createElement('button');
+      document.body.appendChild(trigger);
+      trigger.focus();
+
+      const { rerender } = render(
+        <Modal isOpen onClose={() => {}}>
+          <button>ok</button>
+        </Modal>,
+      );
+
+      trigger.remove();
+
+      expect(() =>
+        rerender(
+          <Modal isOpen={false} onClose={() => {}}>
+            <button>ok</button>
+          </Modal>,
+        ),
+      ).not.toThrow();
+      expect(document.activeElement).toBe(document.body);
+    });
+
+    it('wraps Tab and Shift+Tab inside the modal', () => {
+      const { getByText } = render(
+        <Modal isOpen onClose={() => {}}>
+          <button>first</button>
+          <button>last</button>
+        </Modal>,
+      );
+
+      const first = getByText('first');
+      const last = getByText('last');
+
+      act(() => last.focus());
+      press('Tab');
+      expect(document.activeElement).toBe(first);
+
+      press('Tab', { shiftKey: true });
+      expect(document.activeElement).toBe(last);
+    });
+  });
+
+  describe('escape handling', () => {
+    it('closes on Escape', () => {
+      const onClose = vi.fn();
+      render(
+        <Modal isOpen onClose={onClose}>
+          <button>ok</button>
+        </Modal>,
+      );
+
+      press('Escape');
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    // Regression guard for the ref indirection: skipping `onClose` as a
+    // dependency must not pin the effect to a stale callback.
+    it('calls the latest onClose after a re-render', () => {
+      const first = vi.fn();
+      const second = vi.fn();
+
+      const { rerender } = render(
+        <Modal isOpen onClose={first}>
+          <button>ok</button>
+        </Modal>,
+      );
+      rerender(
+        <Modal isOpen onClose={second}>
+          <button>ok</button>
+        </Modal>,
+      );
+
+      press('Escape');
+      expect(first).not.toHaveBeenCalled();
+      expect(second).toHaveBeenCalledTimes(1);
+    });
+
+    it('stops listening once closed', () => {
+      const onClose = vi.fn();
+      const { rerender } = render(
+        <Modal isOpen onClose={onClose}>
+          <button>ok</button>
+        </Modal>,
+      );
+      rerender(
+        <Modal isOpen={false} onClose={onClose}>
+          <button>ok</button>
+        </Modal>,
+      );
+
+      press('Escape');
+      expect(onClose).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('error paths', () => {
+    it('surfaces a message when the container never mounts', async () => {
+      render(<Modal isOpen onClose={() => {}} renderContainer={false} />);
+
+      await waitFor(() => {
+        expect(toastStore.getToasts().map((t) => t.message)).toContain(
+          FOCUS_TRAP_FAILURE_MESSAGE,
+        );
+      });
+      expect(toastStore.getToasts()[0].variant).toBe('error');
+    });
+
+    it('surfaces a message when the modal has nothing focusable', () => {
+      const onError = vi.fn();
+      render(<Modal isOpen onClose={() => {}} onError={onError} />);
+
+      press('Tab');
+      expect(onError).toHaveBeenCalledWith(FOCUS_TRAP_FAILURE_MESSAGE);
+    });
+
+    it('reports the failure only once per open', () => {
+      const onError = vi.fn();
+      render(<Modal isOpen onClose={() => {}} onError={onError} />);
+
+      press('Tab');
+      press('Tab');
+      press('Tab');
+      expect(onError).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/Dechat/dex_with_fiat_frontend/src/hooks/__tests__/useMessageRetry.test.ts
+++ b/Dechat/dex_with_fiat_frontend/src/hooks/__tests__/useMessageRetry.test.ts
@@ -1,0 +1,257 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  MAX_AUTO_RETRIES,
+  RETRY_BASE_DELAY_MS,
+  getRetryDelayMs,
+  useMessageRetry,
+} from '@/hooks/useMessageRetry';
+
+describe('getRetryDelayMs', () => {
+  it('doubles on each attempt', () => {
+    expect(getRetryDelayMs(1)).toBe(RETRY_BASE_DELAY_MS);
+    expect(getRetryDelayMs(2)).toBe(RETRY_BASE_DELAY_MS * 2);
+    expect(getRetryDelayMs(3)).toBe(RETRY_BASE_DELAY_MS * 4);
+  });
+
+  it('clamps non-positive attempts to the base delay', () => {
+    expect(getRetryDelayMs(0)).toBe(RETRY_BASE_DELAY_MS);
+    expect(getRetryDelayMs(-5)).toBe(RETRY_BASE_DELAY_MS);
+  });
+});
+
+describe('useMessageRetry', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const advance = async (ms: number) => {
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(ms);
+    });
+  };
+
+  /**
+   * Advance `ms` in 250ms slices, each with its own `act` boundary. React's
+   * scheduler flushes on a MessageChannel task that a single long
+   * `advanceTimersByTimeAsync` never yields to, so one big jump would leave the
+   * effect that schedules the *next* backoff step unrun.
+   */
+  const advanceInSlices = async (ms: number) => {
+    for (let elapsed = 0; elapsed < ms; elapsed += 250) {
+      await advance(250);
+    }
+  };
+
+  it('makes at most MAX_AUTO_RETRIES automatic attempts, with exponential backoff', async () => {
+    const onRetry = vi.fn();
+    const { result } = renderHook(() =>
+      useMessageRetry({
+        messageId: 'm1',
+        content: 'send me again',
+        isFailed: true,
+        onRetry,
+      }),
+    );
+
+    expect(onRetry).not.toHaveBeenCalled();
+
+    // Attempt 1 after 1s.
+    await advance(RETRY_BASE_DELAY_MS - 1);
+    expect(onRetry).toHaveBeenCalledTimes(0);
+    await advance(1);
+    expect(onRetry).toHaveBeenCalledTimes(1);
+
+    // Attempt 2 after a further 2s.
+    await advance(RETRY_BASE_DELAY_MS * 2 - 1);
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    await advance(1);
+    expect(onRetry).toHaveBeenCalledTimes(2);
+
+    // Attempt 3 after a further 4s.
+    await advance(RETRY_BASE_DELAY_MS * 4);
+    expect(onRetry).toHaveBeenCalledTimes(MAX_AUTO_RETRIES);
+
+    // Budget spent — no further automatic attempts, ever.
+    await advanceInSlices(30_000);
+    expect(onRetry).toHaveBeenCalledTimes(MAX_AUTO_RETRIES);
+    expect(result.current.attempts).toBe(MAX_AUTO_RETRIES);
+    expect(result.current.hasExhaustedAutoRetries).toBe(true);
+    expect(result.current.secondsUntilNextRetry).toBeNull();
+  });
+
+  it('resends the original content, not a rewritten body', async () => {
+    const onRetry = vi.fn();
+    renderHook(() =>
+      useMessageRetry({
+        messageId: 'm1',
+        content: 'the original text',
+        isFailed: true,
+        onRetry,
+      }),
+    );
+
+    await advance(RETRY_BASE_DELAY_MS);
+    expect(onRetry).toHaveBeenCalledWith('m1', 'the original text');
+  });
+
+  it('does not retry while the message is not failed', async () => {
+    const onRetry = vi.fn();
+    renderHook(() =>
+      useMessageRetry({
+        messageId: 'm1',
+        content: 'hi',
+        isFailed: false,
+        onRetry,
+      }),
+    );
+
+    await advanceInSlices(10_000);
+    expect(onRetry).not.toHaveBeenCalled();
+  });
+
+  it('does nothing without a handler', async () => {
+    const { result } = renderHook(() =>
+      useMessageRetry({ messageId: 'm1', content: 'hi', isFailed: true }),
+    );
+
+    await advanceInSlices(10_000);
+    expect(result.current.attempts).toBe(0);
+    expect(result.current.isRetrying).toBe(false);
+  });
+
+  it('exposes a countdown to the next automatic attempt', async () => {
+    const onRetry = vi.fn();
+    const { result } = renderHook(() =>
+      useMessageRetry({
+        messageId: 'm1',
+        content: 'hi',
+        isFailed: true,
+        onRetry,
+      }),
+    );
+
+    await advance(0);
+    expect(result.current.secondsUntilNextRetry).toBe(1);
+
+    await advance(500);
+    expect(result.current.secondsUntilNextRetry).toBe(1);
+  });
+
+  it('retries immediately on demand without spending the automatic budget', async () => {
+    const onRetry = vi.fn();
+    const { result } = renderHook(() =>
+      useMessageRetry({
+        messageId: 'm1',
+        content: 'hi',
+        isFailed: true,
+        onRetry,
+      }),
+    );
+
+    act(() => result.current.retryNow());
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(result.current.attempts).toBe(0);
+
+    // The three automatic attempts still follow.
+    await advanceInSlices(30_000);
+    expect(onRetry).toHaveBeenCalledTimes(1 + MAX_AUTO_RETRIES);
+  });
+
+  it('reports in-flight state and recovers when an async resend rejects', async () => {
+    let reject: (reason: Error) => void = () => {};
+    const onRetry = vi.fn(
+      () =>
+        new Promise<void>((_resolve, rejectFn) => {
+          reject = rejectFn;
+        }),
+    );
+
+    const { result } = renderHook(() =>
+      useMessageRetry({
+        messageId: 'm1',
+        content: 'hi',
+        isFailed: true,
+        onRetry,
+      }),
+    );
+
+    act(() => result.current.retryNow());
+    expect(result.current.isRetrying).toBe(true);
+
+    await act(async () => {
+      reject(new Error('still offline'));
+      await Promise.resolve();
+    });
+    expect(result.current.isRetrying).toBe(false);
+
+    // Failure did not stall the schedule.
+    await advance(RETRY_BASE_DELAY_MS);
+    expect(onRetry).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not stall when the handler throws synchronously', async () => {
+    const onRetry = vi.fn(() => {
+      throw new Error('boom');
+    });
+
+    const { result } = renderHook(() =>
+      useMessageRetry({
+        messageId: 'm1',
+        content: 'hi',
+        isFailed: true,
+        onRetry,
+      }),
+    );
+
+    expect(() => act(() => result.current.retryNow())).not.toThrow();
+    expect(result.current.isRetrying).toBe(false);
+  });
+
+  it('resets the budget once the message stops being failed', async () => {
+    const onRetry = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ isFailed }: { isFailed: boolean }) =>
+        useMessageRetry({
+          messageId: 'm1',
+          content: 'hi',
+          isFailed,
+          onRetry,
+        }),
+      { initialProps: { isFailed: true } },
+    );
+
+    await advanceInSlices(30_000);
+    expect(result.current.attempts).toBe(MAX_AUTO_RETRIES);
+
+    rerender({ isFailed: false });
+    expect(result.current.attempts).toBe(0);
+    expect(result.current.hasExhaustedAutoRetries).toBe(false);
+
+    // A later failure of the same message gets a fresh set of attempts.
+    onRetry.mockClear();
+    rerender({ isFailed: true });
+    await advanceInSlices(30_000);
+    expect(onRetry).toHaveBeenCalledTimes(MAX_AUTO_RETRIES);
+  });
+
+  it('cancels pending retries on unmount', async () => {
+    const onRetry = vi.fn();
+    const { unmount } = renderHook(() =>
+      useMessageRetry({
+        messageId: 'm1',
+        content: 'hi',
+        isFailed: true,
+        onRetry,
+      }),
+    );
+
+    unmount();
+    await advanceInSlices(10_000);
+    expect(onRetry).not.toHaveBeenCalled();
+  });
+});

--- a/Dechat/dex_with_fiat_frontend/src/hooks/useAccessibleModal.ts
+++ b/Dechat/dex_with_fiat_frontend/src/hooks/useAccessibleModal.ts
@@ -1,4 +1,25 @@
-import { useEffect, RefObject } from 'react';
+'use client';
+
+import { useEffect, useRef, RefObject } from 'react';
+import { toastStore } from '@/lib/toastStore';
+
+/**
+ * User-facing message shown when the focus trap cannot take hold, so keyboard
+ * and screen-reader users are told what happened instead of silently losing
+ * their place. Exported so tests and callers can assert on it.
+ */
+export const FOCUS_TRAP_FAILURE_MESSAGE =
+  'This dialog could not capture keyboard focus. Press Tab to reach its controls, or Escape to close it.';
+
+/** Options for {@link useAccessibleModal}. */
+export interface AccessibleModalOptions {
+  /**
+   * Called when the modal cannot be made keyboard-accessible (its container
+   * never mounted, or it contains nothing focusable). Defaults to raising an
+   * error toast carrying {@link FOCUS_TRAP_FAILURE_MESSAGE}.
+   */
+  onError?: (message: string) => void;
+}
 
 function getFocusable(container: HTMLElement): HTMLElement[] {
   const selector =
@@ -8,34 +29,146 @@ function getFocusable(container: HTMLElement): HTMLElement[] {
   );
 }
 
+// ── Body scroll lock ──────────────────────────────────────────────────────
+//
+// The lock is reference-counted at module scope rather than snapshotted per
+// effect. A per-effect snapshot is unsafe because the value it reads back may
+// have been written by *another* live modal (or by an earlier run of the same
+// effect), in which case the last cleanup to run restores `'hidden'` and leaves
+// the page permanently unscrollable. Only the first acquire records the real
+// pre-modal value, and only the last release restores it.
+
+let scrollLockCount = 0;
+let scrollLockPreviousOverflow = '';
+
+function acquireScrollLock(): void {
+  if (scrollLockCount === 0) {
+    scrollLockPreviousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+  }
+  scrollLockCount += 1;
+}
+
+function releaseScrollLock(): void {
+  if (scrollLockCount === 0) {
+    return;
+  }
+  scrollLockCount -= 1;
+  if (scrollLockCount === 0) {
+    document.body.style.overflow = scrollLockPreviousOverflow;
+    scrollLockPreviousOverflow = '';
+  }
+}
+
+/**
+ * Trap focus inside an open modal, lock background scrolling, close on
+ * `Escape`, and hand focus back to whatever opened it.
+ *
+ * ## Lifecycle
+ *
+ * All of the above is keyed on `isOpen` alone. `onClose` is read through a ref
+ * so an unstable callback (the common `onClose={() => setOpen(false)}` case)
+ * cannot tear the effect down and set it up again mid-interaction — a re-setup
+ * would re-snapshot the scroll lock, yank focus back to the first control, and
+ * bounce focus through the trigger on the way past.
+ *
+ * ## Error paths
+ *
+ * If the container never mounts, or holds nothing focusable and cannot itself
+ * receive focus, the trap cannot work. Rather than failing silently, that is
+ * reported through {@link AccessibleModalOptions.onError} (an error toast by
+ * default) so the user is told the dialog is not keyboard-navigable.
+ *
+ * @param isOpen - Whether the modal is currently open.
+ * @param containerRef - Ref to the modal's root element.
+ * @param onClose - Invoked when the user presses `Escape`. May change identity
+ *   between renders; the latest value is always used.
+ * @param options - See {@link AccessibleModalOptions}.
+ */
 export function useAccessibleModal(
   isOpen: boolean,
   containerRef: RefObject<HTMLElement | null>,
   onClose: () => void,
+  options?: AccessibleModalOptions,
 ) {
+  // Keep the latest callbacks reachable from the effect without listing them as
+  // dependencies — that is what makes the effect run once per open/close.
+  const onCloseRef = useRef(onClose);
+  const onErrorRef = useRef(options?.onError);
+
+  useEffect(() => {
+    onCloseRef.current = onClose;
+    onErrorRef.current = options?.onError;
+  });
+
   useEffect(() => {
     if (!isOpen) {
       return;
     }
 
     const previousActive = document.activeElement as HTMLElement | null;
-    const originalOverflow = document.body.style.overflow;
-    document.body.style.overflow = 'hidden';
+    acquireScrollLock();
 
-    const container = containerRef.current;
-    if (container) {
+    let disposed = false;
+    let retryFrame: number | null = null;
+    let errorReported = false;
+
+    const reportError = () => {
+      if (errorReported) {
+        return;
+      }
+      errorReported = true;
+      const handler = onErrorRef.current;
+      if (handler) {
+        handler(FOCUS_TRAP_FAILURE_MESSAGE);
+        return;
+      }
+      toastStore.addToast({
+        message: FOCUS_TRAP_FAILURE_MESSAGE,
+        severity: 'error',
+      });
+    };
+
+    const applyInitialFocus = (isRetry: boolean) => {
+      if (disposed) {
+        return;
+      }
+
+      const container = containerRef.current;
+      if (!container) {
+        // The container can legitimately mount a frame late (animated sheets).
+        // Give it exactly one frame before declaring the trap unusable.
+        if (isRetry) {
+          reportError();
+          return;
+        }
+        retryFrame = requestAnimationFrame(() => {
+          retryFrame = null;
+          applyInitialFocus(true);
+        });
+        return;
+      }
+
       const focusable = getFocusable(container);
       if (focusable.length > 0) {
         focusable[0].focus();
-      } else {
-        container.focus();
+        return;
       }
-    }
+
+      container.focus();
+      if (document.activeElement !== container) {
+        // Nothing to focus and the container itself refused focus (no
+        // tabindex), so keyboard users have no way into the dialog.
+        reportError();
+      }
+    };
+
+    applyInitialFocus(false);
 
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
         event.preventDefault();
-        onClose();
+        onCloseRef.current();
         return;
       }
 
@@ -46,6 +179,7 @@ export function useAccessibleModal(
       const focusable = getFocusable(containerRef.current);
       if (focusable.length === 0) {
         event.preventDefault();
+        reportError();
         return;
       }
 
@@ -65,9 +199,25 @@ export function useAccessibleModal(
     document.addEventListener('keydown', onKeyDown);
 
     return () => {
+      disposed = true;
+      if (retryFrame !== null) {
+        cancelAnimationFrame(retryFrame);
+      }
       document.removeEventListener('keydown', onKeyDown);
-      document.body.style.overflow = originalOverflow;
-      previousActive?.focus();
+      releaseScrollLock();
+
+      // Only hand focus back if the opener is still in the document. Calling
+      // focus() on a detached node is a silent no-op that would strand focus
+      // on the closing modal's own controls, so blur out to the document
+      // instead and keep the fallback predictable.
+      if (previousActive && previousActive.isConnected) {
+        previousActive.focus();
+      } else {
+        const active = document.activeElement;
+        if (active instanceof HTMLElement) {
+          active.blur();
+        }
+      }
     };
-  }, [containerRef, isOpen, onClose]);
+  }, [containerRef, isOpen]);
 }

--- a/Dechat/dex_with_fiat_frontend/src/hooks/useMessageRetry.ts
+++ b/Dechat/dex_with_fiat_frontend/src/hooks/useMessageRetry.ts
@@ -1,0 +1,224 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/** Automatic attempts made before the user has to press Retry themselves. */
+export const MAX_AUTO_RETRIES = 3;
+
+/** Delay before the first automatic retry. Doubles on each subsequent attempt. */
+export const RETRY_BASE_DELAY_MS = 1000;
+
+/**
+ * Delay before automatic retry number `attempt`.
+ *
+ * Plain exponential backoff — 1s, 2s, 4s for attempts 1 through
+ * {@link MAX_AUTO_RETRIES}. Deliberately jitter-free so the countdown shown in
+ * the UI matches the wait exactly.
+ *
+ * @param attempt - One-based attempt number.
+ * @returns Delay in milliseconds. Attempts below 1 are clamped to the base delay.
+ */
+export function getRetryDelayMs(attempt: number): number {
+  const normalized = Math.max(1, Math.floor(attempt));
+  return RETRY_BASE_DELAY_MS * 2 ** (normalized - 1);
+}
+
+/** Narrow a handler's return value without assuming it is a real `Promise`. */
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as { then?: unknown }).then === 'function'
+  );
+}
+
+/** Arguments for {@link useMessageRetry}. */
+export interface UseMessageRetryArgs {
+  /** Id of the message being resent. */
+  messageId: string;
+  /**
+   * Content to resend — the *original* text the user typed, so a retry never
+   * loses or mangles the message.
+   */
+  content: string;
+  /**
+   * `true` while the message is in its failed state. Flipping this back to
+   * `false` (the resend succeeded) cancels any pending automatic retry and
+   * resets the attempt counter.
+   */
+  isFailed: boolean;
+  /** Resend handler. Rejections are treated as another failure. */
+  onRetry?: (messageId: string, content: string) => void | Promise<void>;
+}
+
+/** State returned by {@link useMessageRetry}. */
+export interface UseMessageRetryState {
+  /** Automatic attempts consumed so far, 0…{@link MAX_AUTO_RETRIES}. */
+  attempts: number;
+  /** `true` while a resend is in flight. */
+  isRetrying: boolean;
+  /**
+   * Seconds remaining until the next automatic retry, or `null` when none is
+   * scheduled (no handler, retries exhausted, or a resend is in flight).
+   */
+  secondsUntilNextRetry: number | null;
+  /** `true` once the automatic budget is spent — only manual retries remain. */
+  hasExhaustedAutoRetries: boolean;
+  /** Resend immediately, cancelling any scheduled automatic attempt. */
+  retryNow: () => void;
+}
+
+/**
+ * Drive automatic resends of a failed chat message, with a manual escape hatch.
+ *
+ * While `isFailed` holds, up to {@link MAX_AUTO_RETRIES} resends are scheduled
+ * on an exponential backoff ({@link getRetryDelayMs}). The countdown to the next
+ * attempt is exposed so the UI can show it. Once the budget is spent the hook
+ * goes quiet and {@link UseMessageRetryState.retryNow} — the Retry button — is
+ * the only way forward.
+ *
+ * Manual retries do not consume the automatic budget: pressing Retry cancels the
+ * pending timer, resends at once, and lets the remaining automatic attempts
+ * resume if it fails again.
+ *
+ * @example
+ * ```tsx
+ * const retry = useMessageRetry({
+ *   messageId: message.id,
+ *   content: message.originalPayload?.content ?? message.content,
+ *   isFailed: Boolean(message.error),
+ *   onRetry,
+ * });
+ *
+ * <button onClick={retry.retryNow} disabled={retry.isRetrying}>
+ *   {retry.secondsUntilNextRetry !== null
+ *     ? `Retrying in ${retry.secondsUntilNextRetry}s`
+ *     : 'Retry'}
+ * </button>
+ * ```
+ */
+export function useMessageRetry({
+  messageId,
+  content,
+  isFailed,
+  onRetry,
+}: UseMessageRetryArgs): UseMessageRetryState {
+  const [attempts, setAttempts] = useState(0);
+  const [isRetrying, setIsRetrying] = useState(false);
+  const [nextRetryAt, setNextRetryAt] = useState<number | null>(null);
+  const [secondsUntilNextRetry, setSecondsUntilNextRetry] = useState<
+    number | null
+  >(null);
+
+  // Read through refs so a new inline `onRetry` (or edited content) never
+  // restarts the backoff schedule mid-wait.
+  const onRetryRef = useRef(onRetry);
+  const contentRef = useRef(content);
+  const messageIdRef = useRef(messageId);
+  const isMountedRef = useRef(true);
+
+  useEffect(() => {
+    onRetryRef.current = onRetry;
+    contentRef.current = content;
+    messageIdRef.current = messageId;
+  });
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  const runRetry = useCallback(() => {
+    const handler = onRetryRef.current;
+    if (!handler) {
+      return;
+    }
+
+    setNextRetryAt(null);
+    setSecondsUntilNextRetry(null);
+    setIsRetrying(true);
+
+    const finish = () => {
+      if (isMountedRef.current) {
+        setIsRetrying(false);
+      }
+    };
+
+    try {
+      const result: unknown = handler(messageIdRef.current, contentRef.current);
+      if (isPromiseLike(result)) {
+        // A rejected resend is just another failure: clear the in-flight flag
+        // so the next backoff step (or the manual button) can take over.
+        result.then(finish, finish);
+        return;
+      }
+    } catch {
+      // Synchronous throw — same handling as a rejection.
+    }
+    finish();
+  }, []);
+
+  const retryNow = useCallback(() => {
+    if (isRetrying) {
+      return;
+    }
+    runRetry();
+  }, [isRetrying, runRetry]);
+
+  // Recovery: a message that is no longer failed gets a fresh budget, so a
+  // later failure of the same message retries from the start.
+  useEffect(() => {
+    if (!isFailed) {
+      setAttempts(0);
+      setNextRetryAt(null);
+      setSecondsUntilNextRetry(null);
+    }
+  }, [isFailed]);
+
+  // Schedule the next automatic attempt.
+  useEffect(() => {
+    if (!isFailed || !onRetryRef.current || isRetrying) {
+      return;
+    }
+    if (attempts >= MAX_AUTO_RETRIES) {
+      return;
+    }
+
+    const delay = getRetryDelayMs(attempts + 1);
+    setNextRetryAt(Date.now() + delay);
+
+    const timer = setTimeout(() => {
+      setAttempts((previous) => previous + 1);
+      runRetry();
+    }, delay);
+
+    return () => clearTimeout(timer);
+  }, [attempts, isFailed, isRetrying, runRetry]);
+
+  // Tick the countdown that the UI renders.
+  useEffect(() => {
+    if (nextRetryAt === null) {
+      setSecondsUntilNextRetry(null);
+      return;
+    }
+
+    const tick = () => {
+      const remaining = Math.max(0, nextRetryAt - Date.now());
+      setSecondsUntilNextRetry(Math.ceil(remaining / 1000));
+    };
+
+    tick();
+    const interval = setInterval(tick, 250);
+    return () => clearInterval(interval);
+  }, [nextRetryAt]);
+
+  return {
+    attempts,
+    isRetrying,
+    secondsUntilNextRetry,
+    hasExhaustedAutoRetries: attempts >= MAX_AUTO_RETRIES,
+    retryNow,
+  };
+}

--- a/Dechat/dex_with_fiat_frontend/src/lib/aiAssistant.test.ts
+++ b/Dechat/dex_with_fiat_frontend/src/lib/aiAssistant.test.ts
@@ -240,8 +240,7 @@ describe('AIAssistant abort signal support', () => {
 
     expect(toastAddMock).toHaveBeenCalled();
     consoleErrorSpy.mockRestore();
-
-
+  });
 });
 
 /**
@@ -489,7 +488,11 @@ describe('aiAssistant request retry with exponential backoff', () => {
         }),
     );
 
-    const result = await assistant.analyzeUserMessage('hello');
+    // Fake timers are installed, so the backoff sleep between attempts only
+    // resolves once the pending timers are drained.
+    const promise = assistant.analyzeUserMessage('hello');
+    await vi.runAllTimersAsync();
+    const result = await promise;
 
     expect(result.intent).toBe('query');
     expect(fetch).toHaveBeenCalledTimes(2);
@@ -503,7 +506,9 @@ describe('aiAssistant request retry with exponential backoff', () => {
 
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-    const result = await assistant.analyzeUserMessage('hello');
+    const promise = assistant.analyzeUserMessage('hello');
+    await vi.runAllTimersAsync();
+    const result = await promise;
 
     expect(result.intent).toBe('unknown');
     expect(fetch).toHaveBeenCalledTimes(4); // initial + 3 retries
@@ -582,7 +587,9 @@ describe('aiAssistant request retry with exponential backoff', () => {
         }),
     );
 
-    const result = await assistant.generateFollowUpQuestion('query', ['name']);
+    const promise = assistant.generateFollowUpQuestion('query', ['name']);
+    await vi.runAllTimersAsync();
+    const result = await promise;
 
     expect(result).toBe('What is your name?');
     expect(fetch).toHaveBeenCalledTimes(2);

--- a/Dechat/dex_with_fiat_frontend/src/lib/apiSchemas.test.ts
+++ b/Dechat/dex_with_fiat_frontend/src/lib/apiSchemas.test.ts
@@ -26,8 +26,11 @@ describe('apiSchemas - Request Retry with Exponential Backoff', () => {
         .mockResolvedValue('success');
 
       const promise = withRetry(fn);
-      
-      // First attempt fails
+
+      // Fake timers are installed, so the backoff sleep between attempts only
+      // resolves once the pending timers are drained.
+      await vi.runAllTimersAsync();
+
       await expect(promise).resolves.toBe('success');
       expect(fn).toHaveBeenCalledTimes(2);
     });
@@ -36,7 +39,15 @@ describe('apiSchemas - Request Retry with Exponential Backoff', () => {
       const fn = vi.fn().mockRejectedValue(new TypeError('Failed to fetch'));
       const config: RetryConfig = { maxRetries: 2 };
 
-      await expect(withRetry(fn, config)).rejects.toThrow('Failed to fetch');
+      // Attach the rejection handler before draining timers, otherwise the
+      // rejection lands while nothing is listening and surfaces as an
+      // unhandled rejection.
+      const assertion = expect(withRetry(fn, config)).rejects.toThrow(
+        'Failed to fetch',
+      );
+      await vi.runAllTimersAsync();
+      await assertion;
+
       expect(fn).toHaveBeenCalledTimes(3); // initial + 2 retries
     });
 
@@ -46,7 +57,6 @@ describe('apiSchemas - Request Retry with Exponential Backoff', () => {
         .mockRejectedValueOnce(new TypeError('Failed to fetch'))
         .mockResolvedValue('success');
 
-      const startTime = Date.now();
       const promise = withRetry(fn, { initialDelayMs: 100, maxRetries: 2 });
       
       // Advance timers for first retry
@@ -70,8 +80,10 @@ describe('apiSchemas - Request Retry with Exponential Backoff', () => {
 
     it('should not retry on AbortError', async () => {
       const fn = vi.fn().mockRejectedValue(new DOMException('Aborted', 'AbortError'));
-      
-      await expect(withRetry(fn)).rejects.toThrow('AbortError');
+
+      await expect(withRetry(fn)).rejects.toThrow(
+        expect.objectContaining({ name: 'AbortError' }),
+      );
       expect(fn).toHaveBeenCalledTimes(1);
     });
 
@@ -85,7 +97,10 @@ describe('apiSchemas - Request Retry with Exponential Backoff', () => {
           error instanceof Error && error.message === 'Custom error'
       };
 
-      await expect(withRetry(fn, config)).resolves.toBe('success');
+      const promise = withRetry(fn, config);
+      await vi.runAllTimersAsync();
+
+      await expect(promise).resolves.toBe('success');
       expect(fn).toHaveBeenCalledTimes(2);
     });
 
@@ -117,17 +132,23 @@ describe('apiSchemas - Request Retry with Exponential Backoff', () => {
     it('should add jitter to avoid thundering herd', async () => {
       const delays: number[] = [];
       const originalSetTimeout = global.setTimeout;
-      
-      global.setTimeout = vi.fn((callback, delay) => {
+
+      const spy: typeof global.setTimeout = ((
+        callback: Parameters<typeof global.setTimeout>[0],
+        delay?: number,
+      ) => {
         delays.push(delay as number);
         return originalSetTimeout(callback, delay);
-      }) as any;
+      }) as typeof global.setTimeout;
+      global.setTimeout = spy;
 
       const fn = vi.fn()
         .mockRejectedValueOnce(new TypeError('Failed to fetch'))
         .mockResolvedValue('success');
 
-      await withRetry(fn, { initialDelayMs: 1000 });
+      const promise = withRetry(fn, { initialDelayMs: 1000 });
+      await vi.runAllTimersAsync();
+      await promise;
 
       // Delay should be close to 1000ms but with jitter (±25%)
       expect(delays[0]).toBeGreaterThan(750);
@@ -154,7 +175,10 @@ describe('apiSchemas - Request Retry with Exponential Backoff', () => {
         .mockResolvedValueOnce({ ok: false, status: 500, statusText: 'Internal Server Error' } as Response)
         .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ data: 'test' }) } as Response);
 
-      const result = await fetchWithRetry('https://api.example.com/test');
+      const promise = fetchWithRetry('https://api.example.com/test');
+      await vi.runAllTimersAsync();
+      const result = await promise;
+
       expect(result.ok).toBe(true);
       expect(fetch).toHaveBeenCalledTimes(2);
     });
@@ -164,7 +188,10 @@ describe('apiSchemas - Request Retry with Exponential Backoff', () => {
         .mockResolvedValueOnce({ ok: false, status: 503, statusText: 'Service Unavailable' } as Response)
         .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ data: 'test' }) } as Response);
 
-      const result = await fetchWithRetry('https://api.example.com/test');
+      const promise = fetchWithRetry('https://api.example.com/test');
+      await vi.runAllTimersAsync();
+      const result = await promise;
+
       expect(result.ok).toBe(true);
       expect(fetch).toHaveBeenCalledTimes(2);
     });
@@ -174,7 +201,10 @@ describe('apiSchemas - Request Retry with Exponential Backoff', () => {
         .mockResolvedValueOnce({ ok: false, status: 429, statusText: 'Too Many Requests' } as Response)
         .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ data: 'test' }) } as Response);
 
-      const result = await fetchWithRetry('https://api.example.com/test');
+      const promise = fetchWithRetry('https://api.example.com/test');
+      await vi.runAllTimersAsync();
+      const result = await promise;
+
       expect(result.ok).toBe(true);
       expect(fetch).toHaveBeenCalledTimes(2);
     });
@@ -226,7 +256,10 @@ describe('apiSchemas - Request Retry with Exponential Backoff', () => {
         retryableStatusCodes: [418],
       };
 
-      const result = await fetchWithRetry('https://api.example.com/test', {}, config);
+      const promise = fetchWithRetry('https://api.example.com/test', {}, config);
+      await vi.runAllTimersAsync();
+      const result = await promise;
+
       expect(result.ok).toBe(true);
       expect(fetch).toHaveBeenCalledTimes(2);
     });
@@ -235,8 +268,13 @@ describe('apiSchemas - Request Retry with Exponential Backoff', () => {
   describe('default configuration', () => {
     it('should use default maxRetries of 3', async () => {
       const fn = vi.fn().mockRejectedValue(new TypeError('Failed to fetch'));
-      
-      await expect(withRetry(fn)).rejects.toThrow('Failed to fetch');
+
+      const assertion = expect(withRetry(fn)).rejects.toThrow(
+        'Failed to fetch',
+      );
+      await vi.runAllTimersAsync();
+      await assertion;
+
       expect(fn).toHaveBeenCalledTimes(4); // initial + 3 retries
     });
 

--- a/Dechat/dex_with_fiat_frontend/src/lib/apiSchemas.ts
+++ b/Dechat/dex_with_fiat_frontend/src/lib/apiSchemas.ts
@@ -31,6 +31,29 @@ export const verifyAccountSchema = z.object({
 export type VerifyAccountInput = z.infer<typeof verifyAccountSchema>;
 
 /**
+ * Error thrown by {@link fetchWithRetry} when the server answers with a
+ * non-OK status.
+ *
+ * Carries the status and the original `Response` as typed fields so
+ * {@link withRetry} can decide whether the status is retryable without
+ * casting. Previously these were stapled onto a plain `Error` through `any`,
+ * which left the status invisible to the retry check.
+ */
+export class HttpResponseError extends Error {
+  /** HTTP status code of the failed response. */
+  readonly status: number;
+  /** The original response, for callers that need headers or a body. */
+  readonly response: Response;
+
+  constructor(response: Response) {
+    super(`HTTP ${response.status}: ${response.statusText}`);
+    this.name = 'HttpResponseError';
+    this.status = response.status;
+    this.response = response;
+  }
+}
+
+/**
  * Retry configuration for API requests with exponential backoff
  */
 export interface RetryConfig {
@@ -126,10 +149,16 @@ export async function withRetry<T>(
     } catch (error) {
       lastError = error;
 
+      // An aborted request must never be retried, whatever the caller's
+      // `retryableErrors` says — the caller asked us to stop.
+      if (error instanceof DOMException && error.name === 'AbortError') {
+        throw error;
+      }
+
       // Check if error is retryable
       const isRetryableError = mergedConfig.retryableErrors(error);
       const isRetryableStatus =
-        error instanceof Response &&
+        (error instanceof HttpResponseError || error instanceof Response) &&
         mergedConfig.retryableStatusCodes.includes(error.status);
 
       if (!isRetryableError && !isRetryableStatus) {
@@ -164,10 +193,7 @@ export async function fetchWithRetry(
     
     if (!response.ok) {
       // Throw error to trigger retry for non-OK responses
-      const error = new Error(`HTTP ${response.status}: ${response.statusText}`);
-      (error as any).status = response.status;
-      (error as any).response = response;
-      throw error;
+      throw new HttpResponseError(response);
     }
     
     return response;

--- a/Dechat/dex_with_fiat_frontend/src/lib/filterTelemetry.ts
+++ b/Dechat/dex_with_fiat_frontend/src/lib/filterTelemetry.ts
@@ -1,34 +1,102 @@
 'use client';
 
+/**
+ * @file Consent-gated telemetry for the transaction-filter UI.
+ *
+ * Filter interactions (chips, keyboard cycling, "clear all") are high-frequency
+ * and purely presentational, so they are kept out of {@link chatTelemetry}'s
+ * `ChatEventName` union rather than widening it. They still ride the same
+ * `chat:telemetry` `CustomEvent` channel, which means every existing listener —
+ * analytics adapters, debug overlays, the consent banner — picks them up with
+ * no extra wiring; listeners that only care about chat events filter on
+ * {@link ChatEvent.name}.
+ *
+ * Nothing here throws and nothing here awaits: emission is fire-and-forget so a
+ * broken analytics adapter can never break a filter click. See
+ * {@link filterTelemetry} for the public surface.
+ */
+
 import { TELEMETRY_SCHEMA_VERSION, getTelemetryConsent, ChatEvent } from './chatTelemetry';
 
+/**
+ * Names of the filter events dispatched on the `chat:telemetry` channel.
+ *
+ * These deliberately do **not** overlap with `ChatEventName`, so a consumer can
+ * tell filter traffic apart from chat traffic by name alone.
+ *
+ * - `filter_toggle` — a single filter value was switched on or off.
+ * - `filter_clear_all` — every category was reset at once.
+ * - `filter_cycle` — a category was advanced to its next value (or wrapped
+ *   round and cleared) via {@link FilterCyclePayload}.
+ * - `filter_shortcut` — a keyboard shortcut was used to drive one of the above.
+ */
 export type FilterEventName =
   | 'filter_toggle'
   | 'filter_clear_all'
   | 'filter_cycle'
   | 'filter_shortcut';
 
+/** Payload for `filter_toggle`, emitted by {@link filterTelemetry.toggle}. */
 export interface FilterTogglePayload {
+  /** Filter category that was touched, e.g. `'status'`, `'asset'`, `'network'`. */
   category: string;
+  /** The individual value within that category, e.g. `'pending'`. */
   value: string;
+  /** `true` when the value was just selected, `false` when it was deselected. */
   enabled: boolean;
 }
 
+/** Payload for `filter_cycle`, emitted by {@link filterTelemetry.cycle}. */
 export interface FilterCyclePayload {
+  /** Filter category being cycled. */
   category: string;
+  /**
+   * Value the category advanced to. Omitted when the cycle wrapped past the
+   * last option and cleared the category instead — i.e. whenever
+   * {@link FilterCyclePayload.isCleared} is `true`.
+   */
   nextValue?: string;
+  /** `true` when cycling wrapped around and reset the category to "no filter". */
   isCleared: boolean;
 }
 
+/** Payload for `filter_shortcut`, emitted by {@link filterTelemetry.shortcut}. */
 export interface FilterShortcutPayload {
+  /** The pressed key, lower-cased, without its `Ctrl`/`Cmd`+`Shift` modifiers. */
   key: string;
+  /** Logical action the shortcut ran, e.g. `'clear_all'`, `'cycle_status'`. */
   action: string;
 }
 
 /**
- * Emit a filter-related telemetry event.
- * Reuses the 'chat:telemetry' event name for centralized collection,
- * but uses distinct names for filtering actions.
+ * Build a {@link ChatEvent} envelope for a filter action and dispatch it on the
+ * shared `chat:telemetry` window channel.
+ *
+ * Reuses the `'chat:telemetry'` event name for centralized collection but keeps
+ * distinct {@link FilterEventName}s for filtering actions, so a single listener
+ * can serve both without the two event families colliding.
+ *
+ * Three guards make this safe to call from any render path:
+ * 1. **Consent** — returns immediately when {@link getTelemetryConsent} is
+ *    `false`, so nothing leaves the page without opt-in.
+ * 2. **SSR** — skips dispatch entirely when `window` is undefined, so calling
+ *    this during server rendering is a no-op rather than a crash.
+ * 3. **Deferred dispatch** — the actual `dispatchEvent` runs inside
+ *    `requestAnimationFrame`, keeping listener work off the click handler's
+ *    critical path (mirrors the same fix in `chatTelemetry`'s emitter).
+ *
+ * @typeParam P - Shape of the event-specific payload.
+ * @param name - Which filter event to emit.
+ * @param payload - Event-specific data; widened to `Record<string, unknown>`
+ *   inside the envelope.
+ * @returns Nothing. Emission is fire-and-forget and completes asynchronously on
+ *   the next animation frame, so a caller cannot observe whether any listener
+ *   ran.
+ * @throws Never. Both the consent/envelope step and the deferred dispatch are
+ *   wrapped in `try/catch`; a throwing listener, a blocked `localStorage`, or a
+ *   `CustomEvent` constructor failure are all swallowed on purpose so telemetry
+ *   can never break the filter UI. The trade-off is that delivery failures are
+ *   silent — do not use this channel for anything the app depends on.
  */
 function emit<P extends object>(
   name: FilterEventName,
@@ -41,7 +109,7 @@ function emit<P extends object>(
         // We cast name as ChatEventName to satisfy the ChatEvent type if needed,
         // or we could define a more generic TelemetryEvent type.
         // For now, let's keep it compatible with existing listeners.
-      name: name as unknown as ChatEvent['name'], 
+      name: name as unknown as ChatEvent['name'],
       version: TELEMETRY_SCHEMA_VERSION,
       timestamp: Date.now(),
       payload: payload as Record<string, unknown>,
@@ -63,19 +131,77 @@ function emit<P extends object>(
   }
 }
 
+/**
+ * Public entry point for recording transaction-filter interactions.
+ *
+ * Each method is a thin, named wrapper over {@link emit}: call the one that
+ * matches the user's intent and pass the matching payload. Every method is
+ * synchronous, returns `void`, never throws, and silently no-ops without
+ * telemetry consent — so call sites need no guards of their own.
+ *
+ * Consumed by `useTransactionFilters`, which calls these alongside the state
+ * updates they describe. Chat-side counterparts live in {@link chatTelemetry}.
+ *
+ * @example
+ * ```ts
+ * // The user selects the "pending" status chip.
+ * filterTelemetry.toggle({ category: 'status', value: 'pending', enabled: true });
+ *
+ * // Ctrl+Shift+1 advances the status category to its next value.
+ * filterTelemetry.cycle({ category: 'status', nextValue: 'completed', isCleared: false });
+ * filterTelemetry.shortcut({ key: '1', action: 'cycle_status' });
+ *
+ * // Cycling past the last option wraps around and clears the category.
+ * filterTelemetry.cycle({ category: 'status', isCleared: true });
+ *
+ * // Ctrl+Shift+X resets every category.
+ * filterTelemetry.clearAll();
+ * filterTelemetry.shortcut({ key: 'x', action: 'clear_all' });
+ * ```
+ */
 export const filterTelemetry = {
+  /**
+   * Record that one filter value was switched on or off.
+   *
+   * @param payload - Category, value, and the resulting on/off state. Pass the
+   *   state the filter is moving *to*, not the one it came from.
+   */
   toggle(payload: FilterTogglePayload): void {
     emit('filter_toggle', payload);
   },
 
+  /**
+   * Record that every filter category was reset in a single action.
+   *
+   * Carries no payload — the event's existence is the whole signal. Emit it
+   * once per bulk reset, not once per cleared category, so "clear all" stays
+   * distinguishable from a burst of {@link filterTelemetry.toggle} calls.
+   */
   clearAll(): void {
     emit('filter_clear_all', {});
   },
 
+  /**
+   * Record that a category was advanced to its next value, or wrapped past the
+   * end and cleared.
+   *
+   * @param payload - The category, the value it landed on, and whether the
+   *   cycle wrapped. Omit `nextValue` when `isCleared` is `true`.
+   */
   cycle(payload: FilterCyclePayload): void {
     emit('filter_cycle', payload);
   },
 
+  /**
+   * Record that a keyboard shortcut drove a filter action.
+   *
+   * This is additive: shortcuts also emit the event for the action they
+   * performed ({@link filterTelemetry.toggle}, {@link filterTelemetry.cycle},
+   * or {@link filterTelemetry.clearAll}). Emitting both is what lets keyboard
+   * and pointer usage of the same action be compared.
+   *
+   * @param payload - The key pressed and the logical action it triggered.
+   */
   shortcut(payload: FilterShortcutPayload): void {
     emit('filter_shortcut', payload);
   },

--- a/Dechat/dex_with_fiat_frontend/src/locales/en.json
+++ b/Dechat/dex_with_fiat_frontend/src/locales/en.json
@@ -35,7 +35,11 @@
       "convert": "Convert 100 USDC to USD"
     },
     "error_message": "Message failed to send. Please check your connection.",
-    "cancelled_message": "Request cancelled by user."
+    "cancelled_message": "Request cancelled by user.",
+    "resending": "Resending…",
+    "retry_countdown": "Retrying automatically in {seconds}s (attempt {attempt} of {max})",
+    "retry_exhausted": "Automatic retries exhausted after {max} attempts.",
+    "retry_message": "Resend message: {content}"
   },
   "header": {
     "title": "DexFiat · Stellar",

--- a/Dechat/dex_with_fiat_frontend/src/locales/es.json
+++ b/Dechat/dex_with_fiat_frontend/src/locales/es.json
@@ -35,7 +35,11 @@
       "convert": "Convertir 100 USDC a USD"
     },
     "error_message": "Error al enviar el mensaje. Verifique su conexión.",
-    "cancelled_message": "Solicitud cancelada por el usuario."
+    "cancelled_message": "Solicitud cancelada por el usuario.",
+    "resending": "Reenviando…",
+    "retry_countdown": "Reintentando automáticamente en {seconds}s (intento {attempt} de {max})",
+    "retry_exhausted": "Reintentos automáticos agotados tras {max} intentos.",
+    "retry_message": "Reenviar mensaje: {content}"
   },
   "header": {
     "title": "DexFiat · Stellar",

--- a/Dechat/dex_with_fiat_frontend/src/locales/fr.json
+++ b/Dechat/dex_with_fiat_frontend/src/locales/fr.json
@@ -35,7 +35,11 @@
       "convert": "Convertir 100 USDC en USD"
     },
     "error_message": "Échec de l'envoi du message. Vérifiez votre connexion.",
-    "cancelled_message": "Demande annulée par l'utilisateur."
+    "cancelled_message": "Demande annulée par l'utilisateur.",
+    "resending": "Renvoi en cours…",
+    "retry_countdown": "Nouvelle tentative automatique dans {seconds}s (essai {attempt} sur {max})",
+    "retry_exhausted": "Tentatives automatiques épuisées après {max} essais.",
+    "retry_message": "Renvoyer le message : {content}"
   },
   "header": {
     "title": "DexFiat · Stellar",

--- a/Dechat/stellar-contracts/src/lib.rs
+++ b/Dechat/stellar-contracts/src/lib.rs
@@ -204,6 +204,9 @@ pub struct UserDailyDeposit {
     pub window_start: u32,
 }
 
+/// A depositor's escrowed position: the persistent successor to the evictable
+/// [`Receipt`], written by [`FiatBridge::migrate_escrow`] and read by
+/// [`FiatBridge::get_escrow_record`]. `amount` is in the token's smallest unit.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct EscrowRecord {
@@ -3237,6 +3240,72 @@ impl FiatBridge {
         Ok(migrated_count)
     }
 
+    /// Look up a single migrated escrow position by its sequential id.
+    ///
+    /// This is the read side of the receipt→escrow migration and the intended
+    /// way for indexers, dashboards and off-chain reconciliation jobs to
+    /// enumerate escrowed balances: ids are dense and start at `0`, so a caller
+    /// can walk `0..get_migration_cursor()` without knowing any receipt hashes.
+    /// It is a plain storage read — no authentication is required and no state
+    /// is mutated, so it is safe to call from a simulation.
+    ///
+    /// An id maps to the position the originating [`Receipt`] occupied in
+    /// `DataKey::ReceiptIndex`, so escrow id `n` always describes the `n`-th
+    /// deposit the bridge ever recorded.
+    ///
+    /// # Parameters
+    ///
+    /// - `id`: zero-based index of the escrow record, in deposit order. Values
+    ///   at or above [`FiatBridge::get_migration_cursor`] have not been migrated yet.
+    ///
+    /// # Returns
+    ///
+    /// - `Some(record)` — the stored [`EscrowRecord`] for `id`.
+    /// - `None` — in three distinct situations, which this function does *not*
+    ///   distinguish between:
+    ///   1. `id` is beyond the migration cursor, so the record has simply not
+    ///      been written yet (call [`FiatBridge::migrate_escrow`] to advance);
+    ///   2. `id` is past the end of the receipt range and will never exist;
+    ///   3. the source receipt had been evicted from `temporary` storage before
+    ///      migration reached it, so that cursor position was skipped and left
+    ///      permanently empty.
+    ///
+    ///   Compare `id` against [`FiatBridge::get_migration_cursor`] and
+    ///   [`FiatBridge::get_escrow_storage_version`] to tell case 1 from cases 2 and 3.
+    ///
+    /// # Errors
+    ///
+    /// None. This function cannot fail: a missing entry is reported as `None`
+    /// rather than an [`Error`], and it neither requires auth nor panics.
+    ///
+    /// # Notes
+    ///
+    /// - Reading does not extend the entry's TTL. A record whose persistent TTL
+    ///   has lapsed reads back as `None`; use the receipt TTL-bumping paths to
+    ///   keep long-lived positions alive.
+    /// - The returned `version` field should be checked against
+    ///   [`ESCROW_STORAGE_VERSION`] before interpreting the payload, so that a
+    ///   future schema bump surfaces as a version mismatch rather than a
+    ///   silently misread record.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// // Two deposits, then a migration large enough to cover both.
+    /// bridge.deposit(&user, &100, &token, &Bytes::new(&env), &0, &0, &None);
+    /// bridge.deposit(&user, &250, &token, &Bytes::new(&env), &0, &0, &None);
+    /// assert_eq!(bridge.migrate_escrow(&10), 2);
+    ///
+    /// // Ids are dense and ordered by deposit, so escrow 1 is the 250 deposit.
+    /// let record = bridge.get_escrow_record(&1).expect("migrated");
+    /// assert_eq!(record.amount, 250);
+    /// assert_eq!(record.depositor, user);
+    /// assert_eq!(record.version, ESCROW_STORAGE_VERSION);
+    /// assert!(record.migrated);
+    ///
+    /// // Nothing was ever deposited at index 2.
+    /// assert!(bridge.get_escrow_record(&2).is_none());
+    /// ```
     pub fn get_escrow_record(env: Env, id: u64) -> Option<EscrowRecord> {
         env.storage().persistent().get(&DataKey::EscrowRecord(id))
     }


### PR DESCRIPTION
#1239 — get_escrow_record docs ([lib.rs:3243](vscode-webview://1rrao8qgg4jvfrncr1ro6ujam5vc826kh09pfdj65doj0mj19gcl/Dechat/stellar-contracts/src/lib.rs#L3243))
Intent, parameter, all three distinct reasons it returns None and how to distinguish them, the fact it cannot fail or panic, TTL/version caveats, and a worked deposit→migrate→read example. Cross-refs use FiatBridge::… rather than Self::… — #[contractimpl] copies docs onto generated spec items where Self doesn't resolve, which is why the file's existing Self:: links all emit rustdoc warnings. Mine resolve cleanly.

#1247 — filterTelemetry docs ([filterTelemetry.ts](vscode-webview://1rrao8qgg4jvfrncr1ro6ujam5vc826kh09pfdj65doj0mj19gcl/Dechat/dex_with_fiat_frontend/src/lib/filterTelemetry.ts))
File header, every exported type/field, the emit helper's three guards, and each public method with a worked example. Documented explicitly that it never throws, so delivery failures are silent.

#1210 — useAccessibleModal race ([useAccessibleModal.ts](vscode-webview://1rrao8qgg4jvfrncr1ro6ujam5vc826kh09pfdj65doj0mj19gcl/Dechat/dex_with_fiat_frontend/src/hooks/useAccessibleModal.ts))
Root cause: onClose was an effect dependency and every consumer passes an inline callback, so the whole modal setup tore down and rebuilt on each parent re-render. Fallout: stacked modals clobbered each other's scroll-lock snapshot (page permanently unscrollable), focus was yanked back to the first control mid-form, and restoring focus to an unmounted opener silently stranded it. Fixed with a ref for onClose, a module-scope reference-counted scroll lock, connected-node-checked focus restore, and an error toast when the trap can't take hold. 14 regression tests — 6 fail against the old implementation, all 14 pass after.

#1043 — resend failed message ([useMessageRetry.ts](vscode-webview://1rrao8qgg4jvfrncr1ro6ujam5vc826kh09pfdj65doj0mj19gcl/Dechat/dex_with_fiat_frontend/src/hooks/useMessageRetry.ts), [Message.tsx:250](vscode-webview://1rrao8qgg4jvfrncr1ro6ujam5vc826kh09pfdj65doj0mj19gcl/Dechat/dex_with_fiat_frontend/src/components/Message.tsx#L250))
3 automatic retries at 1s/2s/4s with a live countdown, plus a manual button that doesn't spend the automatic budget. Content comes from originalPayload.content — the text the user actually typed, which survives content being overwritten with the failure placeholder. onRetry now carries it, wired through ChatMessages to StellarChatInterface. 20 new tests; status copy added to en/fr/es.

Two things to flag
The contract WASM size guard drove a scope cut. soroban-sdk embeds doc strings in the on-chain spec, and CI's limit (92160 bytes) had only ~2.2 KB of headroom over main's 89929. I'd initially also documented migrate_escrow, get_migration_cursor, get_escrow_storage_version and EscrowRecord's fields — that came to 94589 bytes, over the limit. I cut back to get_escrow_record plus a one-line EscrowRecord doc, landing at 91173 bytes. Documenting the rest of the escrow area needs MAX_WASM_BYTES raised in .github/workflows/contracts.yml; I didn't touch it, since weakening a size guard as a side effect of a docs PR is your call.

Pre-existing failures on main, not from these changes. pnpm lint and pnpm build fail on apiSchemas.ts, OfflineStatusBanner.tsx, and a parse error in aiAssistant.test.ts; pnpm test:unit fails 19 tests across those same files plus CCIPBridgeModal. I verified identical failures on a stashed baseline. My files are lint-clean, pnpm typecheck passes, next build compiles successfully (it's the lint gate that fails), and contracts pass cargo test (282), cargo clippy -D warnings, and the WASM build.

Push only — I didn't open a PR against leojay-net/Stellar-Dex-Chat. Say the word and I'll open it, or four separate ones if you'd rather they track the issues individually.


Closes #1043 
Closes #1210 
Closes #1239 
Closes #1247 
