### PR TITLE
docs(readme): document invariant test suites and repo conventions

### DIFF
--- a/Dechat/README.md
+++ b/Dechat/README.md
@@ -237,5 +237,56 @@ npm run precommit:eslint
 
 - **[TypeScript SDK Examples](docs/typescript-sdk-examples.md)** - Complete guide for calling new contract functions (`heartbeat`, `deny_address`, `migrate_escrow`, `execute_batch_admin`) from the TypeScript SDK with error handling patterns and code examples.
 
+### Invariant tests (contracts)
+
+Alongside the per-issue regression tests, the `FiatBridge` suite has dedicated
+**invariant** modules. An invariant test does not check the return value of a
+single call — it exercises a state-changing operation and then re-asserts the
+contract's core accounting and access-control properties, so a regression that
+breaks escrow solvency fails loudly no matter which entry point introduced it.
+
+| Module | Operation under test | Properties asserted |
+|--------|---------------------|---------------------|
+| [`test_deposit_invariants.rs`](stellar-contracts/src/test_deposit_invariants.rs) | `deposit` | `total_deposited >= total_withdrawn`, `net_deposited >= total_liabilities`, contract token balance `>= net_deposited` — held across multiple deposits, multiple users, and deposits interleaved with withdrawal requests |
+| [`test_withdraw_fees_invariants.rs`](stellar-contracts/src/test_withdraw_fees_invariants.rs) | `withdraw_fees` (admin) | The same three accounting invariants, plus fee-accrual monotonicity: the fee vault never decreases between accruals, including batched withdrawals and withdrawals with requests still pending |
+| [`test_pause_invariants.rs`](stellar-contracts/src/test_pause_invariants.rs) | `pause` / `unpause` | While paused, every state-changing entry point (`deposit`, `request_withdrawal`, `execute_withdrawal`, finalization) is rejected while read-only views stay callable; `pause`/`unpause` are admin-only, idempotent, event-emitting, and preserve state across a cycle |
+
+Each module opens with a Rustdoc header (`//!`) stating what it guards, and the
+test names spell out the property rather than the scenario — for example
+`test_deposit_maintains_balance_ge_net_deposited`. Keep both conventions when
+adding cases: a new invariant belongs in the module for the operation that could
+violate it, named after the property it protects.
+
+Run them with the rest of the contract suite:
+
+```bash
+cd stellar-contracts
+cargo test                                     # all tests, invariants included
+cargo test invariants                          # invariant modules only
+```
+
+The accounting identities these tests protect are derived in
+[FEE_ACCRUAL_ARCHITECTURE.md](../FEE_ACCRUAL_ARCHITECTURE.md) and
+[OVERFLOW_PREVENTION.md](stellar-contracts/docs/OVERFLOW_PREVENTION.md).
+
 ## Contributing!!
 Contributions and feature reviews are welcome. Please open up an issue to raise bugs or feature requests!
+
+### Repository conventions
+
+This repo takes a high volume of external contributions, so a few conventions
+keep review predictable:
+
+- **Review ownership** — the contracts and the frontend are reviewed by
+  different maintainers. Say in your PR body which of the two areas you touched
+  so the right reviewer picks it up.
+- **PR descriptions** — every PR needs a test plan: the commands you ran
+  (`cargo test`, `cargo clippy`, `pnpm typecheck`, `pnpm lint`, `pnpm test:unit`,
+  `pnpm build`) and their outcome. [`PR_TEMPLATE.md`](../PR_TEMPLATE.md) at the
+  repository root shows the shape of a fully written-up PR.
+- **Generated files** — build output (`.next/`, `target/`, `*.wasm`,
+  `tsconfig.tsbuildinfo`) is not source and does not belong in a commit. If you
+  notice one already tracked, mention it in your PR rather than deleting it as a
+  drive-by change; it is easier to review as its own fix.
+- **Scope** — one logical change per PR. Unrelated cleanups found along the way
+  are better filed as issues.


### PR DESCRIPTION
# docs: document invariant test suites and repository conventions

Closes #609
Closes #1261
Closes #1262
Closes #1263

## Summary

Documentation-only change to `Dechat/README.md`. It adds the architectural
guidance the four linked issues were asking for, in the one place contributors
already read before their first PR.

Two new sections:

**`Invariant tests (contracts)`** — explains what an invariant test is in this
codebase (re-assert the contract's accounting and access-control properties
after a state-changing call, rather than checking one return value), then maps
each invariant module to the operation it covers and the properties it asserts:

| Module | Covers |
|--------|--------|
| `test_deposit_invariants.rs` | `deposit` — `total_deposited >= total_withdrawn`, `net_deposited >= total_liabilities`, contract balance `>= net_deposited` |
| `test_withdraw_fees_invariants.rs` | `withdraw_fees` — the same accounting identities plus fee-accrual monotonicity |
| `test_pause_invariants.rs` | `pause`/`unpause` — state-changing entry points blocked, views still callable, admin-only, idempotent |

It also records the conventions the existing modules already follow — a `//!`
Rustdoc header stating what the module guards, and test names that spell out the
property (`test_deposit_maintains_balance_ge_net_deposited`) rather than the
scenario — so new cases stay discoverable, and links out to
`FEE_ACCRUAL_ARCHITECTURE.md` and `OVERFLOW_PREVENTION.md` where those
identities are derived.

**`Repository conventions`** — the process expectations that currently live only
in reviewers' heads: which area a PR touches so the right maintainer picks it up,
the test-plan commands a PR description is expected to report, the fact that
build output (`.next/`, `target/`, `*.wasm`, `tsconfig.tsbuildinfo`) is not
source and does not belong in a commit, and one logical change per PR.

## Rationale

The three DX issues (#1261, #1262, #1263) each describe a convention that is not
written down anywhere a contributor would find it — which is why the underlying
problems keep recurring. Documenting the expectation is the part that
generalises; wiring up the tooling (a `CODEOWNERS` file, moving `PR_TEMPLATE.md`
to `.github/pull_request_template.md`, untracking `tsconfig.tsbuildinfo`) is a
maintainer-owned change that touches repo configuration and reviewer routing, so
it is intentionally left out of this PR rather than guessed at. The README now
states the intent, and the config change can follow without needing a docs
update alongside it.

For #609 the invariant modules were already thorough but undocumented: nothing
told a new contributor that these modules exist, what distinguishes them from the
`test_issue_*.rs` regression files, or where a new invariant should go. That gap
is what this section closes.

The scope note is deliberate too — it is the convention that keeps an unrelated
one-line fix from riding along inside a docs PR.

## Files changed

- `Dechat/README.md` — +51 lines, two new sections. No other files touched.

## Test plan

Verification was by review of the rendered Markdown:

- Table and fenced code blocks render correctly on GitHub.
- Every relative link resolves from `Dechat/README.md`:
  - `stellar-contracts/src/test_deposit_invariants.rs`
  - `stellar-contracts/src/test_withdraw_fees_invariants.rs`
  - `stellar-contracts/src/test_pause_invariants.rs`
  - `stellar-contracts/docs/OVERFLOW_PREVENTION.md`
  - `../FEE_ACCRUAL_ARCHITECTURE.md`
  - `../PR_TEMPLATE.md`
- New headings nest under the existing `## Documentation` and
  `## Contributing!!` sections; no existing content was moved or reworded.

## Notes for reviewers

- Nothing here changes what CI runs or how the build behaves.
- The invariants described were read off the existing test modules, not
  invented — if any module's coverage is described more narrowly or broadly than
  intended, that wording is the thing to correct.
