### PR TITLE
fix: resolve race conditions and add useToast structured telemetry

### DIFF
--- a/Dechat/dex_with_fiat_frontend/src/hooks/useBeneficiaries.test.ts
+++ b/Dechat/dex_with_fiat_frontend/src/hooks/useBeneficiaries.test.ts
@@ -1,4 +1,4 @@
-import { renderHook, act } from '@testing-library/react';
+import { renderHook, act, waitFor } from '@testing-library/react';
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 import { useBeneficiaries } from './useBeneficiaries';
 
@@ -21,7 +21,7 @@ describe('useBeneficiaries', () => {
   });
 
   afterEach(() => {
-    // No timer cleanup needed for this hook
+    vi.restoreAllMocks();
   });
 
   it('loads beneficiaries from localStorage on mount', () => {
@@ -155,5 +155,66 @@ describe('useBeneficiaries', () => {
     // After effects run, it should have loaded from localStorage
     expect(result.current.beneficiaries).toEqual(mockBeneficiaries);
     expect(result.current.isLoaded).toBe(true);
+  });
+
+  it('does not update state after unmount when API fetch completes', async () => {
+    let resolveFetch!: (value: Response) => void;
+    const fetchPromise = new Promise<Response>((resolve) => {
+      resolveFetch = resolve;
+    });
+
+    vi.spyOn(global, 'fetch').mockReturnValue(fetchPromise);
+
+    const { result, unmount } = renderHook(() =>
+      useBeneficiaries({ fetchFromApi: true, userId: 'user-1' }),
+    );
+
+    expect(result.current.isLoaded).toBe(false);
+
+    // Unmount before the fetch resolves
+    unmount();
+
+    // Resolve the fetch after unmount — should not update state
+    resolveFetch(
+      new Response(JSON.stringify([]), { status: 200 }),
+    );
+
+    await waitFor(() => {
+      // After resolving, state should remain unchanged (not loaded)
+      // since the component was already unmounted
+      expect(result.current.beneficiaries).toHaveLength(0);
+    });
+  });
+
+  it('cancels in-flight request when userId changes', async () => {
+    let resolveFirst!: (value: Response) => void;
+    const firstFetch = new Promise<Response>((resolve) => { resolveFirst = resolve; });
+    let resolveSecond!: (value: Response) => void;
+    const secondFetch = new Promise<Response>((resolve) => { resolveSecond = resolve; });
+
+    const fetchSpy = vi.spyOn(global, 'fetch')
+      .mockReturnValueOnce(firstFetch)
+      .mockReturnValueOnce(secondFetch);
+
+    let userId = 'user-a';
+    const { result, rerender } = renderHook(() =>
+      useBeneficiaries({ fetchFromApi: true, userId }),
+    );
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    userId = 'user-b';
+    rerender();
+
+    // Resolve stale request after userId change — state should reflect second request result
+    const firstData = [{ id: '1', name: 'Old', bankId: 1, bankName: 'B', bankCode: 'B', accountNumber: '1', accountName: 'A', createdAt: 0 }];
+    resolveFirst(new Response(JSON.stringify(firstData), { status: 200 }));
+
+    const secondData = [{ id: '2', name: 'New', bankId: 2, bankName: 'C', bankCode: 'C', accountNumber: '2', accountName: 'B', createdAt: 0 }];
+    resolveSecond(new Response(JSON.stringify(secondData), { status: 200 }));
+
+    await waitFor(() => {
+      expect(result.current.isLoaded).toBe(true);
+    });
   });
 });

--- a/Dechat/dex_with_fiat_frontend/src/hooks/useBeneficiaries.ts
+++ b/Dechat/dex_with_fiat_frontend/src/hooks/useBeneficiaries.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 
 const KEYBOARD_SHORTCUTS = {
   ADD_BENEFICIARY: 'Ctrl+B',
@@ -95,28 +95,31 @@ export function useBeneficiaries(options?: { fetchFromApi?: boolean; userId?: st
   const [beneficiaries, setBeneficiaries] = useState<Beneficiary[]>([]);
   const [isLoaded, setIsLoaded] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState<number>(-1);
-  const [isMounted, setIsMounted] = useState(false);
+  const isMountedRef = useRef(false);
 
   useEffect(() => {
-    setIsMounted(true);
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
   }, []);
 
   // Fetch from API with deduplication if enabled
   useEffect(() => {
-    if (!isMounted || !fetchFromApi || typeof window === 'undefined') return;
+    if (!fetchFromApi || typeof window === 'undefined') return;
 
     let cancelled = false;
 
     (async () => {
       try {
         const data = await fetchBeneficiariesWithDedup(userId);
-        if (!cancelled) {
+        if (!cancelled && isMountedRef.current) {
           setBeneficiaries(Array.isArray(data) ? data : []);
           setIsLoaded(true);
         }
       } catch (error) {
         console.error('Error loading beneficiaries:', error);
-        if (!cancelled) {
+        if (!cancelled && isMountedRef.current) {
           setIsLoaded(true);
         }
       }
@@ -125,11 +128,11 @@ export function useBeneficiaries(options?: { fetchFromApi?: boolean; userId?: st
     return () => {
       cancelled = true;
     };
-  }, [isMounted, fetchFromApi, userId]);
+  }, [fetchFromApi, userId]);
 
   // Load from localStorage if not fetching from API
   useEffect(() => {
-    if (!isMounted || fetchFromApi || typeof window === 'undefined') return;
+    if (fetchFromApi || typeof window === 'undefined') return;
     try {
       const stored = localStorage.getItem(STORAGE_KEY);
       if (stored) {
@@ -140,7 +143,7 @@ export function useBeneficiaries(options?: { fetchFromApi?: boolean; userId?: st
       setBeneficiaries([]);
     }
     setIsLoaded(true);
-  }, [isMounted, fetchFromApi]);
+  }, [fetchFromApi]);
 
   useEffect(() => {
     if (!isLoaded || typeof window === 'undefined') return;

--- a/Dechat/dex_with_fiat_frontend/src/hooks/useBridgeStats.test.ts
+++ b/Dechat/dex_with_fiat_frontend/src/hooks/useBridgeStats.test.ts
@@ -1,0 +1,136 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import useBridgeStats from './useBridgeStats';
+
+vi.mock('@/lib/stellarContract', () => ({
+  getContractBalance: vi.fn(),
+  getBridgeLimit: vi.fn(),
+  getTotalDeposited: vi.fn(),
+  clearCache: vi.fn(),
+}));
+
+import {
+  getContractBalance,
+  getBridgeLimit,
+  getTotalDeposited,
+} from '@/lib/stellarContract';
+
+const mockGetContractBalance = vi.mocked(getContractBalance);
+const mockGetBridgeLimit = vi.mocked(getBridgeLimit);
+const mockGetTotalDeposited = vi.mocked(getTotalDeposited);
+
+describe('useBridgeStats', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockGetContractBalance.mockResolvedValue(100n);
+    mockGetBridgeLimit.mockResolvedValue(1000n);
+    mockGetTotalDeposited.mockResolvedValue(500n);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('fetches stats on mount and sets state', async () => {
+    const { result } = renderHook(() => useBridgeStats());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.balance).toBe(100n);
+    expect(result.current.limit).toBe(1000n);
+    expect(result.current.totalDeposited).toBe(500n);
+    expect(result.current.fetchCount).toBe(1);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('does not update state after unmount', async () => {
+    let resolveBalance!: (v: bigint) => void;
+    mockGetContractBalance.mockReturnValue(
+      new Promise<bigint>((resolve) => { resolveBalance = resolve; }),
+    );
+    mockGetBridgeLimit.mockResolvedValue(1000n);
+    mockGetTotalDeposited.mockResolvedValue(500n);
+
+    const { result, unmount } = renderHook(() => useBridgeStats());
+
+    unmount();
+
+    // Resolve after unmount — should not throw or update state
+    expect(() => { resolveBalance(200n); }).not.toThrow();
+
+    await vi.runAllTimersAsync();
+
+    // State should remain at initial values since component was unmounted
+    expect(result.current.balance).toBeNull();
+  });
+
+  it('discards stale concurrent fetch result when a newer fetch supersedes it', async () => {
+    let resolveFirst!: (v: bigint) => void;
+    let resolveSecond!: (v: bigint) => void;
+
+    mockGetContractBalance
+      .mockReturnValueOnce(new Promise<bigint>((r) => { resolveFirst = r; }))
+      .mockReturnValueOnce(new Promise<bigint>((r) => { resolveSecond = r; }));
+    mockGetBridgeLimit.mockResolvedValue(1000n);
+    mockGetTotalDeposited.mockResolvedValue(500n);
+
+    const { result } = renderHook(() => useBridgeStats());
+
+    // Trigger a second fetch (manual refresh) before the first completes
+    act(() => {
+      void result.current.refetchStats();
+    });
+
+    // Resolve the second (newer) fetch first
+    resolveSecond(999n);
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    // Now resolve the first (stale) fetch — its result should be discarded
+    resolveFirst(111n);
+    await vi.runAllTimersAsync();
+
+    // The newer fetch result (999n) should be preserved
+    expect(result.current.balance).toBe(999n);
+  });
+
+  it('sets error state when fetch fails', async () => {
+    mockGetContractBalance.mockRejectedValue(new Error('Network error'));
+
+    const { result } = renderHook(() => useBridgeStats());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.error).toBe('Network error');
+    expect(result.current.balance).toBeNull();
+  });
+
+  it('dispatches bridge_stats_telemetry events', async () => {
+    const events: CustomEvent[] = [];
+    window.addEventListener('bridge_stats_telemetry', (e) => {
+      events.push(e as CustomEvent);
+    });
+
+    const { unmount } = renderHook(() => useBridgeStats());
+
+    await waitFor(() => {
+      expect(events.some((e) => e.detail?.event === 'bridge_stats_mounted')).toBe(true);
+    });
+
+    await waitFor(() => {
+      expect(events.some((e) => e.detail?.event === 'bridge_stats_fetch_success')).toBe(true);
+    });
+
+    unmount();
+    window.removeEventListener('bridge_stats_telemetry', (e) => {
+      events.push(e as CustomEvent);
+    });
+  });
+});

--- a/Dechat/dex_with_fiat_frontend/src/hooks/useBridgeStats.ts
+++ b/Dechat/dex_with_fiat_frontend/src/hooks/useBridgeStats.ts
@@ -37,6 +37,7 @@ export default function useBridgeStats(): BridgeStats {
   const [fetchCount, setFetchCount] = useState(0);
   const [lastFetchedAt, setLastFetchedAt] = useState<Date | null>(null);
   const isMountedRef = useRef(true);
+  const fetchIdRef = useRef(0);
 
   useEffect(() => {
     isMountedRef.current = true;
@@ -48,6 +49,7 @@ export default function useBridgeStats(): BridgeStats {
 
   const refetchStats = useCallback(async () => {
     if (!isMountedRef.current) return;
+    const fetchId = ++fetchIdRef.current;
     setLoading(true);
     setError(null);
     try {
@@ -56,7 +58,7 @@ export default function useBridgeStats(): BridgeStats {
         getBridgeLimit(),
         getTotalDeposited(),
       ]);
-      if (!isMountedRef.current) return;
+      if (!isMountedRef.current || fetchId !== fetchIdRef.current) return;
       setBalance(b);
       setLimit(l);
       setTotalDeposited(t);
@@ -64,12 +66,12 @@ export default function useBridgeStats(): BridgeStats {
       setLastFetchedAt(new Date());
       dispatchTelemetry('bridge_stats_fetch_success', { balance: b, limit: l });
     } catch (err) {
-      if (!isMountedRef.current) return;
+      if (!isMountedRef.current || fetchId !== fetchIdRef.current) return;
       const msg = err instanceof Error ? err.message : String(err);
       setError(msg);
       dispatchTelemetry('bridge_stats_fetch_error', { error: msg });
     } finally {
-      if (isMountedRef.current) setLoading(false);
+      if (isMountedRef.current && fetchId === fetchIdRef.current) setLoading(false);
     }
   }, []);
 

--- a/Dechat/dex_with_fiat_frontend/src/hooks/useChatPagination.test.ts
+++ b/Dechat/dex_with_fiat_frontend/src/hooks/useChatPagination.test.ts
@@ -57,4 +57,40 @@ describe('useChatPagination', () => {
     expect(result.current.visibleMessages).toHaveLength(10);
     expect(result.current.hasMore).toBe(false);
   });
+
+  it('does not update state after unmount when setTimeout fires', () => {
+    const messages = createMessages(50);
+    const { result, unmount } = renderHook(() => useChatPagination(messages, 20));
+
+    act(() => {
+      result.current.loadMore();
+    });
+
+    // Unmount before the 400ms timer fires
+    unmount();
+
+    // Advancing the timer should not throw or warn about state updates on unmounted component
+    expect(() => {
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+    }).not.toThrow();
+  });
+
+  it('isLoadingMore resets to false after loadMore completes', () => {
+    const messages = createMessages(50);
+    const { result } = renderHook(() => useChatPagination(messages, 20));
+
+    act(() => {
+      result.current.loadMore();
+    });
+
+    expect(result.current.isLoadingMore).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+
+    expect(result.current.isLoadingMore).toBe(false);
+  });
 });

--- a/Dechat/dex_with_fiat_frontend/src/hooks/useChatPagination.ts
+++ b/Dechat/dex_with_fiat_frontend/src/hooks/useChatPagination.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo, useEffect } from 'react';
+import { useState, useCallback, useMemo, useEffect, useRef } from 'react';
 import { ChatMessage } from '@/types';
 import {
   DEFAULT_PAGE_SIZE,
@@ -18,6 +18,7 @@ export const useChatPagination = (
 ) => {
   const [visibleCount, setVisibleCount] = useState(pageSize);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Reset visible count when session changes (if we had a way to detect it)
   // Actually, useChat will manage messages per session, so we just react to allMessages length decreasing
@@ -27,6 +28,16 @@ export const useChatPagination = (
       setVisibleCount(pageSize);
     }
   }, [allMessages.length, pageSize]);
+
+  // Clear pending load-more timer on unmount to prevent state updates on an unmounted component.
+  useEffect(() => {
+    return () => {
+      if (timerRef.current !== null) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, []);
 
   const visibleMessages = useMemo(() => {
     return getVisibleMessages(allMessages, visibleCount);
@@ -40,9 +51,9 @@ export const useChatPagination = (
     if (!hasMore || isLoadingMore) return;
 
     setIsLoadingMore(true);
-    
-    // Simulate a small delay for better UX (optional, but requested "loading guards")
-    setTimeout(() => {
+
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null;
       setVisibleCount((prev: number) => getNextMessageCount(allMessages, prev, pageSize));
       setIsLoadingMore(false);
     }, 400);

--- a/Dechat/dex_with_fiat_frontend/src/hooks/useToast.test.ts
+++ b/Dechat/dex_with_fiat_frontend/src/hooks/useToast.test.ts
@@ -1,0 +1,118 @@
+import { renderHook, act } from '@testing-library/react';
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import { useToast } from './useToast';
+import { toastStore } from '@/lib/toastStore';
+
+describe('useToast telemetry', () => {
+  let dispatchedEvents: CustomEvent[] = [];
+
+  beforeEach(() => {
+    dispatchedEvents = [];
+    toastStore.clearToasts();
+    window.addEventListener('toast_telemetry', (e) => {
+      dispatchedEvents.push(e as CustomEvent);
+    });
+  });
+
+  afterEach(() => {
+    window.removeEventListener('toast_telemetry', (e) => {
+      dispatchedEvents.push(e as CustomEvent);
+    });
+    toastStore.clearToasts();
+  });
+
+  it('dispatches toast_added event when addToast is called', () => {
+    const { result } = renderHook(() => useToast());
+
+    act(() => {
+      result.current.addToast('Hello world', 'success');
+    });
+
+    const addedEvents = dispatchedEvents.filter(
+      (e) => e.detail?.event === 'toast_added',
+    );
+    expect(addedEvents).toHaveLength(1);
+    expect(addedEvents[0].detail.message).toBe('Hello world');
+    expect(addedEvents[0].detail.variant).toBe('success');
+  });
+
+  it('dispatches toast_added with options object form', () => {
+    const { result } = renderHook(() => useToast());
+
+    act(() => {
+      result.current.addToast({ message: 'Options form', variant: 'error' });
+    });
+
+    const addedEvents = dispatchedEvents.filter(
+      (e) => e.detail?.event === 'toast_added',
+    );
+    expect(addedEvents).toHaveLength(1);
+    expect(addedEvents[0].detail.message).toBe('Options form');
+    expect(addedEvents[0].detail.variant).toBe('error');
+  });
+
+  it('dispatches toast_dismissed event when dismissToast is called', () => {
+    const { result } = renderHook(() => useToast());
+
+    let toastId: string | null = null;
+    act(() => {
+      toastId = result.current.addToast('Dismiss me', 'info');
+    });
+
+    act(() => {
+      if (toastId) result.current.dismissToast(toastId);
+    });
+
+    const dismissedEvents = dispatchedEvents.filter(
+      (e) => e.detail?.event === 'toast_dismissed',
+    );
+    expect(dismissedEvents).toHaveLength(1);
+    expect(dismissedEvents[0].detail.id).toBe(toastId);
+  });
+
+  it('dispatches toasts_cleared event when clearToasts is called', () => {
+    const { result } = renderHook(() => useToast());
+
+    act(() => {
+      result.current.addToast('First', 'info');
+      result.current.addToast('Second', 'warning');
+    });
+
+    act(() => {
+      result.current.clearToasts();
+    });
+
+    const clearedEvents = dispatchedEvents.filter(
+      (e) => e.detail?.event === 'toasts_cleared',
+    );
+    expect(clearedEvents).toHaveLength(1);
+    expect(clearedEvents[0].detail.count).toBe(2);
+  });
+
+  it('includes deduped flag when toast is suppressed by deduplication', () => {
+    const { result } = renderHook(() => useToast());
+
+    act(() => {
+      result.current.addToast('Duplicate', 'info');
+      result.current.addToast('Duplicate', 'info');
+    });
+
+    const addedEvents = dispatchedEvents.filter(
+      (e) => e.detail?.event === 'toast_added',
+    );
+    expect(addedEvents).toHaveLength(2);
+    expect(addedEvents[0].detail.deduped).toBe(false);
+    expect(addedEvents[1].detail.deduped).toBe(true);
+  });
+
+  it('returns toasts from the store', () => {
+    const { result } = renderHook(() => useToast());
+
+    act(() => {
+      result.current.addToast('Visible toast', 'success');
+    });
+
+    expect(result.current.toasts).toHaveLength(1);
+    expect(result.current.toasts[0].message).toBe('Visible toast');
+  });
+});

--- a/Dechat/dex_with_fiat_frontend/src/hooks/useToast.ts
+++ b/Dechat/dex_with_fiat_frontend/src/hooks/useToast.ts
@@ -1,7 +1,15 @@
 import { useSyncExternalStore, useCallback } from 'react';
-import { AppToast, toastStore } from '@/lib/toastStore';
+import { AppToast, AddToastOptions, ToastVariant, toastStore } from '@/lib/toastStore';
 
 const EMPTY_ARRAY: AppToast[] = [];
+
+function dispatchToastTelemetry(event: string, detail?: Record<string, unknown>) {
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(
+      new CustomEvent('toast_telemetry', { detail: { event, ...detail } }),
+    );
+  }
+}
 
 export function useToast() {
   const getSnapshot = useCallback(() => toastStore.getSnapshot(), []);
@@ -11,10 +19,40 @@ export function useToast() {
     () => EMPTY_ARRAY,
   );
 
+  const addToast = useCallback(
+    (messageOrOptions: string | AddToastOptions, variantParam?: ToastVariant): string | null => {
+      const id = toastStore.addToast(messageOrOptions, variantParam);
+      const message =
+        typeof messageOrOptions === 'string' ? messageOrOptions : messageOrOptions.message;
+      const variant =
+        typeof messageOrOptions === 'string' ? (variantParam ?? 'info') : (messageOrOptions.variant ?? messageOrOptions.severity ?? 'info');
+      dispatchToastTelemetry('toast_added', { id, message, variant, deduped: id === null });
+      return id;
+    },
+    [],
+  );
+
+  const dismissToast = useCallback(
+    (id: string) => {
+      toastStore.dismissToast(id);
+      dispatchToastTelemetry('toast_dismissed', { id });
+    },
+    [],
+  );
+
+  const clearToasts = useCallback(
+    () => {
+      const count = toastStore.getSnapshot().length;
+      toastStore.clearToasts();
+      dispatchToastTelemetry('toasts_cleared', { count });
+    },
+    [],
+  );
+
   return {
     toasts,
-    addToast: toastStore.addToast.bind(toastStore),
-    dismissToast: toastStore.dismissToast.bind(toastStore),
-    clearToasts: toastStore.clearToasts.bind(toastStore),
+    addToast,
+    dismissToast,
+    clearToasts,
   };
 }


### PR DESCRIPTION
## Summary

- **#1214 — useChatPagination**: Store the `setTimeout` handle in a `useRef` and clear it on unmount. Previously the 400 ms delay callback could fire after the component unmounted, calling `setVisibleCount` / `setIsLoadingMore` on a dead component.

- **#1211 — useBeneficiaries**: Replace the `isMounted` `useState` flag with a `useRef`. The old pattern triggered an extra render cycle and left a window where `setIsMounted(true)` could update state on an already-unmounted component. The new pattern also removes `isMounted` from effect dependency arrays so fetch/localStorage effects start immediately on mount.

- **#1209 — useToast**: Wrap `addToast`, `dismissToast`, and `clearToasts` with `useCallback` functions that dispatch a `CustomEvent('toast_telemetry', { detail: { event, ... } })` after each call, including the toast `id`, `message`, `variant`, dedup flag, and cleared count.

- **#1212 — useBridgeStats**: Add a `fetchIdRef` generation counter. Each `refetchStats` call captures its own fetch ID and discards results after `await` if a newer call has since started, preventing stale concurrent fetches from clobbering the latest state.

## Test plan

- [ ] `useChatPagination` — unmount during 400 ms delay does not throw; `isLoadingMore` resets after timer fires
- [ ] `useBeneficiaries` — state not updated after unmount when API resolves; `cancelled` flag respected on `userId` change
- [ ] `useToast` — `toast_added`, `toast_dismissed`, `toasts_cleared` events with correct detail payloads; dedup flag set to `true` for suppressed toasts
- [ ] `useBridgeStats` — stale concurrent fetch result discarded; error state set correctly; telemetry events dispatched

Closes #1209
Closes #1211
Closes #1212
Closes #1214