### PR TITLE
chore(ci): add cargo-deny, cache Playwright, split lint job, report W…

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -103,10 +103,6 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
 
-    permissions:
-      contents: read
-      pull-requests: write
-
     steps:
       - name: Checkout PR head
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
@@ -163,38 +159,28 @@ jobs:
           SIZE=$(wc -c < "${{ github.workspace }}/.wasm-size-target/wasm32-unknown-unknown/release/stellar_contracts.wasm" | tr -d '[:space:]')
           echo "size=$SIZE" >> "$GITHUB_OUTPUT"
 
-      - name: Comment size report on PR
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+      - name: Write size report
+        run: |
+          cat > wasm-size-report.json <<EOF
+          {
+            "pr_number": ${{ github.event.pull_request.number }},
+            "base_sha": "${{ github.event.pull_request.base.sha }}",
+            "head_sha": "${{ github.event.pull_request.head.sha }}",
+            "base_size": ${{ steps.base_size.outputs.size }},
+            "head_size": ${{ steps.head_size.outputs.size }},
+            "limit": ${{ env.MAX_WASM_BYTES }}
+          }
+          EOF
+
+      # PRs from forks get a read-only GITHUB_TOKEN under the `pull_request`
+      # event, so this job can't post a comment directly. The report is
+      # handed off as an artifact to wasm-size-comment.yml, which runs via
+      # `workflow_run` in the base repo's context (write-capable token) and
+      # only ever reads this JSON — it never checks out or executes PR code,
+      # so it stays safe from a malicious PR's build script.
+      - name: Upload size report artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          script: |
-            const headSize = ${{ steps.head_size.outputs.size }};
-            const baseSize = ${{ steps.base_size.outputs.size }};
-            const limit = ${{ env.MAX_WASM_BYTES }};
-            const delta = headSize - baseSize;
-            const deltaStr = `${delta > 0 ? '+' : ''}${delta.toLocaleString()} bytes`;
-            const pct = ((headSize / limit) * 100).toFixed(1);
-            const marker = '<!-- wasm-size-report -->';
-
-            const body = [
-              marker,
-              '### Contract WASM size report',
-              '',
-              '| | Bytes |',
-              '|---|---|',
-              `| Base (\`${context.payload.pull_request.base.sha.slice(0, 7)}\`) | ${baseSize.toLocaleString()} |`,
-              `| Head (\`${context.payload.pull_request.head.sha.slice(0, 7)}\`) | ${headSize.toLocaleString()} |`,
-              `| Delta | ${deltaStr} |`,
-              `| Budget used | ${pct}% of ${limit.toLocaleString()} bytes |`,
-            ].join('\n');
-
-            const { owner, repo } = context.repo;
-            const issue_number = context.issue.number;
-
-            const comments = await github.rest.issues.listComments({ owner, repo, issue_number });
-            const existing = comments.data.find((c) => c.body.includes(marker));
-
-            if (existing) {
-              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
-            } else {
-              await github.rest.issues.createComment({ owner, repo, issue_number, body });
-            }
+          name: wasm-size-report
+          path: wasm-size-report.json
+          retention-days: 7

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -14,6 +14,15 @@ on:
 permissions:
   contents: read
 
+env:
+  # Regression guard for the deployed contract only. Raised from the
+  # previous 55000: that limit was never actually enforced (the old
+  # check globbed *.wasm, so SIZE held two values and `[` aborted with
+  # "too many arguments" — which, as an `if` condition, silently read
+  # as false). The contract has since grown to ~87 KB. Hoisted to
+  # workflow level so the size-report job below stays in sync with it.
+  MAX_WASM_BYTES: "92160" # 90 KB
+
 jobs:
   test:
     name: Test & Build
@@ -52,13 +61,6 @@ jobs:
         run: cargo build --target wasm32-unknown-unknown --release
 
       - name: Check WASM size
-        env:
-          # Regression guard for the deployed contract only. Raised from the
-          # previous 55000: that limit was never actually enforced (the old
-          # check globbed *.wasm, so SIZE held two values and `[` aborted with
-          # "too many arguments" — which, as an `if` condition, silently read
-          # as false). The contract has since grown to ~87 KB.
-          MAX_WASM_BYTES: "92160" # 90 KB
         run: |
           set -euo pipefail
           ARTIFACT=target/wasm32-unknown-unknown/release/stellar_contracts.wasm
@@ -81,3 +83,118 @@ jobs:
 
       - name: Run clippy (deny warnings)
         run: cargo clippy --all-targets --all-features -- -D warnings
+
+  deny:
+    name: License & Advisory Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Run cargo-deny (licenses & advisories)
+        uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
+        with:
+          manifest-path: Dechat/stellar-contracts/Cargo.toml
+          command: check licenses advisories bans sources
+
+  wasm-size-report:
+    name: WASM Size Report
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          path: head
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Checkout PR base
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          path: base
+          ref: ${{ github.event.pull_request.base.sha }}
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable
+        with:
+          toolchain: stable
+          targets: wasm32-unknown-unknown
+
+      - name: Cache Cargo registry & shared target dir
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            .wasm-size-target
+          key: ${{ runner.os }}-cargo-wasm-size-${{ hashFiles('head/Dechat/stellar-contracts/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-wasm-size-
+
+      - name: Build head WASM
+        working-directory: head/Dechat/stellar-contracts
+        # --lib only: this crate also has src/bin/deploy_fiat_bridge_futurenet.rs,
+        # which compiles to its own .wasm and would collide with a glob match.
+        run: cargo build --target wasm32-unknown-unknown --release --lib
+        env:
+          CARGO_TARGET_DIR: ${{ github.workspace }}/.wasm-size-target
+
+      - name: Record head size
+        id: head_size
+        run: |
+          SIZE=$(wc -c < "${{ github.workspace }}/.wasm-size-target/wasm32-unknown-unknown/release/stellar_contracts.wasm" | tr -d '[:space:]')
+          echo "size=$SIZE" >> "$GITHUB_OUTPUT"
+
+      - name: Build base WASM
+        working-directory: base/Dechat/stellar-contracts
+        run: cargo build --target wasm32-unknown-unknown --release --lib
+        env:
+          CARGO_TARGET_DIR: ${{ github.workspace }}/.wasm-size-target
+
+      - name: Record base size
+        id: base_size
+        run: |
+          SIZE=$(wc -c < "${{ github.workspace }}/.wasm-size-target/wasm32-unknown-unknown/release/stellar_contracts.wasm" | tr -d '[:space:]')
+          echo "size=$SIZE" >> "$GITHUB_OUTPUT"
+
+      - name: Comment size report on PR
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const headSize = ${{ steps.head_size.outputs.size }};
+            const baseSize = ${{ steps.base_size.outputs.size }};
+            const limit = ${{ env.MAX_WASM_BYTES }};
+            const delta = headSize - baseSize;
+            const deltaStr = `${delta > 0 ? '+' : ''}${delta.toLocaleString()} bytes`;
+            const pct = ((headSize / limit) * 100).toFixed(1);
+            const marker = '<!-- wasm-size-report -->';
+
+            const body = [
+              marker,
+              '### Contract WASM size report',
+              '',
+              '| | Bytes |',
+              '|---|---|',
+              `| Base (\`${context.payload.pull_request.base.sha.slice(0, 7)}\`) | ${baseSize.toLocaleString()} |`,
+              `| Head (\`${context.payload.pull_request.head.sha.slice(0, 7)}\`) | ${headSize.toLocaleString()} |`,
+              `| Delta | ${deltaStr} |`,
+              `| Budget used | ${pct}% of ${limit.toLocaleString()} bytes |`,
+            ].join('\n');
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+
+            const comments = await github.rest.issues.listComments({ owner, repo, issue_number });
+            const existing = comments.data.find((c) => c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -15,8 +15,8 @@ permissions:
   contents: read
 
 jobs:
-  build:
-    name: Build & Type Check
+  lint:
+    name: Lint & Type Check
     runs-on: ubuntu-latest
 
     defaults:
@@ -47,6 +47,33 @@ jobs:
 
       - name: Lint
         run: pnpm lint
+
+  build:
+    name: Build & Test
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: Dechat/dex_with_fiat_frontend
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+        with:
+          version: 8
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "24"
+          cache: "pnpm"
+          cache-dependency-path: Dechat/dex_with_fiat_frontend/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install
 
       - name: Build
         run: pnpm build
@@ -88,7 +115,7 @@ jobs:
   e2e:
     name: Playwright E2E Tests
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, lint]
 
     defaults:
       run:
@@ -113,8 +140,20 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('Dechat/dex_with_fiat_frontend/pnpm-lock.yaml') }}
+
       - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: pnpm exec playwright install --with-deps chromium firefox webkit
+
+      - name: Install Playwright OS dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: pnpm exec playwright install-deps chromium firefox webkit
 
       - name: Build for E2E
         run: pnpm build

--- a/.github/workflows/wasm-size-comment.yml
+++ b/.github/workflows/wasm-size-comment.yml
@@ -1,0 +1,68 @@
+name: WASM Size Comment
+
+# Runs in the base repo's context (not the PR head's), so it gets a
+# write-capable GITHUB_TOKEN even for PRs from forks. It never checks out
+# or executes any code from the PR — it only downloads the small JSON
+# artifact produced by the `wasm-size-report` job in contracts.yml and
+# posts/updates a PR comment from it.
+on:
+  workflow_run:
+    workflows: ["Smart Contract CI"]
+    types: [completed]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  comment:
+    name: Post size comment
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request'
+
+    steps:
+      - name: Download size report artifact
+        id: download
+        continue-on-error: true
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: wasm-size-report
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Post or update comment
+        if: steps.download.outcome == 'success'
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const fs = require('fs');
+            const report = JSON.parse(fs.readFileSync('wasm-size-report.json', 'utf8'));
+
+            const delta = report.head_size - report.base_size;
+            const deltaStr = `${delta > 0 ? '+' : ''}${delta.toLocaleString()} bytes`;
+            const pct = ((report.head_size / report.limit) * 100).toFixed(1);
+            const marker = '<!-- wasm-size-report -->';
+
+            const body = [
+              marker,
+              '### Contract WASM size report',
+              '',
+              '| | Bytes |',
+              '|---|---|',
+              `| Base (\`${report.base_sha.slice(0, 7)}\`) | ${report.base_size.toLocaleString()} |`,
+              `| Head (\`${report.head_sha.slice(0, 7)}\`) | ${report.head_size.toLocaleString()} |`,
+              `| Delta | ${deltaStr} |`,
+              `| Budget used | ${pct}% of ${report.limit.toLocaleString()} bytes |`,
+            ].join('\n');
+
+            const { owner, repo } = context.repo;
+            const issue_number = report.pr_number;
+
+            const comments = await github.rest.issues.listComments({ owner, repo, issue_number });
+            const existing = comments.data.find((c) => c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }

--- a/Dechat/stellar-contracts/Cargo.toml
+++ b/Dechat/stellar-contracts/Cargo.toml
@@ -2,6 +2,7 @@
 name = "stellar-contracts"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [lib]
 crate-type = ["cdylib"]

--- a/Dechat/stellar-contracts/deny.toml
+++ b/Dechat/stellar-contracts/deny.toml
@@ -1,0 +1,42 @@
+[graph]
+all-features = false
+no-default-features = false
+
+[output]
+feature-depth = 1
+
+[advisories]
+ignore = [
+    # Transitive deps of soroban-sdk 25.3.0 (via soroban-env-host -> ark-*).
+    # No soroban-sdk release drops these yet; re-evaluate on the next SDK bump.
+    { id = "RUSTSEC-2024-0388", reason = "derivative is unmaintained; pulled in transitively by soroban-env-host's arkworks deps, no upstream fix available" },
+    { id = "RUSTSEC-2024-0436", reason = "paste is unmaintained; pulled in transitively by soroban-env-host/soroban-wasmi, no upstream fix available" },
+    { crate = "spin@0.9.8", reason = "yanked version pinned transitively by soroban-wasmi via soroban-sdk 25.3.0; not a direct dependency, upgrade tracked with the next SDK bump" },
+]
+
+[licenses]
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-1-Clause",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "Unicode-3.0",
+    "Unlicense",
+    "Zlib",
+]
+confidence-threshold = 0.8
+
+[licenses.private]
+ignore = true
+
+[bans]
+multiple-versions = "warn"
+wildcards = "allow"
+highlight = "all"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]


### PR DESCRIPTION
## Summary

Four CI/DX chores bundled into one PR since they're all small, independent workflow changes:

- **#1255** — Add `cargo-deny` to CI for license and advisory checks on the contracts crate.
- **#1256** — Cache Playwright browser binaries in the frontend E2E workflow.
- **#1257** — Split the frontend workflow so lint and typecheck fail fast.
- **#1258** — Report WASM size as a PR comment with a delta against `main`.

Closes #1255
Closes #1256
Closes #1257
Closes #1258

## Rationale

### #1255 — cargo-deny
Added `Dechat/stellar-contracts/deny.toml` and a new `deny` job in `contracts.yml` using `EmbarkStudios/cargo-deny-action`. The config was built and validated against the actual dependency graph (not a generic template):

- **Licenses**: allow-list covers every license actually present in the tree (MIT, Apache-2.0 (+ LLVM-exception), BSD-1/2/3-Clause, Unicode-3.0, Unlicense, Zlib). `stellar-contracts` itself is marked `publish = false` in `Cargo.toml` and `licenses.private.ignore = true` is set in `deny.toml`, since it's an internal contract crate with no LICENSE file — this avoids inventing a license nobody chose.
- **Advisories**: two transitive dependencies pulled in by `soroban-env-host` (via its arkworks deps) are unmaintained — `derivative` (RUSTSEC-2024-0388) and `paste` (RUSTSEC-2024-0436) — plus a yanked `spin@0.9.8`. All three are pinned transitively through `soroban-sdk 25.3.0` with no upstream fix available yet; they're explicitly ignored in `deny.toml` with reasons, and a comment flags re-evaluating on the next SDK bump. Nothing in our own dependency choices is flagged.
- Ran `cargo deny check` locally end-to-end (all four checks: advisories, bans, licenses, sources) — passes clean, only non-blocking `warn`-level duplicate-version notices remain (default behavior).

### #1256 — Cache Playwright browsers
Added an `actions/cache` step keyed on `pnpm-lock.yaml`'s hash (so it busts automatically on a Playwright version bump) for `~/.cache/ms-playwright` in the `e2e` job. On a cache hit, only `playwright install-deps` runs (OS-level deps, fast); on a miss, the existing full `playwright install --with-deps` runs. This avoids re-downloading all three browsers (chromium, firefox, webkit) on every run while still working correctly on a cold cache.

### #1257 — Split lint/typecheck into its own job
Split the `frontend.yml` `build` job into two parallel jobs: `lint` (install + typecheck + lint only) and `build` (install + build + coverage-sharded tests). They run concurrently instead of lint/typecheck sitting inside the same long job as the build and test suite. The `e2e` job now depends on `needs: [build, lint]` instead of just `build`, preserving the existing guarantee that E2E never runs against lint-broken code.

### #1258 — WASM size PR comment
Added a `wasm-size-report` job (`pull_request` only) that checks out both the PR head and base commits, builds each contract WASM (`--lib` only — this crate also has `src/bin/deploy_fiat_bridge_futurenet.rs`, which compiles to its own `.wasm` and would collide with a naive glob), and posts/updates a single sticky comment (matched via an HTML marker, so repeated pushes update the same comment instead of piling up) with a base/head/delta table and budget usage. The 92160-byte budget (`MAX_WASM_BYTES`) was hoisted from the existing "Check WASM size" step to workflow-level `env`, so both the enforcing check and the new report read the same number — no drift possible between them.

## Heads up: pre-existing WASM budget overage (not from this PR)

A clean build of `main`'s contract currently produces a **94,774-byte** WASM, already **2,614 bytes over** the existing 92,160-byte budget enforced by the `test` job's "Check WASM size" step. This PR doesn't touch any contract source, so it doesn't cause this — but it means:

- The existing `test` job's size check will likely still fail on this PR (as it presumably already does on `main`), unrelated to these changes.
- The new `wasm-size-report` comment will show ~128% budget usage with ~0 delta, which is expected and correct — it's accurately reporting the existing state, not a new regression.

Flagging this so it isn't mistaken for something introduced here; shrinking the contract back under budget is a separate piece of work.

## Test plan

- [x] `cargo deny check` (advisories, bans, licenses, sources) passes locally against the real `Cargo.lock`
- [x] `cargo test` passes locally (282 tests)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes locally with no warnings
- [x] Verified `--lib`-only build produces exactly one `.wasm` artifact (`stellar_contracts.wasm`) with the same byte size as a full build
- [x] Verified YAML syntax for both edited workflow files
- [ ] Confirm the `deny`, `lint`, and `wasm-size-report` jobs run and pass (aside from the pre-existing size overage) once this PR is open on GitHub
