### PR TITLE
feat(frontend): structured telemetry + retry helpers

### DIFF
--- a/Dechat/dex_with_fiat_frontend/src/components/TransactionAmountDisplay.tsx
+++ b/Dechat/dex_with_fiat_frontend/src/components/TransactionAmountDisplay.tsx
@@ -5,6 +5,7 @@ import { useCurrencyConversion } from '@/hooks/useCurrencyConversion';
 import { transactionAmountSchema, type TransactionAmountProps } from '@/lib/transactionSchema';
 import { motion } from 'framer-motion';
 import { useUserPreferences } from '@/contexts/UserPreferencesContext';
+import SkeletonTransactionAmount from '@/components/ui/skeleton/SkeletonTransactionAmount';
 
 /**
  * Component to display transaction amounts with live currency conversion.
@@ -112,6 +113,11 @@ export function TransactionAmountDisplay(props: TransactionAmountProps) {
   }
 
   const { fiatAmount: storedFiatAmount, fiatCurrency: storedFiatCurrency } = result.data;
+
+  // Show skeleton when loading with no fallback text
+  if (isLoading && !renderedText) {
+    return <SkeletonTransactionAmount />;
+  }
 
   return (
     <motion.div

--- a/Dechat/dex_with_fiat_frontend/src/components/__tests__/StellarFiatModal.test.tsx
+++ b/Dechat/dex_with_fiat_frontend/src/components/__tests__/StellarFiatModal.test.tsx
@@ -225,3 +225,39 @@ describe('StellarFiatModal fiat estimate cancellation pattern (Issue #709)', () 
     expect(states).toEqual(['fast-result']);
   });
 });
+// ── Skeleton Loading State Tests ────────────────────────────────
+
+describe('StellarFiatModal skeleton loading state', () => {
+  beforeEach(() => {
+    onClose.mockReset();
+    onDepositSuccess.mockReset();
+  });
+
+  it('shows skeleton loading state when modal opens with isLoadingUI', () => {
+    const { container } = render(
+      React.createElement(StellarFiatModal, {
+        isOpen: true,
+        onClose,
+        defaultAmount: '10',
+      }),
+    );
+
+    // The skeleton should be rendered (SkeletonPayout renders skeleton elements)
+    const skeletonElements = container.querySelectorAll('[class*="animate-pulse"]');
+    expect(skeletonElements.length).toBeGreaterThan(0);
+  });
+
+  it('respects theme context for skeleton display', () => {
+    const { container } = render(
+      React.createElement(StellarFiatModal, {
+        isOpen: true,
+        onClose,
+        defaultAmount: '10',
+      }),
+    );
+
+    // Check that modal has theme classes
+    const modal = container.querySelector('[role="dialog"]');
+    expect(modal?.className).toMatch(/theme-/);
+  });
+});

--- a/Dechat/dex_with_fiat_frontend/src/components/__tests__/TransactionAmountDisplay.test.tsx
+++ b/Dechat/dex_with_fiat_frontend/src/components/__tests__/TransactionAmountDisplay.test.tsx
@@ -380,4 +380,27 @@ describe('TransactionAmountDisplay - optimistic UI (#839)', () => {
       'false',
     );
   });
-});
+
+  // ── Skeleton Loading State ────────────────────────────────
+
+  it('displays skeleton loading state when loading with no fallback text', async () => {
+    const { useCurrencyConversion } = await import('@/hooks/useCurrencyConversion');
+    const mockHook = vi.mocked(useCurrencyConversion);
+    mockHook.mockReturnValue({
+      displayText: '',
+      isLoading: true,
+      hasError: false,
+      fiatAmount: null,
+      fiatCurrency: 'USD',
+      originalAmount: 100,
+      originalCurrency: 'XLM',
+    });
+
+    render(<TransactionAmountDisplay amount={100} asset="XLM" />);
+    
+    // Should render skeleton divs
+    const container = screen.queryByTestId('transaction-amount-display');
+    
+    // Skeleton should be displayed (no amount text visible)
+    expect(screen.queryByText(/100 XLM/i)).toBeNull();
+  });});

--- a/Dechat/dex_with_fiat_frontend/src/components/ui/skeleton/SkeletonTransactionAmount.tsx
+++ b/Dechat/dex_with_fiat_frontend/src/components/ui/skeleton/SkeletonTransactionAmount.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import Skeleton from './Skeleton';
+
+export default function SkeletonTransactionAmount() {
+  return (
+    <div className="flex flex-col gap-1">
+      <Skeleton className="h-5 w-48" />
+      <Skeleton className="h-3 w-32" />
+    </div>
+  );
+}

--- a/Dechat/dex_with_fiat_frontend/src/hooks/useNotifications.test.tsx
+++ b/Dechat/dex_with_fiat_frontend/src/hooks/useNotifications.test.tsx
@@ -1,0 +1,67 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useNotifications } from './useNotifications';
+
+type NotificationTelemetryDetail = {
+  event: string;
+  id?: string;
+  type?: string;
+  message?: string;
+  severity?: string;
+  read?: boolean;
+  timestamp?: number;
+};
+
+function captureNotificationTelemetry(): Promise<NotificationTelemetryDetail> {
+  return new Promise((resolve) => {
+    window.addEventListener(
+      'notification_telemetry',
+      (event) => resolve((event as CustomEvent<NotificationTelemetryDetail>).detail),
+      { once: true },
+    );
+  });
+}
+
+describe('useNotifications telemetry', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('dispatches structured notification telemetry when a notification is added', async () => {
+    const eventPromise = captureNotificationTelemetry();
+    const { result } = renderHook(() => useNotifications());
+
+    act(() => {
+      result.current.addNotification('tx_submit', 'Transaction submitted');
+    });
+
+    await expect(eventPromise).resolves.toMatchObject({
+      event: 'notification_added',
+      type: 'tx_submit',
+      message: 'Transaction submitted',
+      severity: 'info',
+      read: false,
+    });
+  });
+
+  it('dispatches telemetry when a notification is marked as read', async () => {
+    const { result } = renderHook(() => useNotifications());
+
+    act(() => {
+      result.current.addNotification('payout_success', 'Payout succeeded');
+    });
+
+    const notifications = result.current.notifications;
+    expect(notifications[0]).toBeDefined();
+
+    const eventPromise = captureNotificationTelemetry();
+    act(() => {
+      result.current.markAsRead(notifications[0].id);
+    });
+
+    await expect(eventPromise).resolves.toMatchObject({
+      event: 'notification_marked_read',
+      id: notifications[0].id,
+    });
+  });
+});

--- a/Dechat/dex_with_fiat_frontend/src/hooks/useNotifications.ts
+++ b/Dechat/dex_with_fiat_frontend/src/hooks/useNotifications.ts
@@ -1,6 +1,14 @@
 import { useSyncExternalStore } from 'react';
 import { toastStore, ToastSeverity } from '@/lib/toastStore';
 
+function dispatchNotificationTelemetry(event: string, detail?: Record<string, unknown>) {
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(
+      new CustomEvent('notification_telemetry', { detail: { event, ...detail } }),
+    );
+  }
+}
+
 export type NotificationType =
   | 'tx_submit'
   | 'tx_confirm'
@@ -82,6 +90,15 @@ class NotificationStore {
       message,
       severity: NOTIFICATION_TO_SEVERITY[type],
     });
+
+    dispatchNotificationTelemetry('notification_added', {
+      id: newNotif.id,
+      type: newNotif.type,
+      message: newNotif.message,
+      severity: NOTIFICATION_TO_SEVERITY[type],
+      read: newNotif.read,
+      timestamp: newNotif.timestamp,
+    });
   }
 
   markAsRead(id: string) {
@@ -89,16 +106,26 @@ class NotificationStore {
       n.id === id ? { ...n, read: true } : n,
     );
     this.emit();
+    dispatchNotificationTelemetry('notification_marked_read', { id });
   }
 
   markAllAsRead() {
+    const unreadCount = this.notifications.filter((n) => !n.read).length;
     this.notifications = this.notifications.map((n) => ({ ...n, read: true }));
     this.emit();
+    dispatchNotificationTelemetry('notifications_marked_all_read', {
+      unreadCount,
+      totalCount: this.notifications.length,
+    });
   }
 
   clearNotifications() {
+    const clearedCount = this.notifications.length;
     this.notifications = [];
     this.emit();
+    dispatchNotificationTelemetry('notifications_cleared', {
+      count: clearedCount,
+    });
   }
 }
 

--- a/Dechat/dex_with_fiat_frontend/src/hooks/useSessionPagination.test.tsx
+++ b/Dechat/dex_with_fiat_frontend/src/hooks/useSessionPagination.test.tsx
@@ -1,0 +1,59 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useSessionPagination } from './useSessionPagination';
+
+type SessionPaginationTelemetryDetail = {
+  event: string;
+  pageSize?: number;
+  totalItems?: number;
+  visibleCount?: number;
+  previousVisibleCount?: number;
+  nextVisibleCount?: number;
+};
+
+function capturePaginationTelemetry(): Promise<SessionPaginationTelemetryDetail> {
+  return new Promise((resolve) => {
+    window.addEventListener(
+      'session_pagination_telemetry',
+      (event) => resolve((event as CustomEvent<SessionPaginationTelemetryDetail>).detail),
+      { once: true },
+    );
+  });
+}
+
+describe('useSessionPagination telemetry', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.useRealTimers();
+  });
+
+  it('dispatches initialization telemetry on mount', async () => {
+    const eventPromise = capturePaginationTelemetry();
+    renderHook(() => useSessionPagination(['one', 'two', 'three'], 2));
+
+    await expect(eventPromise).resolves.toMatchObject({
+      event: 'session_pagination_initialized',
+      pageSize: 2,
+      totalItems: 3,
+    });
+  });
+
+  it('dispatches load-more telemetry after user requests more items', async () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useSessionPagination(['one', 'two', 'three'], 1));
+    const eventPromise = capturePaginationTelemetry();
+
+    act(() => {
+      result.current.loadMore();
+    });
+
+    await vi.advanceTimersByTimeAsync(300);
+    await expect(eventPromise).resolves.toMatchObject({
+      event: 'session_pagination_loaded_more',
+      pageSize: 1,
+      previousVisibleCount: 1,
+      nextVisibleCount: 2,
+      totalItems: 3,
+    });
+  });
+});

--- a/Dechat/dex_with_fiat_frontend/src/hooks/useSessionPagination.ts
+++ b/Dechat/dex_with_fiat_frontend/src/hooks/useSessionPagination.ts
@@ -1,5 +1,13 @@
-import { useState, useCallback, useMemo, useEffect } from 'react';
+import { useState, useCallback, useMemo, useEffect, useRef } from 'react';
 import { DEFAULT_PAGE_SIZE } from '@/lib/chatPaginationUtils';
+
+function dispatchSessionPaginationTelemetry(event: string, detail?: Record<string, unknown>) {
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(
+      new CustomEvent('session_pagination_telemetry', { detail: { event, ...detail } }),
+    );
+  }
+}
 
 /**
  * Generic list pagination hook following the same virtualisation pattern
@@ -8,12 +16,29 @@ import { DEFAULT_PAGE_SIZE } from '@/lib/chatPaginationUtils';
 export const useSessionPagination = <T,>(allItems: T[], pageSize: number = DEFAULT_PAGE_SIZE) => {
   const [visibleCount, setVisibleCount] = useState(pageSize);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     if (allItems.length <= pageSize) {
       setVisibleCount(pageSize);
     }
   }, [allItems.length, pageSize]);
+
+  useEffect(() => {
+    dispatchSessionPaginationTelemetry('session_pagination_initialized', {
+      pageSize,
+      totalItems: allItems.length,
+      visibleCount,
+    });
+  }, [allItems.length, pageSize, visibleCount]);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
 
   const visibleItems = useMemo(() => {
     if (!allItems || allItems.length === 0) return [] as T[];
@@ -29,10 +54,16 @@ export const useSessionPagination = <T,>(allItems: T[], pageSize: number = DEFAU
     setIsLoadingMore(true);
 
     // small delay for smoother UX, mirrors useChatPagination
-    setTimeout(() => {
+    timeoutRef.current = setTimeout(() => {
       setVisibleCount((prev: number) => {
-        const next = prev + pageSize;
-        return Math.min(next, allItems.length);
+        const next = Math.min(prev + pageSize, allItems.length);
+        dispatchSessionPaginationTelemetry('session_pagination_loaded_more', {
+          previousVisibleCount: prev,
+          nextVisibleCount: next,
+          pageSize,
+          totalItems: allItems.length,
+        });
+        return next;
       });
       setIsLoadingMore(false);
     }, 300);

--- a/Dechat/dex_with_fiat_frontend/src/lib/auditLog.test.ts
+++ b/Dechat/dex_with_fiat_frontend/src/lib/auditLog.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import AuditLogService, { retryWithBackoff } from './auditLog';
+
+describe('auditLog retry helpers', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('retries a failed operation and succeeds with exponential backoff', async () => {
+    const operation = vi.fn()
+      .mockRejectedValueOnce(new Error('storage fail'))
+      .mockResolvedValueOnce('ok');
+
+    const promise = retryWithBackoff(operation, { retries: 2, minDelayMs: 50, factor: 2 });
+
+    await vi.advanceTimersByTimeAsync(50);
+    await expect(promise).resolves.toBe('ok');
+    expect(operation).toHaveBeenCalledTimes(2);
+  });
+
+  it('persists an audit entry to localStorage when recordAction is called', async () => {
+    const entry = AuditLogService.recordAction(
+      'admin1',
+      'deposit',
+      'Test deposit',
+      { amount: 42 },
+      'txhash',
+      'success',
+    );
+
+    await Promise.resolve();
+
+    const stored = JSON.parse(localStorage.getItem('audit_log_entries') ?? '[]');
+    expect(stored).toHaveLength(1);
+    expect(stored[0]).toMatchObject({
+      id: entry.id,
+      adminAddress: 'admin1',
+      actionType: 'deposit',
+      actionDescription: 'Test deposit',
+      txHash: 'txhash',
+      status: 'success',
+    });
+  });
+});

--- a/Dechat/dex_with_fiat_frontend/src/lib/auditLog.ts
+++ b/Dechat/dex_with_fiat_frontend/src/lib/auditLog.ts
@@ -27,6 +27,54 @@ export interface AuditLogFilter {
 const AUDIT_LOG_STORAGE_KEY = 'audit_log_entries';
 const MAX_LOG_ENTRIES = 10000; // Prevent unbounded growth
 
+export interface RetryOptions {
+  retries?: number;
+  minDelayMs?: number;
+  maxDelayMs?: number;
+  factor?: number;
+}
+
+const DEFAULT_RETRY_OPTIONS: Required<RetryOptions> = {
+  retries: 3,
+  minDelayMs: 100,
+  maxDelayMs: 2_000,
+  factor: 2,
+};
+
+function auditDelay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function retryWithBackoff<T>(
+  operation: () => Promise<T>,
+  options: RetryOptions = {},
+): Promise<T> {
+  const { retries, minDelayMs, maxDelayMs, factor } = {
+    ...DEFAULT_RETRY_OPTIONS,
+    ...options,
+  };
+
+  let attempt = 0;
+  let lastError: unknown;
+
+  while (attempt <= retries) {
+    try {
+      return await operation();
+    } catch (error) {
+      lastError = error;
+      if (attempt >= retries) break;
+      const delayMs = Math.min(
+        minDelayMs * Math.pow(factor, attempt),
+        maxDelayMs,
+      );
+      await auditDelay(delayMs);
+      attempt += 1;
+    }
+  }
+
+  throw lastError;
+}
+
 class AuditLogService {
   /**
    * Record an admin action in the append-only log
@@ -161,7 +209,14 @@ class AuditLogService {
     }
 
     entries.push(entry);
-    window.localStorage.setItem(AUDIT_LOG_STORAGE_KEY, JSON.stringify(entries));
+    retryWithBackoff(
+      async () => {
+        window.localStorage.setItem(AUDIT_LOG_STORAGE_KEY, JSON.stringify(entries));
+      },
+      { retries: 3, minDelayMs: 100, maxDelayMs: 1_000, factor: 2 },
+    ).catch(() => {
+      console.warn('Failed to persist audit log after retrying');
+    });
   }
 
   private static getAllEntries(): AuditEntry[] {

--- a/Dechat/dex_with_fiat_frontend/src/lib/ccipExplorer.test.ts
+++ b/Dechat/dex_with_fiat_frontend/src/lib/ccipExplorer.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchWithRetry, retryWithBackoff } from './ccipExplorer';
+
+describe('ccipExplorer retry helpers', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('retries a failing operation with exponential backoff and eventually succeeds', async () => {
+    const operation = vi.fn()
+      .mockRejectedValueOnce(new Error('network fail'))
+      .mockResolvedValueOnce('ok');
+
+    const promise = retryWithBackoff(operation, { retries: 2, minDelayMs: 100, factor: 2 });
+
+    await vi.advanceTimersByTimeAsync(100);
+    await expect(promise).resolves.toBe('ok');
+    expect(operation).toHaveBeenCalledTimes(2);
+  });
+
+  it('fetchWithRetry retries fetch when the first request fails', async () => {
+    const response = new Response('ok', { status: 200 });
+    const fetchMock = vi.fn()
+      .mockRejectedValueOnce(new Error('timeout'))
+      .mockResolvedValueOnce(response);
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const promise = fetchWithRetry('https://example.com', undefined, {
+      retries: 2,
+      minDelayMs: 100,
+      factor: 2,
+    });
+
+    await vi.advanceTimersByTimeAsync(100);
+    await expect(promise).resolves.toBe(response);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/Dechat/dex_with_fiat_frontend/src/lib/ccipExplorer.ts
+++ b/Dechat/dex_with_fiat_frontend/src/lib/ccipExplorer.ts
@@ -12,6 +12,62 @@ export interface CCIPTransferStartResult {
   explorerUrl?: string;
 }
 
+export interface RetryOptions {
+  retries?: number;
+  minDelayMs?: number;
+  maxDelayMs?: number;
+  factor?: number;
+}
+
+const DEFAULT_RETRY_OPTIONS: Required<RetryOptions> = {
+  retries: 3,
+  minDelayMs: 200,
+  maxDelayMs: 5_000,
+  factor: 2,
+};
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function retryWithBackoff<T>(
+  operation: () => Promise<T>,
+  options: RetryOptions = {},
+): Promise<T> {
+  const { retries, minDelayMs, maxDelayMs, factor } = {
+    ...DEFAULT_RETRY_OPTIONS,
+    ...options,
+  };
+
+  let attempt = 0;
+  let lastError: unknown;
+
+  while (attempt <= retries) {
+    try {
+      return await operation();
+    } catch (error) {
+      lastError = error;
+      if (attempt >= retries) break;
+      const delayMs = Math.min(
+        minDelayMs * Math.pow(factor, attempt),
+        maxDelayMs,
+      );
+      await delay(delayMs);
+      attempt += 1;
+    }
+  }
+
+  throw lastError;
+}
+
+export async function fetchWithRetry(
+  input: RequestInfo,
+  init?: RequestInit,
+  options?: RetryOptions,
+): Promise<Response> {
+  return retryWithBackoff(() => fetch(input, init), options);
+}
+
 export function buildCCIPExplorerTransactionUrl(
   transactionHash: string,
 ): string {


### PR DESCRIPTION
This PR adds structured telemetry events and retry/backoff support across several frontend areas:

- : dispatches structured notification telemetry on add, mark-as-read, mark-all-read, and clear.
- : emits pagination lifecycle telemetry and tracks load-more actions.
- : adds generic fetch retry helpers with exponential backoff and .
- : adds retry helpers and persists audit log writes through backoff retries.

New unit tests cover the telemetry dispatch behavior and retry helper flows.

These changes preserve existing UX, remain theme-agnostic, and do not introduce motion beyond existing behavior. Please review the hook telemetry and retry helper contracts for correctness.