### PR TITLE
fix: stale closure in price service, date validation, error handling

### DIFF
--- a/Dechat/dex_with_fiat_frontend/src/app/api/admin-audit/route.test.ts
+++ b/Dechat/dex_with_fiat_frontend/src/app/api/admin-audit/route.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+vi.mock('@/lib/auditLog', () => ({
+  default: {
+    getAuditEntries: vi.fn(() => []),
+  },
+}));
+
+const { GET } = await import('./route');
+
+function request(query = '') {
+  return new NextRequest(`http://localhost/api/admin-audit${query}`);
+}
+
+describe('GET /api/admin-audit', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 200 with default pagination', async () => {
+    const res = await GET(request());
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toMatchObject({
+      entries: [],
+      total: 0,
+      limit: 100,
+      offset: 0,
+      hasMore: false,
+    });
+  });
+
+  it('returns 400 for invalid startDate', async () => {
+    const res = await GET(request('?startDate=not-a-date'));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain('startDate');
+  });
+
+  it('returns 400 for invalid endDate', async () => {
+    const res = await GET(request('?endDate=zzz'));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain('endDate');
+  });
+
+  it('accepts valid ISO dates', async () => {
+    const res = await GET(
+      request('?startDate=2025-01-01T00:00:00Z&endDate=2025-12-31T23:59:59Z'),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it('clamps limit to max 1000', async () => {
+    const res = await GET(request('?limit=9999'));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.limit).toBe(1000);
+  });
+
+  it('defaults limit to 100 for non-numeric input', async () => {
+    const res = await GET(request('?limit=abc'));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.limit).toBe(100);
+  });
+
+  it('defaults offset to 0 for non-numeric input', async () => {
+    const res = await GET(request('?offset=abc'));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.offset).toBe(0);
+  });
+
+  it('returns 405 for POST', async () => {
+    const { POST } = await import('./route');
+    const res = await POST();
+    expect(res.status).toBe(405);
+  });
+});

--- a/Dechat/dex_with_fiat_frontend/src/app/api/admin-audit/route.ts
+++ b/Dechat/dex_with_fiat_frontend/src/app/api/admin-audit/route.ts
@@ -47,34 +47,35 @@ export async function GET(request: NextRequest) {
 
     const startDate = searchParams.get('startDate');
     if (startDate) {
-      try {
-        filter.startDate = new Date(startDate);
-      } catch {
+      const parsed = new Date(startDate);
+      if (Number.isNaN(parsed.getTime())) {
         return NextResponse.json(
           { error: 'Invalid startDate format. Use ISO 8601 format.' },
           { status: 400 }
         );
       }
+      filter.startDate = parsed;
     }
 
     const endDate = searchParams.get('endDate');
     if (endDate) {
-      try {
-        filter.endDate = new Date(endDate);
-      } catch {
+      const parsed = new Date(endDate);
+      if (Number.isNaN(parsed.getTime())) {
         return NextResponse.json(
           { error: 'Invalid endDate format. Use ISO 8601 format.' },
           { status: 400 }
         );
       }
+      filter.endDate = parsed;
     }
 
     // Pagination parameters
-    const limit = Math.min(
-      parseInt(searchParams.get('limit') || '100', 10),
-      1000 // Max limit
-    );
-    const offset = Math.max(parseInt(searchParams.get('offset') || '0', 10), 0);
+    const rawLimit = parseInt(searchParams.get('limit') || '100', 10);
+    const limit = Number.isFinite(rawLimit)
+      ? Math.min(Math.max(rawLimit, 1), 1000)
+      : 100;
+    const rawOffset = parseInt(searchParams.get('offset') || '0', 10);
+    const offset = Number.isFinite(rawOffset) ? Math.max(rawOffset, 0) : 0;
 
     // Retrieve filtered entries
     const allEntries = AuditLogService.getAuditEntries(filter);

--- a/Dechat/dex_with_fiat_frontend/src/app/api/health/route.test.ts
+++ b/Dechat/dex_with_fiat_frontend/src/app/api/health/route.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+
+const { GET } = await import('./route');
+
+describe('GET /api/health', () => {
+  it('returns 200 with status ok', async () => {
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.status).toBe('ok');
+    expect(body.timestamp).toBeDefined();
+    // timestamp should be a valid ISO date
+    expect(Number.isNaN(new Date(body.timestamp).getTime())).toBe(false);
+  });
+});

--- a/Dechat/dex_with_fiat_frontend/src/app/api/health/route.ts
+++ b/Dechat/dex_with_fiat_frontend/src/app/api/health/route.ts
@@ -3,11 +3,22 @@ import { NextResponse } from 'next/server';
 export const runtime = 'edge';
 
 export async function GET() {
-  return NextResponse.json(
-    {
-      status: 'ok',
-      timestamp: new Date().toISOString(),
-    },
-    { status: 200 },
-  );
+  try {
+    return NextResponse.json(
+      {
+        status: 'ok',
+        timestamp: new Date().toISOString(),
+      },
+      { status: 200 },
+    );
+  } catch (error) {
+    return NextResponse.json(
+      {
+        status: 'error',
+        timestamp: new Date().toISOString(),
+        message: error instanceof Error ? error.message : 'Health check failed',
+      },
+      { status: 503 },
+    );
+  }
 }

--- a/Dechat/dex_with_fiat_frontend/src/app/api/initiate-transfer/route.test.ts
+++ b/Dechat/dex_with_fiat_frontend/src/app/api/initiate-transfer/route.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { z } from 'zod';
+
+const mockSchema = z.object({
+  source: z.string().min(1),
+  reason: z.string().min(1),
+  amount: z.string().min(1),
+  recipient: z.string().min(1),
+  reference: z.string().optional(),
+});
+
+vi.mock('@/lib/telemetry', () => ({
+  telemetry: {
+    extractTraceFromHeaders: () => ({ traceId: 'trace', spanId: 'parent' }),
+    createSpan: () => ({ spanId: 'span' }),
+    addLog: vi.fn(),
+    finishSpan: vi.fn(),
+  },
+}));
+
+vi.mock('@sentry/nextjs', () => ({
+  captureException: vi.fn(),
+}));
+
+vi.mock('@/lib/rateLimit', () => ({
+  applyRateLimit: vi.fn(() => null),
+  getClientIp: vi.fn(() => '127.0.0.1'),
+}));
+
+vi.mock('@/lib/transferStore', () => ({
+  setTransferStatus: vi.fn(),
+}));
+
+vi.mock('@/lib/payout/providers/registry', () => ({
+  getPayoutProvider: () => ({
+    initiateTransfer: vi.fn().mockResolvedValue({ reference: 'ref-123' }),
+  }),
+}));
+
+vi.mock('@/lib/apiSchemas', () => ({
+  initiateTransferSchema: mockSchema,
+}));
+
+const { POST } = await import('./route');
+
+function makeRequest(body: unknown) {
+  return new NextRequest(
+    new Request('http://localhost/api/initiate-transfer', {
+      method: 'POST',
+      body: JSON.stringify(body),
+      headers: { 'content-type': 'application/json' },
+    }),
+  );
+}
+
+describe('POST /api/initiate-transfer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 400 for malformed JSON body', async () => {
+    const badReq = new NextRequest(
+      new Request('http://localhost/api/initiate-transfer', {
+        method: 'POST',
+        body: 'not json{{{',
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+
+    const res = await POST(badReq);
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.success).toBe(false);
+    expect(body.message).toContain('Invalid JSON');
+  });
+
+  it('returns 400 for validation failures', async () => {
+    const req = makeRequest({ source: '', reason: '', amount: '', recipient: '' });
+    const res = await POST(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.success).toBe(false);
+  });
+
+  it('returns 200 for valid request', async () => {
+    const req = makeRequest({
+      source: 'wallet',
+      reason: 'payment',
+      amount: '100',
+      recipient: 'GABC123',
+    });
+    const res = await POST(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+  });
+});

--- a/Dechat/dex_with_fiat_frontend/src/app/api/initiate-transfer/route.ts
+++ b/Dechat/dex_with_fiat_frontend/src/app/api/initiate-transfer/route.ts
@@ -25,7 +25,20 @@ export async function POST(request: NextRequest) {
       endpoint: '/api/initiate-transfer',
     });
 
-    const body = await request.json();
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      telemetry.addLog(span.spanId, 'warn', 'Malformed JSON body');
+      telemetry.finishSpan(span.spanId, {
+        success: false,
+        error: 'Invalid JSON body',
+      });
+      return NextResponse.json(
+        { success: false, message: 'Invalid JSON in request body.' },
+        { status: 400 },
+      );
+    }
 
     // Validate with Zod
     const validationResult = initiateTransferSchema.safeParse(body);
@@ -94,7 +107,6 @@ export async function POST(request: NextRequest) {
       data,
     });
   } catch (error: unknown) {
-    // Capture error in Sentry
     Sentry.captureException(error, {
       tags: {
         endpoint: '/api/initiate-transfer',
@@ -107,13 +119,14 @@ export async function POST(request: NextRequest) {
       },
     });
 
+    const errorMessage =
+      error instanceof Error ? error.message : 'Unknown error';
+
     telemetry.addLog(
       span.spanId,
       'error',
       'Unhandled error in transfer initiation',
-      {
-        error: error instanceof Error ? error.message : 'Unknown error',
-      },
+      { error: errorMessage },
     );
 
     console.error('Initiate transfer error:', error);

--- a/Dechat/dex_with_fiat_frontend/src/lib/cryptoPriceService.test.ts
+++ b/Dechat/dex_with_fiat_frontend/src/lib/cryptoPriceService.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock global fetch
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+const {
+  fetchCryptoPrices,
+  getTokenPrice,
+  clearPriceCache,
+  fetchTickerData,
+} = await import('./cryptoPriceService');
+
+describe('cryptoPriceService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearPriceCache();
+  });
+
+  describe('getTokenPrice deduplication (stale closure fix)', () => {
+    it('deduplicates concurrent requests for the same token+currency', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({ stellar: { usd: 0.12, usd_24h_change: 1.5 } }),
+      });
+
+      // Fire 3 concurrent requests for the same key
+      const [p1, p2, p3] = await Promise.all([
+        getTokenPrice('XLM', 'usd'),
+        getTokenPrice('XLM', 'usd'),
+        getTokenPrice('XLM', 'usd'),
+      ]);
+
+      expect(p1).toBe(0.12);
+      expect(p2).toBe(0.12);
+      expect(p3).toBe(0.12);
+      // Only one fetch should have been made, not three
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns cached value without fetching when cache is fresh', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({ stellar: { usd: 0.15, usd_24h_change: 2.0 } }),
+      });
+
+      // First call fetches
+      const price1 = await getTokenPrice('XLM', 'usd');
+      expect(price1).toBe(0.15);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
+      // Second call should use cache
+      const price2 = await getTokenPrice('XLM', 'usd');
+      expect(price2).toBe(0.15);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns fallback (0) when fetch fails and no cache exists', async () => {
+      mockFetch.mockRejectedValue(new Error('network down'));
+
+      const price = await getTokenPrice('UNKNOWN', 'usd');
+      expect(price).toBe(0);
+    });
+  });
+
+  describe('fetchCryptoPrices', () => {
+    it('returns mapped prices on success', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            stellar: { usd: 0.11, eur: 0.1 },
+            ethereum: { usd: 4000, eur: 3700 },
+          }),
+      });
+
+      const result = await fetchCryptoPrices(['XLM', 'ETH'], ['usd', 'eur']);
+
+      expect(result).toEqual({
+        XLM: { usd: 0.11, eur: 0.1 },
+        ETH: { usd: 4000, eur: 3700 },
+      });
+    });
+
+    it('returns fallback when API returns error', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 429,
+        statusText: 'Too Many Requests',
+      });
+
+      const result = await fetchCryptoPrices(['XLM'], ['usd']);
+      // Should get fallback values, not throw
+      expect(result.XLM).toBeDefined();
+      expect(result.XLM.usd).toBe(0.11);
+    });
+
+    it('returns fallback for unknown symbols', async () => {
+      const result = await fetchCryptoPrices(['FAKECOIN'], ['usd']);
+      expect(result).toEqual({});
+    });
+  });
+
+  describe('fetchTickerData', () => {
+    it('returns empty object on error (not throw)', async () => {
+      mockFetch.mockRejectedValue(new Error('API down'));
+
+      const result = await fetchTickerData(['XLM'], 'usd');
+      expect(result).toEqual({});
+    });
+
+    it('returns ticker data on success', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            stellar: { usd: 0.12, usd_24h_change: 3.5 },
+          }),
+      });
+
+      const result = await fetchTickerData(['XLM'], 'usd');
+      expect(result.XLM).toEqual({
+        symbol: 'XLM',
+        price: 0.12,
+        change24h: 3.5,
+        currency: 'usd',
+      });
+    });
+  });
+});

--- a/Dechat/dex_with_fiat_frontend/src/lib/cryptoPriceService.ts
+++ b/Dechat/dex_with_fiat_frontend/src/lib/cryptoPriceService.ts
@@ -48,6 +48,7 @@ export const SUPPORTED_CURRENCIES = [
 
 // Cache for prices to avoid excessive API calls
 const priceCache: Map<string, TokenPriceData> = new Map();
+const inflightRequests: Map<string, Promise<number>> = new Map();
 const CACHE_DURATION = 2 * 60 * 1000; // 2 minutes
 
 /**
@@ -185,7 +186,10 @@ function getFallbackPrices(
 }
 
 /**
- * Get cached price or fetch from API
+ * Get cached price or fetch from API.
+ * Deduplicates concurrent requests for the same token+currency so only one
+ * API call is in flight at a time — fixes stale-closure where N concurrent
+ * callers each saw a stale cache and fired their own fetch.
  */
 export async function getTokenPrice(
   tokenSymbol: string,
@@ -199,13 +203,33 @@ export async function getTokenPrice(
     return cached.prices[vsCurrency.toLowerCase()] || 0;
   }
 
+  // If there's already an in-flight request for this key, wait for it
+  const existing = inflightRequests.get(cacheKey);
+  if (existing) {
+    return existing;
+  }
+
+  const promise = doFetchAndCache(tokenSymbol, vsCurrency, cacheKey, cached);
+  inflightRequests.set(cacheKey, promise);
+
   try {
-    // Fetch fresh data
+    return await promise;
+  } finally {
+    inflightRequests.delete(cacheKey);
+  }
+}
+
+async function doFetchAndCache(
+  tokenSymbol: string,
+  vsCurrency: string,
+  cacheKey: string,
+  cached: TokenPriceData | undefined,
+): Promise<number> {
+  try {
     const priceData = await fetchCryptoPrices([tokenSymbol], [vsCurrency]);
     const price =
       priceData[tokenSymbol.toUpperCase()]?.[vsCurrency.toLowerCase()] || 0;
 
-    // Update cache
     priceCache.set(cacheKey, {
       tokenSymbol: tokenSymbol.toUpperCase(),
       prices: { [vsCurrency.toLowerCase()]: price },
@@ -215,8 +239,6 @@ export async function getTokenPrice(
     return price;
   } catch (error) {
     console.error(`Error getting price for ${tokenSymbol}:`, error);
-
-    // Return cached data even if stale, or 0 as last resort
     return cached?.prices[vsCurrency.toLowerCase()] || 0;
   }
 }
@@ -341,8 +363,11 @@ export async function fetchTickerData(
 
     return tickerData;
   } catch (error) {
-    console.error('Error fetching ticker data:', error);
-    return {}; // Return empty object to trigger fallback UI
+    const message =
+      error instanceof Error ? error.message : 'Unknown error fetching prices';
+    console.error('Error fetching ticker data:', message);
+    // Return empty object — callers should treat {} as "no data, show fallback"
+    return {};
   }
 }
 


### PR DESCRIPTION
four fixes:

1. cryptoPriceService: concurrent getTokenPrice calls for the same key now deduplicate to a single in-flight request instead of each firing their own fetch (stale closure fix)
2. admin-audit: new Date() doesnt throw on invalid strings — switched to Number.isNaN check so bad dates actually return 400. also guarded limit/offset NaN parsing
3. initiate-transfer: malformed JSON body now returns 400 with a clear message instead of falling through to the generic 500 handler
4. health: wrapped in try/catch so errors return 503 instead of crashing

regression tests included for all four.

fixes #1228
fixes #1231
fixes #1232
fixes #1233