### PR TITLE
chore(dx): add coverage PR comment + unit tests for wallet/theme/pref…

### DIFF
--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -1,0 +1,73 @@
+name: Frontend Coverage Comment
+
+# Runs in the base repo's context (not the PR head's), so it gets a
+# write-capable GITHUB_TOKEN even for PRs from forks. It never checks out
+# or executes any code from the PR — it only downloads the small JSON
+# artifact produced by the `build` job in frontend.yml and posts/updates a
+# PR comment from it.
+on:
+  workflow_run:
+    workflows: ["Frontend CI"]
+    types: [completed]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  comment:
+    name: Post coverage comment
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request'
+
+    steps:
+      - name: Download coverage report artifact
+        id: download
+        continue-on-error: true
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: frontend-coverage-report
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Post or update comment
+        if: steps.download.outcome == 'success'
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const fs = require('fs');
+            const report = JSON.parse(fs.readFileSync('frontend-coverage-report.json', 'utf8'));
+            const marker = '<!-- frontend-coverage-report -->';
+
+            const row = (label, pct, target) => {
+              const status = pct >= target ? '✅' : '⚠️';
+              return `| ${label} | ${pct.toFixed(2)}% | ${target}% | ${status} |`;
+            };
+
+            const body = [
+              marker,
+              '### Frontend unit test coverage',
+              '',
+              `Commit \`${report.head_sha.slice(0, 7)}\``,
+              '',
+              '| Metric | Coverage | Target | |',
+              '|---|---|---|---|',
+              row('Statements', report.statements, report.targets.statements),
+              row('Branches', report.branches, report.targets.branches),
+              row('Functions', report.functions, report.targets.functions),
+              row('Lines', report.lines, report.targets.lines),
+              '',
+              '_Targets are informational — not currently enforced as a CI gate._',
+            ].join('\n');
+
+            const { owner, repo } = context.repo;
+            const issue_number = report.pr_number;
+
+            const comments = await github.rest.issues.listComments({ owner, repo, issue_number });
+            const existing = comments.data.find((c) => c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -110,7 +110,49 @@ jobs:
         run: pnpm test:coverage:merge
         env:
           NODE_OPTIONS: --max-old-space-size=4096
-        # Fails the pipeline if coverage thresholds (stmt 70%, branch 65%, fn 70%) are not met
+        # NOTE: coverage.thresholds are not currently configured in vitest.config.ts,
+        # so this step does not fail the pipeline on low coverage. The target numbers
+        # below (stmt 70%, branch 65%, fn 70%, lines 70%) are informational only until
+        # a threshold gate is deliberately reintroduced.
+
+      - name: Generate coverage report artifact
+        id: coverage_report
+        if: always() && github.event_name == 'pull_request'
+        run: |
+          if [ ! -f coverage/coverage-summary.json ]; then
+            echo "No coverage summary found, skipping report generation."
+            echo "generated=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          node -e "
+            const fs = require('fs');
+            const summary = JSON.parse(fs.readFileSync('coverage/coverage-summary.json', 'utf8'));
+            const total = summary.total;
+            const report = {
+              pr_number: ${{ github.event.pull_request.number }},
+              head_sha: '${{ github.event.pull_request.head.sha }}',
+              statements: total.statements.pct,
+              branches: total.branches.pct,
+              functions: total.functions.pct,
+              lines: total.lines.pct,
+              targets: { statements: 70, branches: 65, functions: 70, lines: 70 },
+            };
+            fs.writeFileSync('frontend-coverage-report.json', JSON.stringify(report));
+          "
+          echo "generated=true" >> "$GITHUB_OUTPUT"
+
+      # PRs from forks get a read-only GITHUB_TOKEN under the `pull_request` event, so
+      # this job can't post a comment directly. The report is handed off as an artifact
+      # to coverage-comment.yml, which runs via `workflow_run` in the base repo's
+      # context (write-capable token) and only ever reads this JSON — it never checks
+      # out or executes any code from the PR.
+      - name: Upload coverage report artifact
+        if: always() && steps.coverage_report.outputs.generated == 'true'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: frontend-coverage-report
+          path: Dechat/dex_with_fiat_frontend/frontend-coverage-report.json
+          retention-days: 7
 
   e2e:
     name: Playwright E2E Tests

--- a/Dechat/dex_with_fiat_frontend/src/app/api/initiate-transfer/route.ts
+++ b/Dechat/dex_with_fiat_frontend/src/app/api/initiate-transfer/route.ts
@@ -64,9 +64,13 @@ export async function POST(request: NextRequest) {
 
     const { source, reason, amount, recipient, reference } =
       validationResult.data;
+    // `clientSessionId` isn't part of initiateTransferSchema, so it's read
+    // from the raw (already-validated-as-an-object) body instead of
+    // validationResult.data.
+    const bodyRecord = body as Record<string, unknown>;
     const clientSessionId =
-      typeof body.clientSessionId === 'string'
-        ? body.clientSessionId
+      typeof bodyRecord.clientSessionId === 'string'
+        ? bodyRecord.clientSessionId
         : undefined;
 
     telemetry.addLog(span.spanId, 'info', 'Request validated', {

--- a/Dechat/dex_with_fiat_frontend/src/components/Message.tsx
+++ b/Dechat/dex_with_fiat_frontend/src/components/Message.tsx
@@ -63,12 +63,6 @@ export default function Message({ message, onActionClick, onRetry, shouldAnimate
   // made since it mounted.
   const totalRetryAttempts = (message.error?.retryAttempts ?? 0) + retry.attempts;
 
-  const handleMessageKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'r' && hasError && onRetry) {
-      retry.retryNow();
-    }
-  };
-
   // Currency conversion hook for transaction amounts
   const amountForConversion = message.metadata?.transactionData?.amountIn 
     ? parseFloat(String(message.metadata.transactionData.amountIn))

--- a/Dechat/dex_with_fiat_frontend/src/components/StellarChatInterface.tsx
+++ b/Dechat/dex_with_fiat_frontend/src/components/StellarChatInterface.tsx
@@ -3,7 +3,6 @@
 import SkeletonChat from '@/components/ui/skeleton/SkeletonChat';
 import SkeletonSidebar from '@/components/ui/skeleton/SkeletonSidebar';
 import { useState, useCallback, useEffect, useRef } from 'react';
-import { useReducedMotion } from 'framer-motion';
 import {
   Wallet,
   LogOut,
@@ -68,7 +67,6 @@ const HEALTH_POLL_INTERVAL_MS = 60_000;
 
 function StellarChatInterfaceContent() {
   const { t } = useTranslation();
-  const prefersReducedMotion = useReducedMotion();
   const {
     connection,
     connect,

--- a/Dechat/dex_with_fiat_frontend/src/contexts/StellarWalletContext.test.tsx
+++ b/Dechat/dex_with_fiat_frontend/src/contexts/StellarWalletContext.test.tsx
@@ -1,0 +1,228 @@
+import React from 'react';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Networks } from '@stellar/stellar-sdk';
+import { StellarWalletProvider, useStellarWallet } from './StellarWalletContext';
+
+const freighter = vi.hoisted(() => ({
+  isConnected: vi.fn(),
+  getAddress: vi.fn(),
+  getNetwork: vi.fn(),
+  requestAccess: vi.fn(),
+  signTransaction: vi.fn(),
+  setAllowed: vi.fn(),
+}));
+
+vi.mock('@stellar/freighter-api', () => freighter);
+
+const fetchXlmBalance = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/stellarContract', () => ({ fetchXlmBalance }));
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return <StellarWalletProvider>{children}</StellarWalletProvider>;
+}
+
+const ADDRESS = 'GABCDEF1234567890TESTADDRESS';
+const SECOND_ADDRESS = 'GSECONDACCOUNTADDRESS1234567';
+
+describe('StellarWalletContext', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    delete (window as { freighter?: unknown }).freighter;
+    vi.clearAllMocks();
+    freighter.isConnected.mockResolvedValue({ isConnected: false });
+    freighter.getAddress.mockResolvedValue({ address: ADDRESS });
+    freighter.getNetwork.mockResolvedValue({
+      network: 'TESTNET',
+      networkPassphrase: Networks.TESTNET,
+    });
+    freighter.requestAccess.mockResolvedValue({ address: ADDRESS });
+    freighter.signTransaction.mockResolvedValue({ signedTxXdr: 'SIGNED_XDR' });
+    freighter.setAllowed.mockResolvedValue({ isAllowed: true });
+    fetchXlmBalance.mockResolvedValue('100.0000000');
+  });
+
+  it('defaults to a disconnected state when Freighter is not installed', async () => {
+    const { result } = renderHook(() => useStellarWallet(), { wrapper });
+
+    await waitFor(() => expect(result.current.isFreighterInstalled).toBe(false));
+
+    expect(result.current.connection.isConnected).toBe(false);
+    expect(result.current.accounts).toEqual([]);
+    expect(result.current.xlmBalance).toBe('');
+    expect(result.current.isNetworkMismatch).toBe(false);
+  });
+
+  describe('connect', () => {
+    it('sets connection, balance, and persists to localStorage on success', async () => {
+      const { result } = renderHook(() => useStellarWallet(), { wrapper });
+
+      await act(async () => {
+        await result.current.connect();
+      });
+
+      expect(result.current.connection.isConnected).toBe(true);
+      expect(result.current.connection.address).toBe(ADDRESS);
+      expect(result.current.xlmBalance).toBe('100.0000000');
+      expect(localStorage.getItem('stellar_address')).toBe(ADDRESS);
+      expect(result.current.error).toBeNull();
+    });
+
+    it('sets an error and leaves the connection unset on a network mismatch', async () => {
+      freighter.getNetwork.mockResolvedValue({
+        network: 'PUBLIC',
+        networkPassphrase: Networks.PUBLIC,
+      });
+
+      const { result } = renderHook(() => useStellarWallet(), { wrapper });
+
+      await act(async () => {
+        await result.current.connect();
+      });
+
+      expect(result.current.error).toBe('Please switch Freighter to Testnet');
+      expect(result.current.connection.isConnected).toBe(false);
+    });
+
+    it('sets an error when Freighter reports a failure', async () => {
+      freighter.requestAccess.mockResolvedValue({
+        error: 'User declined access',
+      });
+
+      const { result } = renderHook(() => useStellarWallet(), { wrapper });
+
+      await act(async () => {
+        await result.current.connect();
+      });
+
+      expect(result.current.error).toBe('User declined access');
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+
+  it('disconnect resets connection, accounts, balance, and storage', async () => {
+    const { result } = renderHook(() => useStellarWallet(), { wrapper });
+
+    await act(async () => {
+      await result.current.connect();
+    });
+    expect(result.current.connection.isConnected).toBe(true);
+
+    act(() => {
+      result.current.disconnect();
+    });
+
+    expect(result.current.connection.isConnected).toBe(false);
+    expect(result.current.accounts).toEqual([]);
+    expect(result.current.xlmBalance).toBe('');
+    expect(localStorage.getItem('stellar_address')).toBeNull();
+  });
+
+  describe('selectAccount', () => {
+    it('switches the active account and persists the new selection', async () => {
+      window.freighter = {
+        getAccounts: vi
+          .fn()
+          .mockResolvedValue({ accounts: [ADDRESS, SECOND_ADDRESS] }),
+      };
+
+      const { result } = renderHook(() => useStellarWallet(), { wrapper });
+
+      await act(async () => {
+        await result.current.connect();
+      });
+      expect(result.current.accounts).toHaveLength(2);
+
+      await act(async () => {
+        await result.current.selectAccount(1);
+      });
+
+      expect(result.current.selectedAccountIndex).toBe(1);
+      expect(result.current.connection.address).toBe(SECOND_ADDRESS);
+      expect(localStorage.getItem('stellar_selected_account_index')).toBe('1');
+    });
+
+    it('is a no-op for an out-of-range index', async () => {
+      window.freighter = {
+        getAccounts: vi.fn().mockResolvedValue({ accounts: [ADDRESS] }),
+      };
+
+      const { result } = renderHook(() => useStellarWallet(), { wrapper });
+
+      await act(async () => {
+        await result.current.connect();
+      });
+      expect(result.current.accounts).toHaveLength(1);
+
+      await act(async () => {
+        await result.current.selectAccount(5);
+      });
+
+      expect(result.current.selectedAccountIndex).toBe(0);
+    });
+  });
+
+  describe('signTx', () => {
+    it('returns the signed XDR on success', async () => {
+      const { result } = renderHook(() => useStellarWallet(), { wrapper });
+
+      await act(async () => {
+        await result.current.connect();
+      });
+
+      const signed = await result.current.signTx('UNSIGNED_XDR');
+
+      expect(signed).toBe('SIGNED_XDR');
+    });
+
+    it('throws when Freighter returns an error', async () => {
+      freighter.signTransaction.mockResolvedValue({ error: 'User rejected' });
+      const { result } = renderHook(() => useStellarWallet(), { wrapper });
+
+      await act(async () => {
+        await result.current.connect();
+      });
+
+      await expect(result.current.signTx('UNSIGNED_XDR')).rejects.toThrow(
+        'User rejected',
+      );
+    });
+  });
+
+  it('mockConnect sets a TESTNET connection directly', () => {
+    const { result } = renderHook(() => useStellarWallet(), { wrapper });
+
+    act(() => {
+      result.current.mockConnect(ADDRESS);
+    });
+
+    expect(result.current.connection.isConnected).toBe(true);
+    expect(result.current.connection.address).toBe(ADDRESS);
+    expect(result.current.connection.network).toBe('TESTNET');
+  });
+
+  it('clearSessionExpired resets the sessionExpired flag after an expired session is detected', async () => {
+    localStorage.setItem('stellar_address', ADDRESS);
+    localStorage.setItem(
+      'stellar_connection_timestamp',
+      String(Date.now() - 25 * 60 * 60 * 1000),
+    );
+    freighter.isConnected.mockResolvedValue({ isConnected: true });
+
+    const { result } = renderHook(() => useStellarWallet(), { wrapper });
+
+    await waitFor(() => expect(result.current.sessionExpired).toBe(true));
+
+    act(() => {
+      result.current.clearSessionExpired();
+    });
+
+    expect(result.current.sessionExpired).toBe(false);
+  });
+
+  it('throws a clear error when consumed outside the provider', () => {
+    expect(() => renderHook(() => useStellarWallet())).toThrow(
+      'useStellarWallet must be used inside StellarWalletProvider',
+    );
+  });
+});

--- a/Dechat/dex_with_fiat_frontend/src/contexts/StellarWalletContext.tsx
+++ b/Dechat/dex_with_fiat_frontend/src/contexts/StellarWalletContext.tsx
@@ -92,23 +92,9 @@ const defaultConnection: StellarWalletConnection = {
   networkPassphrase: '',
 };
 
-const StellarWalletContext = createContext<StellarWalletContextType>({
-  connection: defaultConnection,
-  accounts: [],
-  selectedAccountIndex: 0,
-  xlmBalance: '',
-  selectAccount: () => {},
-  connect: async () => {},
-  disconnect: () => {},
-  signTx: async () => '',
-  isFreighterInstalled: false,
-  isLoading: false,
-  error: null,
-  sessionExpired: false,
-  clearSessionExpired: () => {},
-  mockConnect: () => {},
-  isNetworkMismatch: false,
-});
+const StellarWalletContext = createContext<
+  StellarWalletContextType | undefined
+>(undefined);
 
 export function StellarWalletProvider({ children }: { children: ReactNode }) {
   const [connection, setConnection] =

--- a/Dechat/dex_with_fiat_frontend/src/contexts/ThemeContext.test.tsx
+++ b/Dechat/dex_with_fiat_frontend/src/contexts/ThemeContext.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { renderHook, act } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { ThemeProvider, useTheme } from './ThemeContext';
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return <ThemeProvider>{children}</ThemeProvider>;
+}
+
+describe('ThemeContext', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.removeAttribute('data-theme');
+  });
+
+  it('defaults to light mode when nothing is saved', () => {
+    const { result } = renderHook(() => useTheme(), { wrapper });
+
+    expect(result.current.isDarkMode).toBe(false);
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+  });
+
+  it('restores dark mode from a saved preference', () => {
+    localStorage.setItem('theme', 'dark');
+
+    const { result } = renderHook(() => useTheme(), { wrapper });
+
+    expect(result.current.isDarkMode).toBe(true);
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+  });
+
+  it('toggleDarkMode flips state, DOM attribute, and persisted value', () => {
+    const { result } = renderHook(() => useTheme(), { wrapper });
+
+    act(() => {
+      result.current.toggleDarkMode();
+    });
+
+    expect(result.current.isDarkMode).toBe(true);
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+    expect(localStorage.getItem('theme')).toBe('dark');
+
+    act(() => {
+      result.current.toggleDarkMode();
+    });
+
+    expect(result.current.isDarkMode).toBe(false);
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+    expect(localStorage.getItem('theme')).toBe('light');
+  });
+
+  it('throws a clear error when consumed outside the provider', () => {
+    expect(() => renderHook(() => useTheme())).toThrow(
+      'useTheme must be used within a ThemeProvider',
+    );
+  });
+});

--- a/Dechat/dex_with_fiat_frontend/src/contexts/UserPreferencesContext.test.tsx
+++ b/Dechat/dex_with_fiat_frontend/src/contexts/UserPreferencesContext.test.tsx
@@ -1,0 +1,192 @@
+import React from 'react';
+import { renderHook, act } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { UserPreferencesProvider, useUserPreferences } from './UserPreferencesContext';
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return <UserPreferencesProvider>{children}</UserPreferencesProvider>;
+}
+
+describe('UserPreferencesContext', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('defaults every exposed value when nothing is saved', () => {
+    const { result } = renderHook(() => useUserPreferences(), { wrapper });
+
+    expect(result.current.fiatCurrency).toBe('usd');
+    expect(result.current.currencySymbol).toBe('$');
+    expect(result.current.remindersEnabled).toBe(false);
+    expect(result.current.reminderFrequency).toBe('weekly');
+    expect(result.current.maskingEnabled).toBe(false);
+    expect(result.current.maskingStyle).toBe('asterisk');
+    expect(result.current.highValueThreshold).toBe(500);
+    expect(result.current.twoFactorEnabled).toBe(true);
+  });
+
+  describe('restoring from localStorage', () => {
+    it('picks up a valid saved currency', () => {
+      localStorage.setItem('fiat-currency', 'eur');
+
+      const { result } = renderHook(() => useUserPreferences(), { wrapper });
+
+      expect(result.current.fiatCurrency).toBe('eur');
+      expect(result.current.currencySymbol).toBe('€');
+    });
+
+    it('ignores an unsupported saved currency', () => {
+      localStorage.setItem('fiat-currency', 'zzz');
+
+      const { result } = renderHook(() => useUserPreferences(), { wrapper });
+
+      expect(result.current.fiatCurrency).toBe('usd');
+    });
+
+    it('picks up saved reminders / frequency', () => {
+      localStorage.setItem('reminders-enabled', 'true');
+      localStorage.setItem('reminder-frequency', 'monthly');
+
+      const { result } = renderHook(() => useUserPreferences(), { wrapper });
+
+      expect(result.current.remindersEnabled).toBe(true);
+      expect(result.current.reminderFrequency).toBe('monthly');
+    });
+
+    it('ignores an invalid saved reminder frequency', () => {
+      localStorage.setItem('reminder-frequency', 'daily');
+
+      const { result } = renderHook(() => useUserPreferences(), { wrapper });
+
+      expect(result.current.reminderFrequency).toBe('weekly');
+    });
+
+    it('picks up a valid saved masking style', () => {
+      localStorage.setItem('content-masking-enabled', 'true');
+      localStorage.setItem('content-masking-style', 'block');
+
+      const { result } = renderHook(() => useUserPreferences(), { wrapper });
+
+      expect(result.current.maskingEnabled).toBe(true);
+      expect(result.current.maskingStyle).toBe('block');
+    });
+
+    it('ignores an invalid saved masking style', () => {
+      localStorage.setItem('content-masking-style', 'not-a-style');
+
+      const { result } = renderHook(() => useUserPreferences(), { wrapper });
+
+      expect(result.current.maskingStyle).toBe('asterisk');
+    });
+
+    it('picks up a valid saved high-value threshold', () => {
+      localStorage.setItem('high-value-threshold', '1000');
+
+      const { result } = renderHook(() => useUserPreferences(), { wrapper });
+
+      expect(result.current.highValueThreshold).toBe(1000);
+    });
+
+    it('ignores a non-numeric or non-positive saved threshold', () => {
+      localStorage.setItem('high-value-threshold', 'not-a-number');
+
+      const { result } = renderHook(() => useUserPreferences(), { wrapper });
+
+      expect(result.current.highValueThreshold).toBe(500);
+    });
+
+    it('picks up a saved two-factor preference', () => {
+      localStorage.setItem('two-factor-enabled', 'false');
+
+      const { result } = renderHook(() => useUserPreferences(), { wrapper });
+
+      expect(result.current.twoFactorEnabled).toBe(false);
+    });
+  });
+
+  describe('setters', () => {
+    it('setFiatCurrency updates state, symbol, and storage', () => {
+      const { result } = renderHook(() => useUserPreferences(), { wrapper });
+
+      act(() => {
+        result.current.setFiatCurrency('gbp');
+      });
+
+      expect(result.current.fiatCurrency).toBe('gbp');
+      expect(result.current.currencySymbol).toBe('£');
+      expect(localStorage.getItem('fiat-currency')).toBe('gbp');
+    });
+
+    it('setRemindersEnabled updates state and storage', () => {
+      const { result } = renderHook(() => useUserPreferences(), { wrapper });
+
+      act(() => {
+        result.current.setRemindersEnabled(true);
+      });
+
+      expect(result.current.remindersEnabled).toBe(true);
+      expect(localStorage.getItem('reminders-enabled')).toBe('true');
+    });
+
+    it('setReminderFrequency updates state and storage', () => {
+      const { result } = renderHook(() => useUserPreferences(), { wrapper });
+
+      act(() => {
+        result.current.setReminderFrequency('monthly');
+      });
+
+      expect(result.current.reminderFrequency).toBe('monthly');
+      expect(localStorage.getItem('reminder-frequency')).toBe('monthly');
+    });
+
+    it('setMaskingEnabled updates state and storage', () => {
+      const { result } = renderHook(() => useUserPreferences(), { wrapper });
+
+      act(() => {
+        result.current.setMaskingEnabled(true);
+      });
+
+      expect(result.current.maskingEnabled).toBe(true);
+      expect(localStorage.getItem('content-masking-enabled')).toBe('true');
+    });
+
+    it('setMaskingStyle updates state and storage', () => {
+      const { result } = renderHook(() => useUserPreferences(), { wrapper });
+
+      act(() => {
+        result.current.setMaskingStyle('pipe');
+      });
+
+      expect(result.current.maskingStyle).toBe('pipe');
+      expect(localStorage.getItem('content-masking-style')).toBe('pipe');
+    });
+
+    it('setHighValueThreshold updates state and storage', () => {
+      const { result } = renderHook(() => useUserPreferences(), { wrapper });
+
+      act(() => {
+        result.current.setHighValueThreshold(2000);
+      });
+
+      expect(result.current.highValueThreshold).toBe(2000);
+      expect(localStorage.getItem('high-value-threshold')).toBe('2000');
+    });
+
+    it('setTwoFactorEnabled updates state and storage', () => {
+      const { result } = renderHook(() => useUserPreferences(), { wrapper });
+
+      act(() => {
+        result.current.setTwoFactorEnabled(false);
+      });
+
+      expect(result.current.twoFactorEnabled).toBe(false);
+      expect(localStorage.getItem('two-factor-enabled')).toBe('false');
+    });
+  });
+
+  it('throws a clear error when consumed outside the provider', () => {
+    expect(() => renderHook(() => useUserPreferences())).toThrow(
+      'useUserPreferences must be used within UserPreferencesProvider',
+    );
+  });
+});

--- a/Dechat/dex_with_fiat_frontend/src/hooks/__tests__/useEffectiveDarkMode.test.ts
+++ b/Dechat/dex_with_fiat_frontend/src/hooks/__tests__/useEffectiveDarkMode.test.ts
@@ -35,13 +35,17 @@ describe('useEffectiveDarkMode', () => {
       })),
     });
 
-    // Mock MutationObserver
-    global.MutationObserver = vi.fn().mockImplementation((callback) => ({
-      observe: vi.fn(),
-      disconnect: mutationObserverDisconnectSpy,
-      takeRecords: vi.fn(),
-      _callback: callback,
-    })) as any;
+    // Mock MutationObserver. mockImplementation must be a regular function,
+    // not an arrow function — `new MutationObserver(...)` invokes it via
+    // [[Construct]], which arrow functions don't support.
+    global.MutationObserver = vi.fn().mockImplementation(function (callback) {
+      return {
+        observe: vi.fn(),
+        disconnect: mutationObserverDisconnectSpy,
+        takeRecords: vi.fn(),
+        _callback: callback,
+      };
+    }) as any;
   });
 
   afterEach(() => {
@@ -104,7 +108,7 @@ describe('useEffectiveDarkMode', () => {
 
   it('reacts to data-theme MutationObserver callbacks', () => {
     let observerCallback: () => void = () => {};
-    global.MutationObserver = vi.fn().mockImplementation((callback) => {
+    global.MutationObserver = vi.fn().mockImplementation(function (callback) {
       observerCallback = callback;
       return {
         observe: vi.fn(),

--- a/Dechat/dex_with_fiat_frontend/src/hooks/useChatHistory.test.ts
+++ b/Dechat/dex_with_fiat_frontend/src/hooks/useChatHistory.test.ts
@@ -510,9 +510,8 @@ describe('useChatHistory hook', () => {
       });
 
       // Create another session to switch to
-      let otherId = '';
       act(() => {
-        otherId = result.current.createNewSession();
+        result.current.createNewSession();
       });
 
       // Load the first session

--- a/Dechat/dex_with_fiat_frontend/vitest.config.ts
+++ b/Dechat/dex_with_fiat_frontend/vitest.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
     },
     coverage: {
       provider: 'v8',
-      reporter: ['text'],
+      reporter: ['text', 'json-summary'],
       cleanOnRerun: true,
       exclude: [
         '**/*.{test,spec}.{ts,tsx}',


### PR DESCRIPTION
## Summary

Bundles four assigned issues into one PR:

- Closes #1267 — coverage numbers surfaced in the PR summary instead of a silent pass/fail gate
- Closes #1269 — unit test coverage for `StellarWalletContext.tsx`
- Closes #1270 — unit test coverage for `ThemeContext.tsx`
- Closes #1272 — unit test coverage for `UserPreferencesContext.tsx`

### #1267 — coverage reporting

- `vitest.config.ts` now includes `json-summary` in the coverage reporter list, so `coverage/coverage-summary.json` exists after `pnpm test:coverage:merge`.
- `frontend.yml`'s `build` job emits `frontend-coverage-report.json` (statements/branches/functions/lines % + target numbers) and uploads it as an artifact.
- New `coverage-comment.yml` workflow (mirrors the existing `wasm-size-comment.yml` pattern) runs on `workflow_run` for `Frontend CI`, downloads that artifact, and posts/updates a sticky PR comment with a coverage table.

**Rationale / important note:** `frontend.yml` has a long-standing comment claiming a 70%/65%/70% coverage gate fails the build. It doesn't — `vitest.config.ts`'s `coverage.thresholds` block was silently dropped in a past refactor (commit `0fe14a95`) and never restored, so **no threshold is actually enforced today**. This PR is scoped to *visibility only*; the comment shows the real numbers against the target thresholds (✅/⚠️ per metric) but doesn't fail CI on them. Restoring real enforcement is a separate, deliberate decision — current coverage is unknown, and gating on it here risked breaking CI with something outside this PR's scope.

**Known limitation:** like `wasm-size-comment.yml`, the new `coverage-comment.yml` only starts working for PRs opened *after* it's merged to `main` (`workflow_run` reads the workflow file from the base branch). It won't post a comment on this PR itself — that's expected, not a bug.

### #1269 / #1270 / #1272 — context unit tests

New co-located test files (matching the existing `useChat.test.ts`-style convention):

- `src/contexts/ThemeContext.test.tsx`
- `src/contexts/UserPreferencesContext.test.tsx`
- `src/contexts/StellarWalletContext.test.tsx`

Each covers: default values, localStorage-backed overrides/restoration, every exposed setter/state transition, and the "used outside its provider" error path, per each issue's acceptance criteria.

**Bug fix found while writing the StellarWalletContext tests:** `createContext` was seeded with a real default connection object instead of `undefined`, so the existing `if (!ctx) throw ...` guard in `useStellarWallet` could never actually fire — consuming the hook outside `<StellarWalletProvider>` silently returned default values instead of throwing, unlike `ThemeContext`/`UserPreferencesContext`, which both do this correctly. Fixed to match the sibling contexts' pattern. Verified safe: `useStellarWallet` is only ever consumed under the app-wide `<StellarWalletProvider>` in `Providers.tsx` — all 10 call sites go through the hook, nothing touches the raw context object.

### Also fixed: pre-existing `main` breakage (unrelated to the 4 issues above)

While verifying this branch against `main`, `pnpm typecheck` / `pnpm lint` / `pnpm build` were already failing on a clean, unmodified `main` checkout, for reasons unrelated to any of the above. Fixed as small, isolated, mechanical changes so this PR's CI is actually green:

- **`Message.tsx`**: `handleMessageKeyDown` was declared twice in the same component (likely a merge collision), which hard-fails TypeScript, ESLint, and the Next.js webpack build. Kept the second implementation (guards against Ctrl+R/Cmd+R triggering a false retry) and removed the first — the first's extra `onRetry` truthy check was redundant anyway, since `useMessageRetry`'s `retryNow()` already no-ops when `onRetry` is unset.
- **`StellarChatInterface.tsx`**: removed a dead, unused `prefersReducedMotion` variable/import (`@typescript-eslint/no-unused-vars`).
- **`useChatHistory.test.ts`**: removed a dead, unused `otherId` variable in one test.
- **`app/api/initiate-transfer/route.ts`**: `body.clientSessionId` was accessed on an `unknown`-typed value; narrowed via an explicit cast instead of an unsafe direct property access.
- **`useEffectiveDarkMode.test.ts`**: `MutationObserver` was mocked with `vi.fn().mockImplementation((callback) => ({...}))` — an arrow function can't be used as a constructor, so `new MutationObserver(...)` threw in the hook under test. Switched both occurrences to regular `function` expressions.

None of these touch application behavior beyond what's described above.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean (pre-existing warnings only, no errors)
- [x] `pnpm test:unit` — clean, except 3 pre-existing flaky/timing-sensitive test files unrelated to this PR (`AuditTable.test.tsx`, `SplitViewComparison.test.tsx`, `useBridgeStats.test.ts`/`useToast.test.ts` — network-online/offline and telemetry-event timing issues). Confirmed via a stashed clean-`main` run that these fail identically without any of this branch's changes, and the exact failing subset even varies run-to-run under this sandbox's timing. Left as-is; flagging here for visibility rather than expanding this PR's scope further.
- [x] `pnpm build` — clean
- [x] New context test files verified individually and as part of the full suite (34 new tests, all passing)
- [ ] Confirm the coverage comment appears on the *next* PR opened after this one merges (expected — see limitation note above)
