### PR TITLE
feat: add request validation/rate limiting, error boundary, and ARIA labels

### DIFF
--- a/Dechat/dex_with_fiat_frontend/src/app/api/events/route.test.ts
+++ b/Dechat/dex_with_fiat_frontend/src/app/api/events/route.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const applyRateLimitMock = vi.fn(() => null);
+
+vi.mock('@/lib/rateLimit', () => ({
+  applyRateLimit: (...args: unknown[]) => applyRateLimitMock(...args),
+  getClientIp: vi.fn(() => '127.0.0.1'),
+}));
+
+vi.mock('fs', () => ({
+  default: {
+    existsSync: vi.fn(() => false),
+    readFileSync: vi.fn(),
+  },
+}));
+
+const { GET } = await import('./route');
+
+function makeRequest(query: string) {
+  return new NextRequest(new Request(`http://localhost/api/events${query}`));
+}
+
+describe('GET /api/events', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    applyRateLimitMock.mockReturnValue(null);
+  });
+
+  it('returns 400 for a non-numeric limit', async () => {
+    const req = makeRequest('?limit=not-a-number');
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.success).toBe(false);
+  });
+
+  it('returns 400 for a negative offset', async () => {
+    const req = makeRequest('?offset=-1');
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.success).toBe(false);
+  });
+
+  it('returns 400 when limit exceeds the maximum', async () => {
+    const req = makeRequest('?limit=1000');
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.success).toBe(false);
+  });
+
+  it('defaults limit and offset when omitted', async () => {
+    const req = makeRequest('');
+    const res = await GET(req);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.events).toEqual([]);
+  });
+
+  it('returns 429 when the rate limit is exceeded', async () => {
+    applyRateLimitMock.mockReturnValueOnce(
+      new Response(JSON.stringify({ success: false, retryAfter: 60 }), {
+        status: 429,
+      }) as never,
+    );
+
+    const req = makeRequest('');
+    const res = await GET(req);
+
+    expect(res.status).toBe(429);
+  });
+});

--- a/Dechat/dex_with_fiat_frontend/src/app/api/events/route.ts
+++ b/Dechat/dex_with_fiat_frontend/src/app/api/events/route.ts
@@ -2,15 +2,38 @@ import { NextRequest, NextResponse } from 'next/server';
 import fs from 'fs';
 import path from 'path';
 import { ContractEvent } from '../../../types/events';
+import { applyRateLimit, getClientIp } from '@/lib/rateLimit';
+import { eventsQuerySchema } from '@/lib/apiSchemas';
 
 const DATA_DIR = path.join(process.cwd(), 'data');
 const EVENTS_FILE = path.join(DATA_DIR, 'contract-events.json');
+const RATE_LIMIT = { maxRequests: 30, windowMs: 60_000 };
 
 export async function GET(request: NextRequest) {
+  const ip = getClientIp(request);
+  const limited = applyRateLimit(ip, '/api/events', RATE_LIMIT);
+  if (limited) return limited;
+
   try {
     const { searchParams } = new URL(request.url);
-    const limit = parseInt(searchParams.get('limit') || '20', 10);
-    const offset = parseInt(searchParams.get('offset') || '0', 10);
+
+    const validationResult = eventsQuerySchema.safeParse({
+      limit: searchParams.get('limit') ?? undefined,
+      offset: searchParams.get('offset') ?? undefined,
+    });
+
+    if (!validationResult.success) {
+      return NextResponse.json(
+        {
+          success: false,
+          message: 'Validation failed',
+          errors: validationResult.error.issues,
+        },
+        { status: 400 },
+      );
+    }
+
+    const { limit, offset } = validationResult.data;
 
     if (!fs.existsSync(EVENTS_FILE)) {
       return NextResponse.json({ events: [], total: 0 });

--- a/Dechat/dex_with_fiat_frontend/src/app/api/transfer-status/route.test.ts
+++ b/Dechat/dex_with_fiat_frontend/src/app/api/transfer-status/route.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const applyRateLimitMock = vi.fn(() => null);
+
+vi.mock('@/lib/rateLimit', () => ({
+  applyRateLimit: (...args: unknown[]) => applyRateLimitMock(...args),
+  getClientIp: vi.fn(() => '127.0.0.1'),
+}));
+
+vi.mock('@/lib/payout/providers/registry', () => ({
+  getPayoutProvider: () => ({
+    checkTransferStatus: vi.fn().mockResolvedValue({ reference: 'ref-123', status: 'success' }),
+  }),
+}));
+
+const { POST } = await import('./route');
+
+function makeRequest(body: unknown) {
+  return new NextRequest(
+    new Request('http://localhost/api/transfer-status', {
+      method: 'POST',
+      body: JSON.stringify(body),
+      headers: { 'content-type': 'application/json' },
+    }),
+  );
+}
+
+describe('POST /api/transfer-status', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    applyRateLimitMock.mockReturnValue(null);
+  });
+
+  it('returns 400 for malformed JSON body', async () => {
+    const badReq = new NextRequest(
+      new Request('http://localhost/api/transfer-status', {
+        method: 'POST',
+        body: 'not json{{{',
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+
+    const res = await POST(badReq);
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.success).toBe(false);
+  });
+
+  it('returns 400 for validation failures', async () => {
+    const req = makeRequest({ reference: '' });
+    const res = await POST(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.success).toBe(false);
+  });
+
+  it('returns 200 for a valid request', async () => {
+    const req = makeRequest({ reference: 'ref-123' });
+    const res = await POST(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+  });
+
+  it('returns 429 when the rate limit is exceeded', async () => {
+    applyRateLimitMock.mockReturnValueOnce(
+      new Response(JSON.stringify({ success: false, retryAfter: 60 }), {
+        status: 429,
+      }) as never,
+    );
+
+    const req = makeRequest({ reference: 'ref-123' });
+    const res = await POST(req);
+
+    expect(res.status).toBe(429);
+  });
+});

--- a/Dechat/dex_with_fiat_frontend/src/app/api/transfer-status/route.ts
+++ b/Dechat/dex_with_fiat_frontend/src/app/api/transfer-status/route.ts
@@ -1,17 +1,40 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import { getPayoutProvider } from '@/lib/payout/providers/registry';
+import { applyRateLimit, getClientIp } from '@/lib/rateLimit';
+import { transferStatusSchema } from '@/lib/apiSchemas';
+
+const RATE_LIMIT = { maxRequests: 10, windowMs: 60_000 };
 
 export async function POST(request: NextRequest) {
-  try {
-    const { reference } = await request.json();
+  const ip = getClientIp(request);
+  const limited = applyRateLimit(ip, '/api/transfer-status', RATE_LIMIT);
+  if (limited) return limited;
 
-    if (!reference) {
+  try {
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
       return NextResponse.json(
-        { success: false, message: 'Reference is required' },
+        { success: false, message: 'Request body must be valid JSON' },
         { status: 400 },
       );
     }
+
+    const validationResult = transferStatusSchema.safeParse(body);
+    if (!validationResult.success) {
+      return NextResponse.json(
+        {
+          success: false,
+          message: 'Validation failed',
+          errors: validationResult.error.issues,
+        },
+        { status: 400 },
+      );
+    }
+
+    const { reference } = validationResult.data;
 
     const provider = getPayoutProvider();
     const data = await provider.checkTransferStatus({ reference });

--- a/Dechat/dex_with_fiat_frontend/src/components/ChatHistorySidebar.tsx
+++ b/Dechat/dex_with_fiat_frontend/src/components/ChatHistorySidebar.tsx
@@ -876,7 +876,17 @@ export default function ChatHistorySidebar({
         <div
           className={`theme-border border-t p-4 ${isCollapsed ? 'flex flex-col items-center' : ''}`}
         >
-          <PriceTicker symbols={['XLM', 'ETH', 'BTC']} currency="usd" />
+          <ErrorBoundary
+            fallback={
+              <div className="theme-surface-muted rounded-lg border theme-border p-3">
+                <p className="theme-text-secondary text-sm text-center py-2">
+                  Prices unavailable
+                </p>
+              </div>
+            }
+          >
+            <PriceTicker symbols={['XLM', 'ETH', 'BTC']} currency="usd" />
+          </ErrorBoundary>
 
           <div
             className={`theme-border border-t p-4 ${isCollapsed ? 'flex flex-col items-center' : ''}`}

--- a/Dechat/dex_with_fiat_frontend/src/components/LandingPage.tsx
+++ b/Dechat/dex_with_fiat_frontend/src/components/LandingPage.tsx
@@ -58,7 +58,7 @@ const FeatureCard: React.FC<FeatureCardProps> = ({
       <div className="bg-[var(--color-surface-muted)] border border-[var(--color-border)] rounded-xl p-6 hover:border-blue-500/50 transition-all duration-300 hover:bg-[var(--color-surface)] backdrop-blur-sm shadow-sm hover:shadow-md">
         <div className="flex items-center space-x-4 mb-4">
           <div className="w-12 h-12 bg-blue-600/10 rounded-lg flex items-center justify-center">
-            <Icon className="w-6 h-6 text-blue-500" />
+            <Icon className="w-6 h-6 text-blue-500" aria-hidden="true" />
           </div>
           <h3 className="text-xl font-semibold text-[var(--color-text-primary)]">
             {title}
@@ -353,9 +353,12 @@ export default function LandingPage() {
                 className="group flex items-center space-x-2 bg-[var(--color-primary)] hover:bg-[var(--color-primary-hover)] px-8 py-4 rounded-lg text-lg font-semibold transition-all duration-300 hover:scale-105 shadow-lg hover:shadow-blue-500/25"
                 aria-label="Start bridging: open the chat app"
               >
-                <Play className="w-5 h-5" />
+                <Play className="w-5 h-5" aria-hidden="true" />
                 <span>Start Bridging</span>
-                <ArrowRight className="w-5 h-5 group-hover:translate-x-1 transition-transform duration-300" />
+                <ArrowRight
+                  className="w-5 h-5 group-hover:translate-x-1 transition-transform duration-300"
+                  aria-hidden="true"
+                />
               </button>
 
               <a
@@ -472,7 +475,10 @@ export default function LandingPage() {
 
             <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
               <div className="text-center p-6 bg-[var(--color-surface)] rounded-xl border border-[var(--color-border)] hover:border-blue-500/50 transition-all duration-300">
-                <Network className="w-12 h-12 text-blue-500 mx-auto mb-4" />
+                <Network
+                  className="w-12 h-12 text-blue-500 mx-auto mb-4"
+                  aria-hidden="true"
+                />
                 <h3 className="text-lg font-semibold mb-2 text-[var(--color-text-primary)]">
                   Soroban
                 </h3>
@@ -482,7 +488,10 @@ export default function LandingPage() {
                 </p>
               </div>
               <div className="text-center p-6 bg-[var(--color-surface)] rounded-xl border border-[var(--color-border)] hover:border-purple-500/50 transition-all duration-300">
-                <Shield className="w-12 h-12 text-purple-500 mx-auto mb-4" />
+                <Shield
+                  className="w-12 h-12 text-purple-500 mx-auto mb-4"
+                  aria-hidden="true"
+                />
                 <h3 className="text-lg font-semibold mb-2 text-[var(--color-text-primary)]">
                   Stellar Network
                 </h3>
@@ -492,7 +501,10 @@ export default function LandingPage() {
                 </p>
               </div>
               <div className="text-center p-6 bg-[var(--color-surface)] rounded-xl border border-[var(--color-border)] hover:border-green-500/50 transition-all duration-300">
-                <Cpu className="w-12 h-12 text-green-500 mx-auto mb-4" />
+                <Cpu
+                  className="w-12 h-12 text-green-500 mx-auto mb-4"
+                  aria-hidden="true"
+                />
                 <h3 className="text-lg font-semibold mb-2 text-[var(--color-text-primary)]">
                   AI-Optimized
                 </h3>
@@ -502,7 +514,10 @@ export default function LandingPage() {
                 </p>
               </div>
               <div className="text-center p-6 bg-[var(--color-surface)] rounded-xl border border-[var(--color-border)] hover:border-yellow-500/50 transition-all duration-300">
-                <Lock className="w-12 h-12 text-yellow-500 mx-auto mb-4" />
+                <Lock
+                  className="w-12 h-12 text-yellow-500 mx-auto mb-4"
+                  aria-hidden="true"
+                />
                 <h3 className="text-lg font-semibold mb-2 text-[var(--color-text-primary)]">
                   Freighter Wallet
                 </h3>
@@ -537,7 +552,7 @@ export default function LandingPage() {
             <div className="grid md:grid-cols-2 gap-12">
               <div>
                 <h3 className="text-2xl font-semibold mb-6 flex items-center text-[var(--color-text-primary)]">
-                  <Network className="w-6 h-6 mr-3 text-blue-500" />
+                  <Network className="w-6 h-6 mr-3 text-blue-500" aria-hidden="true" />
                   Stellar Assets
                 </h3>
                 <div className="grid grid-cols-2 gap-4">
@@ -568,7 +583,7 @@ export default function LandingPage() {
 
               <div>
                 <h3 className="text-2xl font-semibold mb-6 flex items-center text-[var(--color-text-primary)]">
-                  <Globe className="w-6 h-6 mr-3 text-green-500" />
+                  <Globe className="w-6 h-6 mr-3 text-green-500" aria-hidden="true" />
                   Fiat Currencies
                 </h3>
                 <div className="grid grid-cols-2 gap-4">
@@ -646,11 +661,15 @@ export default function LandingPage() {
                   key={index}
                   className="bg-[var(--color-surface)] p-6 rounded-xl border border-[var(--color-border)] shadow-sm"
                 >
-                  <div className="flex items-center mb-4">
+                  <div
+                    className="flex items-center mb-4"
+                    aria-label={`Rating: ${testimonial.rating} out of 5 stars`}
+                  >
                     {[...Array(testimonial.rating)].map((_, i) => (
                       <Star
                         key={i}
                         className="w-5 h-5 text-yellow-400 fill-current"
+                        aria-hidden="true"
                       />
                     ))}
                   </div>
@@ -769,8 +788,12 @@ export default function LandingPage() {
                 </button>
               </form>
             ) : (
-              <div className="flex items-center justify-center space-x-2 text-green-400">
-                <CheckCircle className="w-6 h-6" />
+              <div
+                className="flex items-center justify-center space-x-2 text-green-400"
+                role="status"
+                aria-live="polite"
+              >
+                <CheckCircle className="w-6 h-6" aria-hidden="true" />
                 <span className="text-lg">
                   Welcome to Stellar DeFi! Launching DeFi Hub...
                 </span>
@@ -880,21 +903,21 @@ export default function LandingPage() {
                   href="#"
                   className="flex items-center text-gray-400 hover:text-white transition-colors"
                 >
-                  <FileText className="w-4 h-4 mr-2" />
+                  <FileText className="w-4 h-4 mr-2" aria-hidden="true" />
                   Documentation
                 </a>
                 <a
                   href="#"
                   className="flex items-center text-gray-400 hover:text-white transition-colors"
                 >
-                  <HelpCircle className="w-4 h-4 mr-2" />
+                  <HelpCircle className="w-4 h-4 mr-2" aria-hidden="true" />
                   Help Center
                 </a>
                 <a
                   href="#"
                   className="flex items-center text-gray-400 hover:text-white transition-colors"
                 >
-                  <MessageSquare className="w-4 h-4 mr-2" />
+                  <MessageSquare className="w-4 h-4 mr-2" aria-hidden="true" />
                   Community
                 </a>
                 <a
@@ -917,15 +940,15 @@ export default function LandingPage() {
               <h3 className="text-lg font-semibold mb-6">Contact</h3>
               <div className="space-y-4">
                 <div className="flex items-center text-gray-400">
-                  <Mail className="w-4 h-4 mr-3" />
+                  <Mail className="w-4 h-4 mr-3" aria-hidden="true" />
                   <span>support@dexfiat.com</span>
                 </div>
                 <div className="flex items-center text-gray-400">
-                  <Phone className="w-4 h-4 mr-3" />
+                  <Phone className="w-4 h-4 mr-3" aria-hidden="true" />
                   <span>+1 (555) 123-4567</span>
                 </div>
                 <div className="flex items-start text-gray-400">
-                  <MapPin className="w-4 h-4 mr-3 mt-1" />
+                  <MapPin className="w-4 h-4 mr-3 mt-1" aria-hidden="true" />
                   <span>
                     San Francisco, CA
                     <br />

--- a/Dechat/dex_with_fiat_frontend/src/components/__tests__/ChatHistorySidebar.test.tsx
+++ b/Dechat/dex_with_fiat_frontend/src/components/__tests__/ChatHistorySidebar.test.tsx
@@ -288,7 +288,10 @@ describe('ChatHistorySidebar error boundary (#633)', () => {
     vi.useRealTimers();
   });
 
-  it('renders the fallback UI when a child throws and not the crash stack', async () => {
+  // #635: PriceTicker now has its own inner error boundary, so a crash
+  // there is contained to the ticker widget and no longer takes down the
+  // rest of the sidebar (search, sessions, "New Conversation", etc.).
+  it('contains a PriceTicker crash to the ticker widget instead of taking down the whole sidebar', async () => {
     vi.doMock('@/components/PriceTicker', () => ({
       default: () => {
         throw new Error('PriceTicker exploded');
@@ -305,31 +308,10 @@ describe('ChatHistorySidebar error boundary (#633)', () => {
       await vi.advanceTimersByTimeAsync(900);
     });
 
-    expect(screen.getByText('Sidebar unavailable')).toBeTruthy();
+    expect(screen.getByText('Prices unavailable')).toBeTruthy();
     expect(screen.queryByText('PriceTicker exploded')).toBeNull();
-
-    vi.doUnmock('@/components/PriceTicker');
-    vi.resetModules();
-  });
-
-  it('displays the custom retry label from the error boundary props', async () => {
-    vi.doMock('@/components/PriceTicker', () => ({
-      default: () => {
-        throw new Error('forced');
-      },
-    }));
-    vi.resetModules();
-
-    const { default: ChatHistorySidebarFresh } = await import('@/components/ChatHistorySidebar');
-
-    await act(async () => {
-      render(
-        <ChatHistorySidebarFresh onLoadSession={vi.fn()} isCollapsed={false} />,
-      );
-      await vi.advanceTimersByTimeAsync(900);
-    });
-
-    expect(screen.getByRole('button', { name: /reload sidebar/i })).toBeTruthy();
+    expect(screen.queryByText('Sidebar unavailable')).toBeNull();
+    expect(screen.getByPlaceholderText('Search conversations...')).toBeTruthy();
 
     vi.doUnmock('@/components/PriceTicker');
     vi.resetModules();

--- a/Dechat/dex_with_fiat_frontend/src/components/__tests__/LandingPage.test.tsx
+++ b/Dechat/dex_with_fiat_frontend/src/components/__tests__/LandingPage.test.tsx
@@ -52,6 +52,27 @@ describe('LandingPage – accessibility', () => {
     expect(screen.getByRole('link', { name: /DexFiat on Twitter/i })).toBeDefined();
     expect(screen.getByRole('link', { name: /DexFiat on GitHub/i })).toBeDefined();
   });
+
+  it('labels each testimonial star rating for screen readers', () => {
+    render(<LandingPage />);
+    const ratings = screen.getAllByLabelText(/Rating: 5 out of 5 stars/i);
+    expect(ratings.length).toBeGreaterThan(0);
+  });
+
+  it('hides decorative icons from assistive technology', () => {
+    const { container } = render(<LandingPage />);
+    const decorativeIcons = container.querySelectorAll('svg[aria-hidden="true"]');
+    expect(decorativeIcons.length).toBeGreaterThan(0);
+  });
+
+  it('announces the early-access success message via a status role', () => {
+    render(<LandingPage />);
+    const emailInput = screen.getByLabelText(/email address for early access/i);
+    fireEvent.change(emailInput, { target: { value: 'user@example.com' } });
+    const submitButton = screen.getByRole('button', { name: /submit email and launch app/i });
+    fireEvent.click(submitButton);
+    expect(screen.getByRole('status')).toBeDefined();
+  });
 });
 
 describe('LandingPage – keyboard shortcuts (#1185)', () => {

--- a/Dechat/dex_with_fiat_frontend/src/components/__tests__/PriceTicker.error-boundary.test.tsx
+++ b/Dechat/dex_with_fiat_frontend/src/components/__tests__/PriceTicker.error-boundary.test.tsx
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import ErrorBoundary from '@/components/ErrorBoundary';
+
+function ThrowingPriceTicker() {
+  throw new Error('PriceTicker crashed');
+}
+
+describe('PriceTicker error boundary', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('shows the compact fallback instead of crashing the sidebar when PriceTicker throws', () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+
+    render(
+      <ErrorBoundary
+        fallback={
+          <div>
+            <p>Prices unavailable</p>
+          </div>
+        }
+      >
+        <ThrowingPriceTicker />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText('Prices unavailable')).toBeTruthy();
+    expect(consoleErrorSpy).toHaveBeenCalled();
+  });
+});

--- a/Dechat/dex_with_fiat_frontend/src/lib/apiSchemas.ts
+++ b/Dechat/dex_with_fiat_frontend/src/lib/apiSchemas.ts
@@ -41,6 +41,21 @@ export const banksQuerySchema = z
 
 export type BanksQuery = z.infer<typeof banksQuerySchema>;
 
+// Schema for transfer-status endpoint
+export const transferStatusSchema = z.object({
+  reference: z.string().min(1, 'Reference is required'),
+});
+
+export type TransferStatusInput = z.infer<typeof transferStatusSchema>;
+
+// Schema for the events endpoint query string
+export const eventsQuerySchema = z.object({
+  limit: z.coerce.number().int().positive().max(100).default(20),
+  offset: z.coerce.number().int().nonnegative().default(0),
+});
+
+export type EventsQuery = z.infer<typeof eventsQuerySchema>;
+
 /**
  * Error thrown by {@link fetchWithRetry} when the server answers with a
  * non-OK status.


### PR DESCRIPTION
## Summary

- **#1275 / #1273**: `transfer-status` and `events` API routes now validate input through zod schemas (`transferStatusSchema`, `eventsQuerySchema`) and apply the shared `rateLimit` helper, matching the pattern already used by `verify-account` and `initiate-transfer`. Invalid input returns 400 with a machine-readable error shape.
- **#635**: `PriceTicker` now has its own inner `ErrorBoundary` so a crash there only degrades the ticker widget ("Prices unavailable") instead of taking down the whole `ChatHistorySidebar`. The existing #633 sidebar error-boundary tests expected a crash there to show "Sidebar unavailable" for the whole sidebar — updated those two tests to reflect the new, narrower blast radius, since containing the crash to the widget is strictly better UX and is what #635 asks for.
- **#497**: Added `aria-hidden` to decorative icons in `LandingPage.tsx`, an accessible name for testimonial star ratings, and `role="status"` on the early-access form's success message so it's announced by screen readers.

## Test plan

- [x] `npx tsc --noEmit` — zero errors
- [x] `npx vitest run` — all touched/added tests pass (9 pre-existing failures in `useToast`, `useBridgeStats`, and `AuditTable` are unrelated to this change and present on `main` before this branch)
- [x] New tests: `transfer-status/route.test.ts`, `events/route.test.ts`, `PriceTicker.error-boundary.test.tsx`, LandingPage ARIA assertions, updated `ChatHistorySidebar.test.tsx`

Closes #1275
Closes #1273
Closes #635
Closes #497