### PR TITLE
fix(frontend): verify-account error handling, webhook error handling, stale closure, EventSource memory leak

### DIFF
--- a/Dechat/dex_with_fiat_frontend/src/app/api/verify-account/route.ts
+++ b/Dechat/dex_with_fiat_frontend/src/app/api/verify-account/route.ts
@@ -23,7 +23,22 @@ export async function POST(request: NextRequest) {
       endpoint: '/api/verify-account',
     });
 
-    const body = await request.json();
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      telemetry.addLog(span.spanId, 'warn', 'Request body is not valid JSON', {
+        endpoint: '/api/verify-account',
+      });
+      telemetry.finishSpan(span.spanId, {
+        success: false,
+        error: 'Invalid JSON body',
+      });
+      return NextResponse.json(
+        { success: false, message: 'Request body must be valid JSON' },
+        { status: 400 },
+      );
+    }
 
     // Validate with Zod
     const validationResult = verifyAccountSchema.safeParse(body);
@@ -75,11 +90,15 @@ export async function POST(request: NextRequest) {
 
     console.error('Account verification error:', error);
 
-    const axiosError = error as {
-      response?: { status?: number; data?: { message?: string } };
-    };
+    // Use a type-safe narrowing helper instead of an unsafe cast.
+    const httpError =
+      error !== null &&
+      typeof error === 'object' &&
+      'response' in error
+        ? (error as { response?: { status?: number; data?: { message?: string } } })
+        : null;
 
-    if (axiosError.response?.status === 422) {
+    if (httpError?.response?.status === 422) {
       telemetry.finishSpan(span.spanId, {
         success: false,
         error: 'Invalid account number or bank code',
@@ -91,8 +110,8 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    if (axiosError.response?.data?.message) {
-      const message = axiosError.response.data.message;
+    if (httpError?.response?.data?.message) {
+      const message = httpError.response.data.message;
       telemetry.finishSpan(span.spanId, {
         success: false,
         error: message,

--- a/Dechat/dex_with_fiat_frontend/src/app/api/webhook/route.ts
+++ b/Dechat/dex_with_fiat_frontend/src/app/api/webhook/route.ts
@@ -90,7 +90,25 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const event = JSON.parse(payload);
+    let event: Record<string, unknown>;
+    try {
+      event = JSON.parse(payload) as Record<string, unknown>;
+    } catch {
+      telemetry.addLog(span.spanId, 'warn', 'Webhook payload is not valid JSON', {
+        endpoint: '/api/webhook',
+        payloadLength: payload.length,
+      });
+      telemetry.finishSpan(span.spanId, {
+        success: false,
+        error: 'Invalid JSON payload',
+        errorType: 'parse_error',
+      });
+      return NextResponse.json(
+        { message: 'Webhook payload must be valid JSON' },
+        { status: 400 },
+      );
+    }
+
     const payloadHash = crypto
       .createHash('sha256')
       .update(payload)

--- a/Dechat/dex_with_fiat_frontend/src/hooks/usePaystackWebhookStatus.ts
+++ b/Dechat/dex_with_fiat_frontend/src/hooks/usePaystackWebhookStatus.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useToast } from '@/hooks/useToast';
 import { getOrCreateClientSessionId } from '@/lib/clientSession';
 import { chatTelemetry } from '@/lib/chatTelemetry';
@@ -15,6 +15,16 @@ interface PaymentStatusStreamEvent {
 
 export function usePaystackWebhookStatus() {
   const { addToast } = useToast();
+
+  // #1218: Hold addToast in a ref so the EventSource onmessage handler always
+  // calls the latest version without needing addToast in the effect dependency
+  // array. Without this, every render that produces a new addToast reference
+  // would tear down and recreate the EventSource, causing a connection churn
+  // and a brief period where both the old and new connections are open.
+  const addToastRef = useRef(addToast);
+  useEffect(() => {
+    addToastRef.current = addToast;
+  }, [addToast]);
 
   useEffect(() => {
     if (typeof window === 'undefined') {
@@ -41,7 +51,7 @@ export function usePaystackWebhookStatus() {
           hasFailureReason: Boolean(payload.failureReason),
         });
         if (payload.status === 'success') {
-          addToast({
+          addToastRef.current({
             message: 'Payment confirmed!',
             severity: 'success',
             durationMs: 5000,
@@ -50,7 +60,7 @@ export function usePaystackWebhookStatus() {
         }
 
         if (payload.status === 'failed' || payload.status === 'reversed') {
-          addToast({
+          addToastRef.current({
             message: 'Payment failed – please retry',
             severity: 'error',
             durationMs: 5000,
@@ -68,5 +78,5 @@ export function usePaystackWebhookStatus() {
     return () => {
       eventSource.close();
     };
-  }, [addToast]);
+  }, []); // EventSource is created once per mount; addToast is accessed via ref
 }

--- a/Dechat/dex_with_fiat_frontend/src/lib/chatTelemetry.ts
+++ b/Dechat/dex_with_fiat_frontend/src/lib/chatTelemetry.ts
@@ -404,6 +404,8 @@ function emit<P extends object>(
   payload: P,
 ): void {
   try {
+    // Early-exit on the synchronous path to avoid building the event object
+    // when consent is clearly absent at call time.
     if (!getTelemetryConsent()) return;
 
     const normalizedPayload =
@@ -418,10 +420,13 @@ function emit<P extends object>(
       payload: normalizedPayload as Record<string, unknown>,
     };
 
-    // Fix rendering overflow: defer event dispatch to prevent blocking renders
+    // Fix rendering overflow: defer event dispatch to prevent blocking renders.
+    // #1226: Re-check consent inside the rAF callback to close the stale-closure
+    // window — consent may have been revoked between emit() and the next frame.
     if (typeof window !== 'undefined') {
       requestAnimationFrame(() => {
         try {
+          if (!getTelemetryConsent()) return;
           window.dispatchEvent(
             new CustomEvent('chat:telemetry', { detail: event }),
           );


### PR DESCRIPTION
## Summary

- **#1230 — verify-account API route error handling**: `request.json()` could throw a `SyntaxError` for malformed request bodies, which fell through to the Axios-error branch and returned 500. Now wrapped in its own try/catch that returns 400 with a clear message. Also replaced the unsafe `error as { response?: ... }` cast with a type-safe narrowing check (`'response' in error`) before accessing HTTP response fields.

- **#1229 — webhook API route error handling**: `JSON.parse(payload)` after signature verification could throw `SyntaxError` for malformed webhook bodies, returning 500. Now wrapped in try/catch that returns 400 and finishes the telemetry span with `errorType: 'parse_error'` before returning. A malformed body from Paystack is a client-side error, not a server error.

- **#1226 — stale closure in chatTelemetry.ts**: The `emit()` function checked `getTelemetryConsent()` synchronously at call time, then dispatched the event one frame later via `requestAnimationFrame`. If consent was revoked between those two moments, the event was still dispatched — violating the user's preference. Fixed by adding a second `getTelemetryConsent()` check inside the rAF callback. The outer check is kept as an optimisation to skip event object construction when consent is clearly absent.

- **#1218 — EventSource memory leak in usePaystackWebhookStatus**: `addToast` was in the `useEffect` dependency array. Every render that produced a new `addToast` reference tore down the `EventSource` and created a new one, causing connection churn and a brief window where two SSE connections were open simultaneously. Fixed by storing `addToast` in a `useRef` (kept current via a separate synchronous effect) and changing the EventSource effect's dependency array to `[]` so it runs exactly once per component mount.

## Test plan

- [ ] POST `/api/verify-account` with non-JSON body → 400 "Request body must be valid JSON"
- [ ] POST `/api/verify-account` with invalid account (Paystack 422) → 400 "Invalid account number or bank code"
- [ ] POST `/api/webhook` with a valid signature but non-JSON body → 400 "Webhook payload must be valid JSON"
- [ ] POST `/api/webhook` with a valid signature and valid JSON → 200 as before
- [ ] Revoke telemetry consent between a chatTelemetry emit call and the next animation frame → `chat:telemetry` event is NOT dispatched on window
- [ ] Mount/unmount `usePaystackWebhookStatus` repeatedly → only one EventSource is open at a time (check Network tab)

Closes #1230
Closes #1229
Closes #1226
Closes #1218