### PR TITLE
fix(frontend): resolve stale closure in chatHistory updateCurrentSession

### DIFF
--- a/Dechat/dex_with_fiat_frontend/src/hooks/useChatHistory.test.ts
+++ b/Dechat/dex_with_fiat_frontend/src/hooks/useChatHistory.test.ts
@@ -1,7 +1,7 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { ChatSession } from '@/types';
 
-// Pure utility tests for pin ordering logic (mirrors useChatHistory internals)
+// Pure utility tests for pin ordering logic and stale-closure regression (#1223)
 
 function sortSessions(sessions: ChatSession[]): ChatSession[] {
   return [...sessions].sort((a, b) => {
@@ -104,5 +104,57 @@ describe('Thread pinning ordering', () => {
 
     expect(sorted[0].id).toBe(pinned.id);
     expect(sorted[1].id).toBe(noPinField.id);
+  });
+});
+
+// ── updateCurrentSession stale-closure regression (#1223) ──────────────────
+//
+// Before the fix, updateCurrentSession closed over historyState.currentSessionId
+// for its early-return guard. If currentSessionId changed between renders the
+// stale closure value would cause the guard to use the wrong session ID.
+//
+// The fix moves the guard inside the setHistoryState functional updater so it
+// always reads `prev.currentSessionId` (fresh state), never the closure value.
+// We test the invariant in isolation so the fix is not coupled to the full hook.
+
+describe('updateCurrentSession guard reads fresh state (regression #1223)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // Simulate the functional updater pattern used by the fixed updateCurrentSession.
+  function makeUpdater(messages: { id: string }[]) {
+    return (prev: { currentSessionId: string | null; sessions: { id: string; messages: { id: string }[] }[] }) => {
+      if (!prev.currentSessionId) return prev;
+      const idx = prev.sessions.findIndex((s) => s.id === prev.currentSessionId);
+      if (idx === -1) return prev;
+      const updated = [...prev.sessions];
+      updated[idx] = { ...updated[idx], messages };
+      return { ...prev, sessions: updated };
+    };
+  }
+
+  it('updates the session identified by prev.currentSessionId, not a stale outer value', () => {
+    const sessionA = { id: 'a', messages: [] as { id: string }[] };
+    const sessionB = { id: 'b', messages: [] as { id: string }[] };
+    const newMessages = [{ id: 'msg1' }];
+
+    // Stale outer value would be 'a', but we simulate the state having already
+    // advanced to 'b' before the updater runs.
+    const freshState = { currentSessionId: 'b', sessions: [sessionA, sessionB] };
+
+    const nextState = makeUpdater(newMessages)(freshState);
+
+    expect(nextState.sessions.find((s) => s.id === 'b')?.messages).toEqual(newMessages);
+    expect(nextState.sessions.find((s) => s.id === 'a')?.messages).toEqual([]);
+  });
+
+  it('returns prev unchanged when prev.currentSessionId is null', () => {
+    const session = { id: 'a', messages: [] as { id: string }[] };
+    const state = { currentSessionId: null, sessions: [session] };
+
+    const nextState = makeUpdater([{ id: 'msg1' }])(state);
+
+    expect(nextState).toBe(state);
   });
 });

--- a/Dechat/dex_with_fiat_frontend/src/hooks/useChatHistory.ts
+++ b/Dechat/dex_with_fiat_frontend/src/hooks/useChatHistory.ts
@@ -76,9 +76,11 @@ export const useChatHistory = () => {
 
   const updateCurrentSession = useCallback(
     (messages: ChatMessage[]) => {
-      if (!historyState.currentSessionId) return;
-
       setHistoryState((prev) => {
+        // Guard inside the functional updater so it always reads fresh state,
+        // not the stale closure value of historyState.currentSessionId (#1223).
+        if (!prev.currentSessionId) return prev;
+
         const sessionIndex = prev.sessions.findIndex(
           (s) => s.id === prev.currentSessionId,
         );
@@ -90,7 +92,6 @@ export const useChatHistory = () => {
           lastUpdated: new Date(),
         };
 
-        // Update title if this is the first user message
         const updatedSessionWithTitle =
           ChatHistoryManager.updateSessionTitle(updatedSession);
 
@@ -103,7 +104,7 @@ export const useChatHistory = () => {
         };
       });
     },
-    [historyState.currentSessionId],
+    [],
   );
 
   const loadSession = useCallback(


### PR DESCRIPTION
## Root cause

`updateCurrentSession` in `useChatHistory.ts` read `historyState.currentSessionId` from its **stale closure** for the early-return guard:

```typescript
// BEFORE — stale closure
const updateCurrentSession = useCallback(
  (messages: ChatMessage[]) => {
    if (!historyState.currentSessionId) return;  // captures outer historyState
    setHistoryState((prev) => { … });
  },
  [historyState.currentSessionId],
);
```

If `currentSessionId` changed between renders (e.g. the user opened a different session) before the callback was recreated by React, the guard could read the wrong value — silently skipping the update and causing the previous session's messages to be lost.

## Fix (`src/hooks/useChatHistory.ts`)

Move the guard inside the `setHistoryState` functional updater, where `prev` is always the fresh committed state provided by React — no closure involved:

```typescript
// AFTER — always reads fresh state via prev
const updateCurrentSession = useCallback(
  (messages: ChatMessage[]) => {
    setHistoryState((prev) => {
      if (!prev.currentSessionId) return prev;  // fresh, never stale
      …
    });
  },
  [],  // no dependency on historyState needed
);
```

## Regression tests (`src/hooks/useChatHistory.test.ts`)

Two tests added:
1. Verifies the updater applies messages to the session identified by `prev.currentSessionId`, even when a stale outer value would point to a different session.
2. Verifies the updater returns `prev` unchanged when `prev.currentSessionId` is `null`.

Closes #1223